### PR TITLE
fix: jumpToSlice and scaling of images in renderToCanvas

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1019,7 +1019,7 @@ interface IRenderingEngine {
     // (undocumented)
     renderViewports(viewportIds: Array<string>): void;
     // (undocumented)
-    resize(immediate?: boolean, resetPanZoomForViewPlane?: boolean): void;
+    resize(immediate?: boolean, resetPan?: boolean, resetZoom?: boolean): void;
     // (undocumented)
     setViewports(viewports: Array<PublicViewportInput>): void;
 }
@@ -1069,7 +1069,7 @@ interface IStackViewport extends IViewport {
     // (undocumented)
     modality: string;
     // (undocumented)
-    resetCamera(resetPanZoomForViewPlane?: boolean): boolean;
+    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
     // (undocumented)
     resetProperties(): void;
     // (undocumented)
@@ -1279,7 +1279,7 @@ interface IVolumeViewport extends IViewport {
     // (undocumented)
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
     // (undocumented)
-    resetCamera(resetPanZoomForViewPlane?: boolean): boolean;
+    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
     // (undocumented)
     setSlabThickness(slabThickness: number): void;
     // (undocumented)
@@ -1450,13 +1450,13 @@ export class RenderingEngine implements IRenderingEngine {
     // (undocumented)
     renderViewports(viewportIds: Array<string>): void;
     // (undocumented)
-    resize(immediate?: boolean, resetPanZoomForViewPlane?: boolean): void;
+    resize(immediate?: boolean, resetPan?: boolean, resetZoom?: boolean): void;
     // (undocumented)
     setViewports(publicViewportInputEntries: Array<PublicViewportInput>): void;
 }
 
 // @public (undocumented)
-function renderToCanvas(canvas: HTMLCanvasElement, image: IImage): void;
+function renderToCanvas(canvas: HTMLCanvasElement, image: IImage, modality?: string): void;
 
 // @public (undocumented)
 enum RequestType {
@@ -1587,7 +1587,7 @@ export class StackViewport extends Viewport implements IStackViewport {
     // (undocumented)
     removeAllActors(): void;
     // (undocumented)
-    resetCamera(resetPanZoomForViewPlane?: boolean): boolean;
+    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
     // (undocumented)
     resetProperties(): void;
     // (undocumented)
@@ -1816,7 +1816,7 @@ export class Viewport implements IViewport {
     // (undocumented)
     reset(immediate?: boolean): void;
     // (undocumented)
-    protected resetCamera(resetPanZoomForViewPlane?: boolean): boolean;
+    protected resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
     // (undocumented)
     protected resetCameraNoEvent(): void;
     // (undocumented)
@@ -1975,7 +1975,7 @@ export class VolumeViewport extends Viewport implements IVolumeViewport {
     // (undocumented)
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
     // (undocumented)
-    resetCamera(resetPanZoomForViewPlane?: boolean): boolean;
+    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
     // (undocumented)
     setSlabThickness(slabThickness: number): void;
     // (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -743,7 +743,7 @@ interface IRenderingEngine {
     // (undocumented)
     renderViewports(viewportIds: Array<string>): void;
     // (undocumented)
-    resize(immediate?: boolean, resetPanZoomForViewPlane?: boolean): void;
+    resize(immediate?: boolean, resetPan?: boolean, resetZoom?: boolean): void;
     // (undocumented)
     setViewports(viewports: Array<PublicViewportInput>): void;
 }
@@ -770,7 +770,7 @@ interface IStackViewport extends IViewport {
     hasImageURI: (imageURI: string) => boolean;
     // (undocumented)
     modality: string;
-    resetCamera(resetPanZoomForViewPlane?: boolean): boolean;
+    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
     resetProperties(): void;
     resize: () => void;
     scaling: Scaling;
@@ -928,7 +928,7 @@ interface IVolumeViewport extends IViewport {
     getProperties: () => any;
     getSlabThickness(): number;
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
-    resetCamera(resetPanZoomForViewPlane?: boolean): boolean;
+    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
     setSlabThickness(slabThickness: number): void;
     setVolumes(
     volumeInputArray: Array<IVolumeInput>,

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -129,8 +129,6 @@ type AnnotationModifiedEventType = Types_2.CustomEventType<AnnotationModifiedEve
 
 // @public (undocumented)
 type AnnotationRemovedEventDetail = {
-    viewportId: string;
-    renderingEngineId: string;
     annotation: Annotation;
 };
 
@@ -888,13 +886,6 @@ const _default: {
     getWorldWidthAndHeightFromCorners: typeof getWorldWidthAndHeightFromCorners;
     filterAnnotationsForDisplay: typeof filterAnnotationsForDisplay;
     getPointInLineOfSightWithCriteria: typeof getPointInLineOfSightWithCriteria;
-};
-
-// @public (undocumented)
-const _default_2: {
-    snapFocalPointToSlice: typeof snapFocalPointToSlice;
-    getSliceRange: typeof getSliceRange;
-    scrollThroughStack: typeof scrollThroughStack;
 };
 
 // @public (undocumented)
@@ -1769,7 +1760,7 @@ interface IRenderingEngine {
     // (undocumented)
     renderViewports(viewportIds: Array<string>): void;
     // (undocumented)
-    resize(immediate?: boolean, resetPanZoomForViewPlane?: boolean): void;
+    resize(immediate?: boolean, resetPan?: boolean, resetZoom?: boolean): void;
     // (undocumented)
     setViewports(viewports: Array<PublicViewportInput>): void;
 }
@@ -1808,7 +1799,7 @@ interface IStackViewport extends IViewport {
     hasImageURI: (imageURI: string) => boolean;
     // (undocumented)
     modality: string;
-    resetCamera(resetPanZoomForViewPlane?: boolean): boolean;
+    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
     resetProperties(): void;
     resize: () => void;
     scaling: Scaling;
@@ -2033,7 +2024,7 @@ interface IVolumeViewport extends IViewport {
     getProperties: () => any;
     getSlabThickness(): number;
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
-    resetCamera(resetPanZoomForViewPlane?: boolean): boolean;
+    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
     setSlabThickness(slabThickness: number): void;
     setVolumes(
     volumeInputArray: Array<IVolumeInput>,
@@ -2852,7 +2843,7 @@ function registerCursor(toolName: string, iconContent: string, viewBox: {
 }): void;
 
 // @public (undocumented)
-function removeAnnotation(element: HTMLDivElement, annotationUID: string): void;
+function removeAnnotation(annotationUID: string, element?: HTMLDivElement): void;
 
 // @public (undocumented)
 function removeSegmentationRepresentation(toolGroupId: string, segmentationRepresentationUID: string): void;
@@ -2893,7 +2884,7 @@ type ScalingParameters = {
 };
 
 // @public (undocumented)
-function scrollThroughStack(viewport: Types_2.IStackViewport | Types_2.IVolumeViewport, targetId: string, deltaFrames: number, invert?: boolean): void;
+function scrollThroughStack(viewport: Types_2.IStackViewport | Types_2.IVolumeViewport, options: ScrollOptions_2): void;
 
 // @public (undocumented)
 type Segmentation = {
@@ -3185,6 +3176,8 @@ export class StackScrollTool extends BaseTool {
     // (undocumented)
     mouseDragCallback: () => void;
     // (undocumented)
+    previousDirection: number;
+    // (undocumented)
     static toolName: string;
     // (undocumented)
     touchDragCallback: () => void;
@@ -3194,8 +3187,7 @@ declare namespace stackScrollTool {
     export {
         snapFocalPointToSlice,
         getSliceRange,
-        scrollThroughStack,
-        _default_2 as default
+        scrollThroughStack
     }
 }
 

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -130,7 +130,7 @@ type AnnotationModifiedEventType = Types_2.CustomEventType<AnnotationModifiedEve
 // @public (undocumented)
 type AnnotationRemovedEventDetail = {
     annotation: Annotation;
-    FrameOfReferenceUID: string;
+    annotationManagerUID: string;
 };
 
 // @public (undocumented)

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2887,7 +2887,7 @@ type ScalingParameters = {
 // @public (undocumented)
 type ScrollOptions_2 = {
     direction: number;
-    invert: boolean;
+    invert?: boolean;
     volumeId?: string;
 };
 

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -130,6 +130,7 @@ type AnnotationModifiedEventType = Types_2.CustomEventType<AnnotationModifiedEve
 // @public (undocumented)
 type AnnotationRemovedEventDetail = {
     annotation: Annotation;
+    FrameOfReferenceUID: string;
 };
 
 // @public (undocumented)
@@ -2884,6 +2885,13 @@ type ScalingParameters = {
 };
 
 // @public (undocumented)
+type ScrollOptions_2 = {
+    direction: number;
+    invert: boolean;
+    volumeId?: string;
+};
+
+// @public (undocumented)
 function scrollThroughStack(viewport: Types_2.IStackViewport | Types_2.IVolumeViewport, options: ScrollOptions_2): void;
 
 // @public (undocumented)
@@ -3471,7 +3479,8 @@ declare namespace Types {
         ColorLUT,
         LabelmapTypes,
         SVGCursorDescriptor,
-        SVGPoint_2 as SVGPoint
+        SVGPoint_2 as SVGPoint,
+        ScrollOptions_2 as ScrollOptions
     }
 }
 export { Types }

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -298,12 +298,12 @@ class RenderingEngine implements IRenderingEngine {
    * This is left as an app level concern as one might want to debounce the changes, or the like.
    *
    * @param immediate - Whether all of the viewports should be rendered immediately.
-   * @param resetPanZoomForViewPlane - Whether each viewport gets centered (reset pan) and
+   * @param resetPan - Whether the viewport should reset its pan.
+   * @param resetZoom - Whether the viewport should reset its zoom.
    * its zoom gets reset upon resize.
    */
-  public resize(immediate = true, resetPanZoomForViewPlane = true): void {
+  public resize(immediate = true, resetPan = true, resetZoom = true): void {
     this._throwIfDestroyed();
-
     // 1. Get the viewports' canvases
     const viewports = this._getViewportsAsArray();
 
@@ -320,14 +320,16 @@ class RenderingEngine implements IRenderingEngine {
 
     this._resizeVTKViewports(
       vtkDrivenViewports,
-      immediate,
-      resetPanZoomForViewPlane
+      resetPan,
+      resetZoom,
+      immediate
     );
 
     this._resizeUsingCustomResizeHandler(
       customRenderingViewports,
-      immediate,
-      resetPanZoomForViewPlane
+      resetPan,
+      resetZoom,
+      immediate
     );
   }
 
@@ -526,8 +528,9 @@ class RenderingEngine implements IRenderingEngine {
 
   private _resizeUsingCustomResizeHandler(
     customRenderingViewports: StackViewport[],
-    immediate = true,
-    resetPanZoomForViewPlane = true
+    resetPan = true,
+    resetZoom = true,
+    immediate = true
   ) {
     // 1. If viewport has a custom resize method, call it here.
     customRenderingViewports.forEach((vp) => {
@@ -536,7 +539,7 @@ class RenderingEngine implements IRenderingEngine {
 
     // 3. Reset viewport cameras
     customRenderingViewports.forEach((vp) => {
-      vp.resetCamera(resetPanZoomForViewPlane);
+      vp.resetCamera(resetPan, resetZoom);
     });
 
     // 2. If render is immediate: Render all
@@ -547,7 +550,8 @@ class RenderingEngine implements IRenderingEngine {
 
   private _resizeVTKViewports(
     vtkDrivenViewports: Array<IStackViewport | IVolumeViewport>,
-    resetPanZoomForViewPlane = true,
+    resetPan = true,
+    resetZoom = true,
     immediate = true
   ) {
     const canvasesDrivenByVtkJs = vtkDrivenViewports.map((vp) => vp.canvas);
@@ -567,7 +571,7 @@ class RenderingEngine implements IRenderingEngine {
 
     // 3. Reset viewport cameras
     vtkDrivenViewports.forEach((vp: IStackViewport | IVolumeViewport) => {
-      vp.resetCamera(resetPanZoomForViewPlane);
+      vp.resetCamera(resetPan, resetZoom);
     });
 
     // 4. If render is immediate: Render all

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1602,30 +1602,28 @@ class StackViewport extends Viewport implements IStackViewport {
   /**
    * Centers Pan and resets the zoom for stack viewport.
    */
-  public resetCamera(resetPanZoomForViewPlane = true): boolean {
+  public resetCamera(resetPan = true, resetZoom = true): boolean {
     if (this.useCPURendering) {
-      this.resetCameraCPU(resetPanZoomForViewPlane);
+      this.resetCameraCPU(resetPan, resetZoom);
     } else {
-      this.resetCameraGPU();
+      this.resetCameraGPU(resetPan, resetZoom);
     }
 
     return true;
   }
 
-  private resetCameraCPU(resetPanZoomForViewPlane: boolean) {
+  private resetCameraCPU(resetPan, resetZoom) {
     const { image } = this._cpuFallbackEnabledElement;
 
     if (!image) {
       return;
     }
 
-    resetCamera(this._cpuFallbackEnabledElement, resetPanZoomForViewPlane);
+    resetCamera(this._cpuFallbackEnabledElement, resetPan, resetZoom);
   }
 
-  private resetCameraGPU() {
-    // Todo: this doesn't work for resetPanZoomForViewPlane = true
-    const resetPanZoomForViewPlane = false;
-    super.resetCamera(resetPanZoomForViewPlane);
+  private resetCameraGPU(resetPan, resetZoom) {
+    super.resetCamera(resetPan, resetZoom);
   }
 
   /**

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -487,13 +487,14 @@ class Viewport implements IViewport {
 
   /**
    * Resets the camera based on the rendering volume(s) bounds. If
-   * resetPanZoomForViewPlane is false (default behavior), it places
-   * the focal point at the center of the volume (or slice); otherwise,
-   * only the camera zoom and camera Pan is reset for the current view.
-   * @param resetPanZoomForViewPlane - if true, it renders the center of the volume instead
+   * resetPan and resetZoom are true it places the focal point at the center of
+   * the volume (or slice); otherwise, only the camera zoom and camera Pan or Zoom
+   * is reset for the current view.
+   * @param resetPan - If true, the camera focal point is reset to the center of the volume (slice)
+   * @param resetZoom - If true, the camera zoom is reset to the default zoom
    * @returns boolean
    */
-  protected resetCamera(resetPanZoomForViewPlane = false): boolean {
+  protected resetCamera(resetPan = true, resetZoom = true): boolean {
     const renderer = this.getRenderer();
     const previousCamera = _cloneDeep(this.getCamera());
 
@@ -580,7 +581,7 @@ class Viewport implements IViewport {
 
     let focalPointToSet = focalPoint;
 
-    if (resetPanZoomForViewPlane && imageData) {
+    if (!resetPan && imageData) {
       focalPointToSet = this._getFocalPointForViewPlaneReset(imageData);
     }
 
@@ -597,7 +598,9 @@ class Viewport implements IViewport {
 
     renderer.resetCameraClippingRange(bounds);
 
-    activeCamera.setParallelScale(parallelScale);
+    if (resetZoom) {
+      activeCamera.setParallelScale(parallelScale);
+    }
 
     // update reasonable world to physical values
     activeCamera.setPhysicalScale(radius);

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -272,12 +272,9 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
 
   /**
    * Reset the camera for the volume viewport
-   * @param resetPanZoomForViewPlane - only reset Pan and Zoom, if true,
-   * it renders the center of the volume instead
-   * viewport to the middle of the volume
    */
-  public resetCamera(resetPanZoomForViewPlane = false): boolean {
-    return super.resetCamera(resetPanZoomForViewPlane);
+  public resetCamera(resetPan = true, resetZoom = true): boolean {
+    return super.resetCamera(resetPan, resetZoom);
   }
 
   public getFrameOfReferenceUID = (): string => {

--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/resetCamera.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/resetCamera.ts
@@ -7,7 +7,8 @@ import { CPUFallbackEnabledElement } from '../../../../types';
  */
 export default function (
   enabledElement: CPUFallbackEnabledElement,
-  resetPanZoomForViewPlane: boolean
+  resetPan = true,
+  resetZoom = true
 ): void {
   const { canvas, image, viewport } = enabledElement;
   const scale = getImageFitScale(canvas, image, 0).scaleFactor;
@@ -15,10 +16,12 @@ export default function (
   viewport.vflip = false;
   viewport.hflip = false;
 
-  if (resetPanZoomForViewPlane) {
+  if (resetPan) {
     viewport.translation.x = 0;
     viewport.translation.y = 0;
+  }
 
+  if (resetZoom) {
     viewport.displayedArea.tlhc.x = 1;
     viewport.displayedArea.tlhc.y = 1;
     viewport.displayedArea.brhc.x = image.columns;

--- a/packages/core/src/types/IRenderingEngine.ts
+++ b/packages/core/src/types/IRenderingEngine.ts
@@ -8,7 +8,7 @@ export default interface IRenderingEngine {
   offscreenMultiRenderWindow: any;
   offScreenCanvasContainer: any;
   setViewports(viewports: Array<PublicViewportInput>): void;
-  resize(immediate?: boolean, resetPanZoomForViewPlane?: boolean): void;
+  resize(immediate?: boolean, resetPan?: boolean, resetZoom?: boolean): void;
   getViewport(id: string): IStackViewport | IVolumeViewport;
   getViewports(): Array<IStackViewport | IVolumeViewport>;
   render(): void;

--- a/packages/core/src/types/IStackViewport.ts
+++ b/packages/core/src/types/IStackViewport.ts
@@ -113,7 +113,7 @@ export default interface IStackViewport extends IViewport {
   /**
    * Centers Pan and resets the zoom for stack viewport.
    */
-  resetCamera(resetPanZoomForViewPlane?: boolean): boolean;
+  resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
   /**
    * Loads the image based on the provided imageIdIndex. It is an Async function which
    * returns a promise that resolves to the imageId.

--- a/packages/core/src/types/IVolumeViewport.ts
+++ b/packages/core/src/types/IVolumeViewport.ts
@@ -74,7 +74,7 @@ export default interface IVolumeViewport extends IViewport {
   /**
    * Reset the camera for the volume viewport
    */
-  resetCamera(resetPanZoomForViewPlane?: boolean): boolean;
+  resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
   /**
    * Sets the slab thickness option in the `Viewport`'s `options`.
    */

--- a/packages/core/src/utilities/loadImageToCanvas.ts
+++ b/packages/core/src/utilities/loadImageToCanvas.ts
@@ -32,7 +32,8 @@ export default function loadImageToCanvas(
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     function successCallback(image: IImage, imageId: string) {
-      renderToCanvas(canvas, image);
+      const { modality } = metaData.get('generalSeriesModule', imageId) || {};
+      renderToCanvas(canvas, image, modality);
       resolve(imageId);
     }
 
@@ -44,10 +45,10 @@ export default function loadImageToCanvas(
     function sendRequest(imageId, imageIdIndex, options) {
       return loadAndCacheImage(imageId, options).then(
         (image) => {
-          successCallback.call(this, image, imageIdIndex, imageId);
+          successCallback.call(this, image, imageId, imageIdIndex);
         },
         (error) => {
-          errorCallback.call(this, error, imageIdIndex, imageId);
+          errorCallback.call(this, error, imageId);
         }
       );
     }
@@ -77,7 +78,7 @@ export default function loadImageToCanvas(
     };
 
     imageLoadPoolManager.addRequest(
-      sendRequest.bind(null, imageId, options),
+      sendRequest.bind(null, imageId, null, options),
       requestType,
       { imageId },
       priority

--- a/packages/core/src/utilities/renderToCanvas.ts
+++ b/packages/core/src/utilities/renderToCanvas.ts
@@ -13,9 +13,10 @@ import drawImageSync from '../RenderingEngine/helpers/cpuFallback/drawImageSync'
  */
 export default function renderToCanvas(
   canvas: HTMLCanvasElement,
-  image: IImage
+  image: IImage,
+  modality?: string
 ): void {
-  const viewport = getDefaultViewport(canvas, image);
+  const viewport = getDefaultViewport(canvas, image, modality);
 
   const enabledElement: CPUFallbackEnabledElement = {
     canvas,

--- a/packages/tools/src/stateManagement/annotation/annotationState.ts
+++ b/packages/tools/src/stateManagement/annotation/annotationState.ts
@@ -97,25 +97,22 @@ function addAnnotation(element: HTMLDivElement, annotation: Annotation): void {
  * @param annotationUID - The unique identifier for the annotation.
  */
 function removeAnnotation(
-  element: HTMLDivElement,
-  annotationUID: string
+  annotationUID: string,
+  element?: HTMLDivElement
 ): void {
-  const annotationManager = getViewportSpecificAnnotationManager(element);
+  let annotationManager = getDefaultAnnotationManager();
+  if (element) {
+    annotationManager = getViewportSpecificAnnotationManager(element);
+  }
 
   const annotation = annotationManager.getAnnotation(annotationUID);
   annotationManager.removeAnnotation(annotationUID);
 
   // trigger annotation removed
-  const enabledElement = getEnabledElement(element);
-  const { renderingEngine } = enabledElement;
-  const { viewportId } = enabledElement;
-
   const eventType = Events.ANNOTATION_REMOVED;
 
   const eventDetail: AnnotationRemovedEventDetail = {
     annotation,
-    viewportId,
-    renderingEngineId: renderingEngine.id,
   };
 
   triggerEvent(eventTarget, eventType, eventDetail);

--- a/packages/tools/src/stateManagement/annotation/annotationState.ts
+++ b/packages/tools/src/stateManagement/annotation/annotationState.ts
@@ -113,7 +113,7 @@ function removeAnnotation(
 
   const eventDetail: AnnotationRemovedEventDetail = {
     annotation,
-    FrameOfReferenceUID: annotationManager.uid,
+    annotationManagerUID: annotationManager.uid,
   };
 
   triggerEvent(eventTarget, eventType, eventDetail);

--- a/packages/tools/src/stateManagement/annotation/annotationState.ts
+++ b/packages/tools/src/stateManagement/annotation/annotationState.ts
@@ -113,6 +113,7 @@ function removeAnnotation(
 
   const eventDetail: AnnotationRemovedEventDetail = {
     annotation,
+    FrameOfReferenceUID: annotationManager.uid,
   };
 
   triggerEvent(eventTarget, eventType, eventDetail);

--- a/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
+++ b/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
@@ -128,6 +128,10 @@ export default class ToolGroup implements IToolGroup {
       viewportId,
       renderingEngineId: renderingEngineUIDToUse,
     });
+
+    // Handle the newly added viewport's mouse cursor
+    const activeToolName = this.getActivePrimaryMouseButtonTool();
+    this.setViewportsCursorByToolName(activeToolName);
   }
 
   /**

--- a/packages/tools/src/store/removeEnabledElement.ts
+++ b/packages/tools/src/store/removeEnabledElement.ts
@@ -100,7 +100,7 @@ const _removeAllToolsForElement = function (element) {
   const toolsWithData = filterToolsWithAnnotationsForElement(element, tools);
   toolsWithData.forEach(({ annotations }) => {
     annotations.forEach((annotation) => {
-      removeAnnotation(element, annotation.annotationUID);
+      removeAnnotation(annotation.annotationUID, element);
     });
   });
 };

--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -184,7 +184,7 @@ export default class CrosshairsTool extends AnnotationTool {
 
     if (annotations.length) {
       // If found, it will override it by removing the annotation and adding it later
-      removeAnnotation(element, annotations[0].annotationUID);
+      removeAnnotation(annotations[0].annotationUID, element);
     }
 
     const annotation = {

--- a/packages/tools/src/tools/StackScrollTool.ts
+++ b/packages/tools/src/tools/StackScrollTool.ts
@@ -1,4 +1,4 @@
-import { getEnabledElementByIds } from '@cornerstonejs/core';
+import { getEnabledElementByIds, VolumeViewport } from '@cornerstonejs/core';
 import { BaseTool } from './base';
 import { scrollThroughStack } from '../utilities/stackScrollTool';
 import { PublicToolProps, ToolProps, EventTypes } from '../types';
@@ -9,6 +9,7 @@ import { PublicToolProps, ToolProps, EventTypes } from '../types';
  */
 export default class StackScrollTool extends BaseTool {
   static toolName = 'StackScroll';
+  previousDirection: number;
   touchDragCallback: () => void;
   mouseDragCallback: () => void;
 
@@ -22,6 +23,7 @@ export default class StackScrollTool extends BaseTool {
     }
   ) {
     super(toolProps, defaultToolProps);
+    this.previousDirection = 1;
 
     this.touchDragCallback = this._dragCallback.bind(this);
     this.mouseDragCallback = this._dragCallback.bind(this);
@@ -34,6 +36,21 @@ export default class StackScrollTool extends BaseTool {
     const targetId = this.getTargetId(viewport);
     const { invert } = this.configuration;
 
-    scrollThroughStack(viewport, targetId, deltaFrames, invert);
+    let volumeId;
+    if (viewport instanceof VolumeViewport) {
+      volumeId = targetId.split('volumeId:')[1];
+    }
+
+    // We need this check since the deltaFrames can be 0 when the user is
+    // scrolling very slowly so in that case we use the previous direction
+    let direction;
+    if (deltaFrames === 0) {
+      direction = this.previousDirection;
+    } else {
+      direction = deltaFrames > 0 ? 1 : -1;
+      this.previousDirection = direction;
+    }
+
+    scrollThroughStack(viewport, { direction, invert, volumeId });
   }
 }

--- a/packages/tools/src/tools/StackScrollToolMouseWheelTool.ts
+++ b/packages/tools/src/tools/StackScrollToolMouseWheelTool.ts
@@ -1,7 +1,7 @@
 import { BaseTool } from './base';
 import { scrollThroughStack } from '../utilities/stackScrollTool';
 import { MouseWheelEventType } from '../types/EventTypes';
-import { getEnabledElement } from '@cornerstonejs/core';
+import { getEnabledElement, VolumeViewport } from '@cornerstonejs/core';
 
 /**
  * The StackScrollMouseWheelTool is a tool that allows the user to scroll through a
@@ -24,10 +24,16 @@ export default class StackScrollMouseWheelTool extends BaseTool {
 
   mouseWheelCallback(evt: MouseWheelEventType): void {
     const { wheel, element } = evt.detail;
-    const { direction: deltaFrames } = wheel;
+    const { direction } = wheel;
     const { invert } = this.configuration;
     const { viewport } = getEnabledElement(element);
     const targetId = this.getTargetId(viewport);
-    scrollThroughStack(viewport, targetId, deltaFrames, invert);
+
+    let volumeId;
+    if (viewport instanceof VolumeViewport) {
+      volumeId = targetId.split('volumeId:')[1];
+    }
+
+    scrollThroughStack(viewport, { direction, invert, volumeId });
   }
 }

--- a/packages/tools/src/tools/annotation/BidirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/BidirectionalTool.ts
@@ -482,7 +482,7 @@ export default class BidirectionalTool extends AnnotationTool {
       this.isHandleOutsideImage &&
       this.configuration.preventHandleOutsideImage
     ) {
-      removeAnnotation(element, annotation.annotationUID);
+      removeAnnotation(annotation.annotationUID, element);
     }
 
     triggerAnnotationRenderForViewportIds(renderingEngine, viewportIdsToRender);

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -428,7 +428,7 @@ export default class EllipticalROITool extends AnnotationTool {
       this.isHandleOutsideImage &&
       this.configuration.preventHandleOutsideImage
     ) {
-      removeAnnotation(element, annotation.annotationUID);
+      removeAnnotation(annotation.annotationUID, element);
     }
 
     triggerAnnotationRenderForViewportIds(renderingEngine, viewportIdsToRender);

--- a/packages/tools/src/tools/annotation/LengthTool.ts
+++ b/packages/tools/src/tools/annotation/LengthTool.ts
@@ -362,7 +362,7 @@ class LengthTool extends AnnotationTool {
       this.isHandleOutsideImage &&
       this.configuration.preventHandleOutsideImage
     ) {
-      removeAnnotation(element, annotation.annotationUID);
+      removeAnnotation(annotation.annotationUID, element);
     }
 
     triggerAnnotationRenderForViewportIds(renderingEngine, viewportIdsToRender);

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -290,7 +290,7 @@ export default class ProbeTool extends AnnotationTool {
       this.isHandleOutsideImage &&
       this.configuration.preventHandleOutsideImage
     ) {
-      removeAnnotation(element, annotation.annotationUID);
+      removeAnnotation(annotation.annotationUID, element);
     }
 
     triggerAnnotationRenderForViewportIds(renderingEngine, viewportIdsToRender);

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -372,7 +372,7 @@ export default class RectangleROITool extends AnnotationTool {
       this.isHandleOutsideImage &&
       this.configuration.preventHandleOutsideImage
     ) {
-      removeAnnotation(element, annotation.annotationUID);
+      removeAnnotation(annotation.annotationUID, element);
     }
 
     triggerAnnotationRenderForViewportIds(renderingEngine, viewportIdsToRender);

--- a/packages/tools/src/types/EventTypes.ts
+++ b/packages/tools/src/types/EventTypes.ts
@@ -49,10 +49,6 @@ type AnnotationModifiedEventDetail = {
  * The data that is passed to the event handler when an annotation is completed drawing.
  */
 type AnnotationRemovedEventDetail = {
-  /** unique id of the viewport */
-  viewportId: string;
-  /** unique id of the rendering engine */
-  renderingEngineId: string;
   /** The annotation that is being added to the annotations manager. */
   annotation: Annotation;
 };

--- a/packages/tools/src/types/EventTypes.ts
+++ b/packages/tools/src/types/EventTypes.ts
@@ -51,6 +51,8 @@ type AnnotationModifiedEventDetail = {
 type AnnotationRemovedEventDetail = {
   /** The annotation that is being added to the annotations manager. */
   annotation: Annotation;
+  /** FrameOfReferenceUID */
+  FrameOfReferenceUID: string;
 };
 
 /**

--- a/packages/tools/src/types/EventTypes.ts
+++ b/packages/tools/src/types/EventTypes.ts
@@ -51,8 +51,8 @@ type AnnotationModifiedEventDetail = {
 type AnnotationRemovedEventDetail = {
   /** The annotation that is being added to the annotations manager. */
   annotation: Annotation;
-  /** FrameOfReferenceUID */
-  FrameOfReferenceUID: string;
+  /** annotationManagerUID */
+  annotationManagerUID: string;
 };
 
 /**

--- a/packages/tools/src/types/ScrollOptions.ts
+++ b/packages/tools/src/types/ScrollOptions.ts
@@ -1,6 +1,6 @@
 type ScrollOptions = {
   direction: number;
-  invert: boolean;
+  invert?: boolean;
   volumeId?: string;
 };
 

--- a/packages/tools/src/types/ScrollOptions.ts
+++ b/packages/tools/src/types/ScrollOptions.ts
@@ -1,0 +1,7 @@
+type ScrollOptions = {
+  direction: number;
+  invert: boolean;
+  volumeId?: string;
+};
+
+export default ScrollOptions;

--- a/packages/tools/src/types/index.ts
+++ b/packages/tools/src/types/index.ts
@@ -21,6 +21,7 @@ import type InteractionTypes from './InteractionTypes';
 import type { ToolProps, PublicToolProps } from './ToolProps';
 import type { SVGCursorDescriptor, SVGPoint } from './CursorTypes';
 import type JumpToSliceOptions from './JumpToSliceOptions';
+import type ScrollOptions from './ScrollOptions';
 import type {
   Color,
   ColorLUT,
@@ -76,4 +77,6 @@ export type {
   // Cursors
   SVGCursorDescriptor,
   SVGPoint,
+  // Scroll
+  ScrollOptions,
 };

--- a/packages/tools/src/utilities/stackScrollTool/index.ts
+++ b/packages/tools/src/utilities/stackScrollTool/index.ts
@@ -3,8 +3,3 @@ import getSliceRange from './getSliceRange';
 import scrollThroughStack from './scrollThroughStack';
 
 export { snapFocalPointToSlice, getSliceRange, scrollThroughStack };
-export default {
-  snapFocalPointToSlice,
-  getSliceRange,
-  scrollThroughStack,
-};

--- a/packages/tools/src/utilities/stackScrollTool/scrollThroughStack.ts
+++ b/packages/tools/src/utilities/stackScrollTool/scrollThroughStack.ts
@@ -7,12 +7,7 @@ import {
 import clip from '../clip';
 import getSliceRange from './getSliceRange';
 import snapFocalPointToSlice from './snapFocalPointToSlice';
-
-type ScrollOptions = {
-  direction: number;
-  invert: boolean;
-  volumeId?: string;
-};
+import { ScrollOptions } from '../../types';
 
 /**
  * It scrolls one slice in the Stack or Volume Viewport, it uses the options provided

--- a/packages/tools/src/utilities/stackScrollTool/scrollThroughStack.ts
+++ b/packages/tools/src/utilities/stackScrollTool/scrollThroughStack.ts
@@ -8,28 +8,29 @@ import clip from '../clip';
 import getSliceRange from './getSliceRange';
 import snapFocalPointToSlice from './snapFocalPointToSlice';
 
+type ScrollOptions = {
+  direction: number;
+  invert: boolean;
+  volumeId?: string;
+};
+
 /**
- * Scroll the stack defined by the event (`evt`)
- * and volume with `volumeId` `deltaFrames number of frames`.
- * Frames are defined as increasing in the view direction.
- *
- * @param evt - The event corresponding to an interaction with a
- * specific viewport.
- * @param deltaFrames - The number of frames to jump through.
- * @param targetId - The targetId used for scrolling.
- * @param invert - inversion of the scrolling
- * on the viewport.
+ * It scrolls one slice in the Stack or Volume Viewport, it uses the options provided
+ * to determine the slice to scroll to. For Stack Viewport, it scrolls in the 1 or -1
+ * direction, for Volume Viewport, it uses the camera and focal point to determine the
+ * slice to scroll to based on the spacings.
+ * @param viewport - The viewport in which to scroll
+ * @param options - Options to use for scrolling, including direction, invert, and volumeId
+ * @returns
  */
 export default function scrollThroughStack(
   viewport: Types.IStackViewport | Types.IVolumeViewport,
-  targetId: string,
-  deltaFrames: number,
-  invert = false
+  options: ScrollOptions
 ): void {
   const { type: viewportType } = viewport;
-  const camera = viewport.getCamera();
-  const { focalPoint, viewPlaneNormal, position } = camera;
-  const delta = invert ? -deltaFrames : deltaFrames;
+  const { volumeId, direction, invert } = options;
+
+  const delta = invert ? -direction : direction;
 
   if (viewport instanceof StackViewport) {
     // stack viewport
@@ -40,15 +41,8 @@ export default function scrollThroughStack(
 
     viewport.setImageIdIndex(newImageIdIndex);
   } else if (viewport instanceof VolumeViewport) {
-    if (!targetId.startsWith('volumeId')) {
-      throw new Error(
-        `scrollThroughStack: targetId must start with 'volumeId' if viewport is a VolumeViewport`
-      );
-    }
-
-    const volumeId = targetId.split('volumeId:')[1];
-
-    // If volumeId is specified, scroll through that specific volume
+    const camera = viewport.getCamera();
+    const { focalPoint, viewPlaneNormal, position } = camera;
     const { spacingInNormalDirection, imageVolume } =
       csUtils.getTargetVolumeAndSpacingInNormalDir(viewport, camera, volumeId);
 

--- a/packages/tools/src/utilities/viewport/jumpToSlice.ts
+++ b/packages/tools/src/utilities/viewport/jumpToSlice.ts
@@ -1,5 +1,6 @@
 import { getEnabledElement, StackViewport } from '@cornerstonejs/core';
 import JumpToSliceOptions from '../../types/JumpToSliceOptions';
+import clip from '../clip';
 
 /**
  * It uses the imageIdIndex in the Options to scroll to the slice that is intended.
@@ -33,7 +34,10 @@ function jumpToSlice(
     throw new Error('Cannot scroll to slice on a non-stack viewport yet');
   }
 
-  return viewport.setImageIdIndex(imageIdIndex);
+  const numberOfFrames = viewport.getImageIds().length;
+  const newImageIdIndex = clip(imageIdIndex, 0, numberOfFrames - 1);
+
+  return viewport.setImageIdIndex(newImageIdIndex);
 }
 
 export default jumpToSlice;

--- a/packages/tools/test/BidirectionalTool_test.js
+++ b/packages/tools/test/BidirectionalTool_test.js
@@ -151,8 +151,8 @@ describe('Cornerstone Tools: ', () => {
         expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
 
         annotation.state.removeAnnotation(
-          element,
-          bidirectionalAnnotation.annotationUID
+          bidirectionalAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -257,8 +257,8 @@ describe('Cornerstone Tools: ', () => {
         expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
 
         annotation.state.removeAnnotation(
-          element,
-          bidirectionalAnnotation.annotationUID
+          bidirectionalAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -373,8 +373,8 @@ describe('Cornerstone Tools: ', () => {
         expect(data[targets[0]].length).toBe(calculateLength(p3, p2));
 
         annotation.state.removeAnnotation(
-          element,
-          bidirectionalAnnotation.annotationUID
+          bidirectionalAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -518,8 +518,8 @@ describe('Cornerstone Tools: ', () => {
         expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
 
         annotation.state.removeAnnotation(
-          element,
-          bidirectionalAnnotation.annotationUID
+          bidirectionalAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -690,8 +690,8 @@ describe('Cornerstone Tools: ', () => {
         expect(handles[1]).toEqual(afterMoveSecondHandle);
 
         annotation.state.removeAnnotation(
-          element,
-          bidirectionalAnnotation.annotationUID
+          bidirectionalAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -914,8 +914,8 @@ describe('Cornerstone Tools: ', () => {
         expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
 
         annotation.state.removeAnnotation(
-          element,
-          bidirectionalAnnotation.annotationUID
+          bidirectionalAnnotation.annotationUID,
+          element
         );
         done();
       }, 100);

--- a/packages/tools/test/CrosshairsTool_test.js
+++ b/packages/tools/test/CrosshairsTool_test.js
@@ -185,8 +185,8 @@ describe('Cornerstone Tools: ', () => {
           expect(p).toBeCloseTo(imageCenterWorld[i], 3);
         });
         annotation.state.removeAnnotation(
-          element1,
-          crosshairAnnotation.annotationUID
+          crosshairAnnotation.annotationUID,
+          element1
         );
       });
 
@@ -277,8 +277,8 @@ describe('Cornerstone Tools: ', () => {
           expect(p).toBeCloseTo(p1[i], 3);
           expect(p).toBeCloseTo(axialCanvasToolCenter[i], 3);
           annotation.state.removeAnnotation(
-            element1,
-            crosshairAnnotation.annotationUID
+            crosshairAnnotation.annotationUID,
+            element1
           );
         });
       });
@@ -499,8 +499,8 @@ describe('Cornerstone Tools: ', () => {
               // Can successfully move the tool center in all viewports
               expect(p).toBeCloseTo(worldCoord2[i], 3);
               annotation.state.removeAnnotation(
-                element1,
-                crosshairAnnotation.annotationUID
+                crosshairAnnotation.annotationUID,
+                element1
               );
             });
           });

--- a/packages/tools/test/EllipseROI_test.js
+++ b/packages/tools/test/EllipseROI_test.js
@@ -144,8 +144,8 @@ describe('Ellipse Tool: ', () => {
           expect(data[targets[0]].mean).toBe(255);
 
           annotation.state.removeAnnotation(
-            element,
-            ellipseAnnotation.annotationUID
+            ellipseAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -249,8 +249,8 @@ describe('Ellipse Tool: ', () => {
           expect(data[targets[0]].stdDev).toBe(0);
 
           annotation.state.removeAnnotation(
-            element,
-            ellipseAnnotation.annotationUID
+            ellipseAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -466,8 +466,8 @@ describe('Ellipse Tool: ', () => {
           expect(data[targets[0]].mean).toBe(255);
 
           annotation.state.removeAnnotation(
-            element,
-            ellipseAnnotation.annotationUID
+            ellipseAnnotation.annotationUID,
+            element
           );
           done();
         }, 100);

--- a/packages/tools/test/LengthTool_test.js
+++ b/packages/tools/test/LengthTool_test.js
@@ -151,8 +151,8 @@ describe('LengthTool:', () => {
 
           expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
           annotation.state.removeAnnotation(
-            element,
-            lengthAnnotation.annotationUID
+            lengthAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -258,8 +258,8 @@ describe('LengthTool:', () => {
           expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
 
           annotation.state.removeAnnotation(
-            element,
-            lengthAnnotation.annotationUID
+            lengthAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -372,8 +372,8 @@ describe('LengthTool:', () => {
           expect(data[targets[0]].length).toBe(calculateLength(p3, p2));
 
           annotation.state.removeAnnotation(
-            element,
-            lengthAnnotation.annotationUID
+            lengthAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -513,8 +513,8 @@ describe('LengthTool:', () => {
           expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
 
           annotation.state.removeAnnotation(
-            element,
-            lengthAnnotation.annotationUID
+            lengthAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -685,8 +685,8 @@ describe('LengthTool:', () => {
           expect(handles[1]).toEqual(afterMoveSecondHandle);
 
           annotation.state.removeAnnotation(
-            element,
-            lengthAnnotation.annotationUID
+            lengthAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -840,8 +840,8 @@ describe('LengthTool:', () => {
 
           expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
           annotation.state.removeAnnotation(
-            element,
-            lengthAnnotation.annotationUID
+            lengthAnnotation.annotationUID,
+            element
           );
 
           const annotationsAfterRemove = annotation.state.getAnnotations(
@@ -1060,8 +1060,8 @@ describe('LengthTool:', () => {
 
           expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
           annotation.state.removeAnnotation(
-            element,
-            lengthAnnotation.annotationUID
+            lengthAnnotation.annotationUID,
+            element
           );
           done();
         }, 100);
@@ -1151,7 +1151,7 @@ describe('LengthTool:', () => {
 
         expect(data[targets[0]].length).toBe(calculateLength(p1, p2))
 
-        annotation.state.removeAnnotation(element, lengthAnnotation.annotationUID)
+        annotation.state.removeAnnotation(lengthAnnotation.annotationUID, element)
         done()
       }
 

--- a/packages/tools/test/ProbeTool_test.js
+++ b/packages/tools/test/ProbeTool_test.js
@@ -140,8 +140,8 @@ describe('Probe Tool: ', () => {
           expect(data[targets[0]].value).toBe(255);
 
           annotation.state.removeAnnotation(
-            element,
-            probeAnnotation.annotationUID
+            probeAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -244,12 +244,12 @@ describe('Probe Tool: ', () => {
 
           //
           annotation.state.removeAnnotation(
-            element,
-            firstProbeAnnotation.annotationUID
+            firstProbeAnnotation.annotationUID,
+            element
           );
           annotation.state.removeAnnotation(
-            element,
-            secondProbeAnnotation.annotationUID
+            secondProbeAnnotation.annotationUID,
+            element
           );
 
           done();
@@ -356,8 +356,8 @@ describe('Probe Tool: ', () => {
           expect(data[targets[0]].value).toBe(255);
 
           annotation.state.removeAnnotation(
-            element,
-            probeAnnotation.annotationUID
+            probeAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -439,8 +439,8 @@ describe('Probe Tool: ', () => {
           expect(data[targets[0]].value).toBe(0);
 
           annotation.state.removeAnnotation(
-            element,
-            probeAnnotation.annotationUID
+            probeAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -519,8 +519,8 @@ describe('Probe Tool: ', () => {
           expect(data[targets[0]].value).toBe(255);
 
           annotation.state.removeAnnotation(
-            element,
-            probeAnnotation.annotationUID
+            probeAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -616,8 +616,8 @@ describe('Probe Tool: ', () => {
           expect(handles[0]).toEqual(p2);
 
           annotation.state.removeAnnotation(
-            element,
-            probeAnnotation.annotationUID
+            probeAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -843,8 +843,8 @@ describe('Probe Tool: ', () => {
           expect(handles[0]).toEqual(p2);
 
           annotation.state.removeAnnotation(
-            element,
-            probeAnnotation.annotationUID
+            probeAnnotation.annotationUID,
+            element
           );
           done();
         }, 100);

--- a/packages/tools/test/RectangleROI_test.js
+++ b/packages/tools/test/RectangleROI_test.js
@@ -143,8 +143,8 @@ describe('Rectangle ROI Tool: ', () => {
           expect(data[targets[0]].mean).toBe(255);
 
           annotation.state.removeAnnotation(
-            element,
-            rectangleAnnotation.annotationUID
+            rectangleAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -246,8 +246,8 @@ describe('Rectangle ROI Tool: ', () => {
           expect(data[targets[0]].stdDev).toBe(0);
 
           annotation.state.removeAnnotation(
-            element,
-            rectangleAnnotation.annotationUID
+            rectangleAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -362,8 +362,8 @@ describe('Rectangle ROI Tool: ', () => {
           expect(data[targets[0]].stdDev).toBe(0);
 
           annotation.state.removeAnnotation(
-            element,
-            rectangleAnnotation.annotationUID
+            rectangleAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -502,8 +502,8 @@ describe('Rectangle ROI Tool: ', () => {
           expect(data[targets[0]].stdDev).toBe(0);
 
           annotation.state.removeAnnotation(
-            element,
-            rectangleAnnotation.annotationUID
+            rectangleAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -672,8 +672,8 @@ describe('Rectangle ROI Tool: ', () => {
           expect(handles[3]).toEqual(afterMoveSecondHandle);
 
           annotation.state.removeAnnotation(
-            element,
-            rectangleAnnotation.annotationUID
+            rectangleAnnotation.annotationUID,
+            element
           );
           done();
         });
@@ -1022,8 +1022,8 @@ describe('Rectangle ROI Tool: ', () => {
           expect(handles[3]).toEqual(afterMoveSecondHandle);
 
           annotation.state.removeAnnotation(
-            element,
-            rectangleAnnotation.annotationUID
+            rectangleAnnotation.annotationUID,
+            element
           );
           done();
         }, 100);

--- a/packages/tools/test/cpu_BidirectionalTool_test.js
+++ b/packages/tools/test/cpu_BidirectionalTool_test.js
@@ -155,8 +155,8 @@ describe('Bidirectional Tool (CPU): ', () => {
         expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
 
         annotation.state.removeAnnotation(
-          element,
-          bidirectionalAnnotation.annotationUID
+          bidirectionalAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -265,8 +265,8 @@ describe('Bidirectional Tool (CPU): ', () => {
         expect(data[targets[0]].length).toBe(calculateLength(p3, p2));
 
         annotation.state.removeAnnotation(
-          element,
-          bidirectionalAnnotation.annotationUID
+          bidirectionalAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -410,8 +410,8 @@ describe('Bidirectional Tool (CPU): ', () => {
         expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
 
         annotation.state.removeAnnotation(
-          element,
-          bidirectionalAnnotation.annotationUID
+          bidirectionalAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -582,8 +582,8 @@ describe('Bidirectional Tool (CPU): ', () => {
         expect(handles[1]).toEqual(afterMoveSecondHandle);
 
         annotation.state.removeAnnotation(
-          element,
-          bidirectionalAnnotation.annotationUID
+          bidirectionalAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -806,8 +806,8 @@ describe('Bidirectional Tool (CPU): ', () => {
         expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
 
         annotation.state.removeAnnotation(
-          element,
-          bidirectionalAnnotation.annotationUID
+          bidirectionalAnnotation.annotationUID,
+          element
         );
         done();
       }, 100);

--- a/packages/tools/test/cpu_EllipseROI_test.js
+++ b/packages/tools/test/cpu_EllipseROI_test.js
@@ -150,8 +150,8 @@ describe('EllipticalROITool (CPU):', () => {
         expect(data[targets[0]].mean).toBe(255);
 
         annotation.state.removeAnnotation(
-          element,
-          ellipseAnnotation.annotationUID
+          ellipseAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -326,8 +326,8 @@ describe('EllipticalROITool (CPU):', () => {
         expect(data[targets[0]].mean).toBe(255);
 
         annotation.state.removeAnnotation(
-          element,
-          ellipseAnnotation.annotationUID
+          ellipseAnnotation.annotationUID,
+          element
         );
         done();
       }, 100);

--- a/packages/tools/test/cpu_LengthTool_test.js
+++ b/packages/tools/test/cpu_LengthTool_test.js
@@ -152,8 +152,8 @@ describe('Length Tool (CPU):', () => {
 
         expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
         annotation.state.removeAnnotation(
-          element,
-          lengthAnnotation.annotationUID
+          lengthAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -261,8 +261,8 @@ describe('Length Tool (CPU):', () => {
         expect(data[targets[0]].length).toBe(calculateLength(p3, p2));
 
         annotation.state.removeAnnotation(
-          element,
-          lengthAnnotation.annotationUID
+          lengthAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -402,8 +402,8 @@ describe('Length Tool (CPU):', () => {
         expect(data[targets[0]].length).toBe(calculateLength(p1, p2));
 
         annotation.state.removeAnnotation(
-          element,
-          lengthAnnotation.annotationUID
+          lengthAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -571,8 +571,8 @@ describe('Length Tool (CPU):', () => {
         expect(handles[1]).toEqual(afterMoveSecondHandle);
 
         annotation.state.removeAnnotation(
-          element,
-          lengthAnnotation.annotationUID
+          lengthAnnotation.annotationUID,
+          element
         );
         done();
       });

--- a/packages/tools/test/cpu_ProbeTool_test.js
+++ b/packages/tools/test/cpu_ProbeTool_test.js
@@ -146,8 +146,8 @@ describe('ProbeTool (CPU):', () => {
         expect(data[targets[0]].value).toBe(255);
 
         annotation.state.removeAnnotation(
-          element,
-          probeAnnotation.annotationUID
+          probeAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -246,12 +246,12 @@ describe('ProbeTool (CPU):', () => {
 
         //
         annotation.state.removeAnnotation(
-          element,
-          firstProbeAnnotation.annotationUID
+          firstProbeAnnotation.annotationUID,
+          element
         );
         annotation.state.removeAnnotation(
-          element,
-          secondProbeAnnotation.annotationUID
+          secondProbeAnnotation.annotationUID,
+          element
         );
 
         done();
@@ -358,8 +358,8 @@ describe('ProbeTool (CPU):', () => {
         expect(data[targets[0]].value).toBe(255);
 
         annotation.state.removeAnnotation(
-          element,
-          probeAnnotation.annotationUID
+          probeAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -441,8 +441,8 @@ describe('ProbeTool (CPU):', () => {
         expect(data[targets[0]].value).toBe(0);
 
         annotation.state.removeAnnotation(
-          element,
-          probeAnnotation.annotationUID
+          probeAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -532,8 +532,8 @@ describe('ProbeTool (CPU):', () => {
         expect(handles[0][2]).toEqual(p2[2]);
 
         annotation.state.removeAnnotation(
-          element,
-          probeAnnotation.annotationUID
+          probeAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -723,8 +723,8 @@ describe('ProbeTool (CPU):', () => {
         expect(handles[0][2]).toEqual(p2[2]);
 
         annotation.state.removeAnnotation(
-          element,
-          probeAnnotation.annotationUID
+          probeAnnotation.annotationUID,
+          element
         );
         done();
       }, 100);

--- a/packages/tools/test/cpu_RectangleROI_test.js
+++ b/packages/tools/test/cpu_RectangleROI_test.js
@@ -148,8 +148,8 @@ describe('RectangleROITool (CPU):', () => {
         expect(data[targets[0]].mean).toBe(255);
 
         annotation.state.removeAnnotation(
-          element,
-          rectangleAnnotation.annotationUID
+          rectangleAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -253,8 +253,8 @@ describe('RectangleROITool (CPU):', () => {
         expect(data[targets[0]].stdDev).toBe(0);
 
         annotation.state.removeAnnotation(
-          element,
-          rectangleAnnotation.annotationUID
+          rectangleAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -393,8 +393,8 @@ describe('RectangleROITool (CPU):', () => {
         expect(data[targets[0]].stdDev).toBe(0);
 
         annotation.state.removeAnnotation(
-          element,
-          rectangleAnnotation.annotationUID
+          rectangleAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -563,8 +563,8 @@ describe('RectangleROITool (CPU):', () => {
         expect(handles[3]).toEqual(afterMoveSecondHandle);
 
         annotation.state.removeAnnotation(
-          element,
-          rectangleAnnotation.annotationUID
+          rectangleAnnotation.annotationUID,
+          element
         );
         done();
       });
@@ -875,8 +875,8 @@ describe('RectangleROITool (CPU):', () => {
         expect(handles[3]).toEqual(afterMoveSecondHandle);
 
         annotation.state.removeAnnotation(
-          element,
-          rectangleAnnotation.annotationUID
+          rectangleAnnotation.annotationUID,
+          element
         );
         done();
       }, 100);


### PR DESCRIPTION
- Separate resetZoom and resetPan for camera reset as the consumer need to decide which reset is desired (by default reset zoom was applied)
- Remove the need for passing element to `removeAnnotation` for the annotation to get removed 
- Fixed the scaling of the images in the `renderToCanvas` function
- cleanup the stackScrollTool to use the `scrollThroughStack` utility and fix the problem with deltaFrames = 0 by caching previous direction
- Fixed the jumpToSlice bug for imagerIdIndex out of bound