### PR TITLE
fix: Correct module property for ESM builds in package.json

### DIFF
--- a/packages/streaming-image-volume-loader/package.json
+++ b/packages/streaming-image-volume-loader/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/umd/index.js",
   "types": "dist/esm/index.d.ts",
-  "module": "dist/esm/index.ts",
+  "module": "dist/esm/index.js",
   "files": [
     "dist/"
   ],

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -4,7 +4,7 @@
   "description": "Cornerstone3D Tools",
   "main": "dist/umd/index.js",
   "types": "dist/esm/index.d.ts",
-  "module": "dist/esm/index.ts",
+  "module": "dist/esm/index.js",
   "files": [
     "dist/"
   ],


### PR DESCRIPTION
Addresses https://github.com/cornerstonejs/cornerstone3D-beta/issues/64

Fixes the other two packages with the same change that @ty-ler made here https://github.com/cornerstonejs/cornerstone3D-beta/pull/65