### PR TITLE
limit number of workers used in examples

### DIFF
--- a/utils/demo/helpers/initCornerstoneWADOImageLoader.js
+++ b/utils/demo/helpers/initCornerstoneWADOImageLoader.js
@@ -12,8 +12,14 @@ export default function initCornerstoneWADOImageLoader() {
     },
   });
 
+  let maxWebWorkers = 1;
+
+  if (navigator.hardwareConcurrency) {
+    maxWebWorkers = Math.min(navigator.hardwareConcurrency, 7);
+  }
+
   var config = {
-    maxWebWorkers: navigator.hardwareConcurrency || 1,
+    maxWebWorkers,
     startWebWorkersOnDemand: false,
     taskConfiguration: {
       decodeTask: {


### PR DESCRIPTION
Limit the webworkers to the minimum of 7 or hardware concurrency, so we don't spin up too many workers (this is an empircally stable number derived during Cornerstone Legacy development).