### PR TITLE
fix: change package.json 'module' field to use '.js' extension from '.ts'

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/umd/index.js",
   "types": "dist/esm/index.d.ts",
-  "module": "dist/esm/index.ts",
+  "module": "dist/esm/index.js",
   "files": [
     "dist/"
   ],


### PR DESCRIPTION
The 'module' field in package.json should probably use a '.js' extension instead of '.ts'. The generated output files located in `packages/core/dist/esm` don't actually include any .ts files. Changing the extension resolves build issues experienced in Vite when importing the ESM build of @cornerstonejs/core.

Discussion here: #64 