### PR TITLE
fix: selection API, requestPoolManager and VOI and Scaling

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -428,6 +428,8 @@ export enum EVENTS {
     // (undocumented)
     IMAGE_VOLUME_MODIFIED = "CORNERSTONE_IMAGE_VOLUME_MODIFIED",
     // (undocumented)
+    PRE_STACK_NEW_IMAGE = "CORNERSTONE_PRE_STACK_NEW_IMAGE",
+    // (undocumented)
     STACK_NEW_IMAGE = "CORNERSTONE_STACK_NEW_IMAGE",
     // (undocumented)
     VOI_MODIFIED = "CORNERSTONE_VOI_MODIFIED",
@@ -476,6 +478,8 @@ declare namespace EventTypes {
         VolumeCacheVolumeRemovedEventDetail,
         StackNewImageEvent,
         StackNewImageEventDetail,
+        PreStackNewImageEvent,
+        PreStackNewImageEventDetail,
         ImageSpacingCalibratedEvent,
         ImageSpacingCalibratedEventDetail,
         ImageLoadProgressEvent,
@@ -664,6 +668,8 @@ interface IImage {
     intercept: number;
     // (undocumented)
     invert: boolean;
+    // (undocumented)
+    isPreScaled?: boolean;
     // (undocumented)
     maxPixelValue: number;
     // (undocumented)
@@ -1375,6 +1381,16 @@ type Point4 = [number, number, number, number];
 
 // @public (undocumented)
 function prefetchStack(imageIds: string[], requestType?: RequestType, priority?: number): void;
+
+// @public (undocumented)
+type PreStackNewImageEvent = CustomEvent_2<PreStackNewImageEventDetail>;
+
+// @public (undocumented)
+type PreStackNewImageEventDetail = {
+    imageId: string;
+    viewportId: string;
+    renderingEngineId: string;
+};
 
 // @public (undocumented)
 type PTScaling = {

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -355,6 +355,7 @@ enum Events {
     IMAGE_RENDERED = 'CORNERSTONE_IMAGE_RENDERED',
     IMAGE_SPACING_CALIBRATED = 'CORNERSTONE_IMAGE_SPACING_CALIBRATED',
     IMAGE_VOLUME_MODIFIED = 'CORNERSTONE_IMAGE_VOLUME_MODIFIED',
+    PRE_STACK_NEW_IMAGE = 'CORNERSTONE_PRE_STACK_NEW_IMAGE',
     STACK_NEW_IMAGE = 'CORNERSTONE_STACK_NEW_IMAGE',
     VOI_MODIFIED = 'CORNERSTONE_VOI_MODIFIED',
     VOLUME_CACHE_VOLUME_ADDED = 'CORNERSTONE_VOLUME_CACHE_VOLUME_ADDED',
@@ -398,6 +399,8 @@ declare namespace EventTypes {
         VolumeCacheVolumeRemovedEventDetail,
         StackNewImageEvent,
         StackNewImageEventDetail,
+        PreStackNewImageEvent,
+        PreStackNewImageEventDetail,
         ImageSpacingCalibratedEvent,
         ImageSpacingCalibratedEventDetail,
         ImageLoadProgressEvent,
@@ -506,6 +509,7 @@ interface IImage {
     imageId: string;
     intercept: number;
     invert: boolean;
+    isPreScaled?: boolean;
     // (undocumented)
     maxPixelValue: number;
     minPixelValue: number;
@@ -973,6 +977,16 @@ type Point3 = [number, number, number];
 
 // @public
 type Point4 = [number, number, number, number];
+
+// @public
+type PreStackNewImageEvent = CustomEvent_2<PreStackNewImageEventDetail>;
+
+// @public
+type PreStackNewImageEventDetail = {
+    imageId: string;
+    viewportId: string;
+    renderingEngineId: string;
+};
 
 // @public (undocumented)
 type PTScaling = {

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1175,6 +1175,8 @@ declare namespace EventTypes {
         VolumeCacheVolumeRemovedEventDetail,
         StackNewImageEvent,
         StackNewImageEventDetail,
+        PreStackNewImageEvent,
+        PreStackNewImageEventDetail,
         ImageSpacingCalibratedEvent,
         ImageSpacingCalibratedEventDetail,
         ImageLoadProgressEvent,
@@ -1334,6 +1336,9 @@ function getGlobalRepresentationConfig(representationType: SegmentationRepresent
 
 // @public (undocumented)
 function getLockedSegments(segmentationId: string): number[] | [];
+
+// @public (undocumented)
+function getOrientationString(vector: Types_2.Point3): string;
 
 // @public (undocumented)
 function getPointInLineOfSightWithCriteria(viewport: Types_2.IVolumeViewport, worldPos: Types_2.Point3, targetVolumeId: string, criteriaFunction: (intensity: number, point: Types_2.Point3) => Types_2.Point3, stepSize?: number): Types_2.Point3;
@@ -1500,6 +1505,7 @@ interface IImage {
     imageId: string;
     intercept: number;
     invert: boolean;
+    isPreScaled?: boolean;
     // (undocumented)
     maxPixelValue: number;
     minPixelValue: number;
@@ -1703,6 +1709,9 @@ type InteractionTypes = 'Mouse';
 
 // @public (undocumented)
 function intersectLine(line1Start: Types_2.Point2, line1End: Types_2.Point2, line2Start: Types_2.Point2, line2End: Types_2.Point2): number[];
+
+// @public (undocumented)
+function invertOrientationString(orientationString: string): string;
 
 // @public (undocumented)
 type IPoints = {
@@ -2392,6 +2401,13 @@ type Orientation = {
     viewUp: Point3;
 };
 
+declare namespace orientation_2 {
+    export {
+        getOrientationString,
+        invertOrientationString
+    }
+}
+
 // @public (undocumented)
 export class PanTool extends BaseTool {
     constructor(toolProps?: PublicToolProps, defaultToolProps?: ToolProps);
@@ -2443,6 +2459,16 @@ function pointInShapeCallback(imageData: vtkImageData | Types_2.CPUImageData, po
 
 // @public (undocumented)
 function pointInSurroundingSphereCallback(viewport: Types_2.IVolumeViewport, imageData: vtkImageData, circlePoints: [Types_2.Point3, Types_2.Point3], callback: PointInShapeCallback): void;
+
+// @public
+type PreStackNewImageEvent = CustomEvent_2<PreStackNewImageEventDetail>;
+
+// @public
+type PreStackNewImageEventDetail = {
+    imageId: string;
+    viewportId: string;
+    renderingEngineId: string;
+};
 
 // @public (undocumented)
 interface ProbeAnnotation extends Annotation {
@@ -3494,6 +3520,7 @@ declare namespace utilities {
         debounce,
         deepmerge as deepMerge,
         throttle,
+        orientation_2 as orientation,
         isObject,
         triggerEvent,
         calibrateImageSpacing,

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1338,7 +1338,7 @@ function getGlobalRepresentationConfig(representationType: SegmentationRepresent
 function getLockedSegments(segmentationId: string): number[] | [];
 
 // @public (undocumented)
-function getOrientationString(vector: Types_2.Point3): string;
+function getOrientationStringLPS(vector: Types_2.Point3): string;
 
 // @public (undocumented)
 function getPointInLineOfSightWithCriteria(viewport: Types_2.IVolumeViewport, worldPos: Types_2.Point3, targetVolumeId: string, criteriaFunction: (intensity: number, point: Types_2.Point3) => Types_2.Point3, stepSize?: number): Types_2.Point3;
@@ -1711,7 +1711,7 @@ type InteractionTypes = 'Mouse';
 function intersectLine(line1Start: Types_2.Point2, line1End: Types_2.Point2, line2Start: Types_2.Point2, line2End: Types_2.Point2): number[];
 
 // @public (undocumented)
-function invertOrientationString(orientationString: string): string;
+function invertOrientationStringLPS(orientationString: string): string;
 
 // @public (undocumented)
 type IPoints = {
@@ -2403,8 +2403,8 @@ type Orientation = {
 
 declare namespace orientation_2 {
     export {
-        getOrientationString,
-        invertOrientationString
+        getOrientationStringLPS,
+        invertOrientationStringLPS
     }
 }
 

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -151,9 +151,9 @@ type Annotations = Array<Annotation>;
 
 // @public (undocumented)
 type AnnotationSelectionChangeEventDetail = {
-    added: Array<Annotation>;
-    removed: Array<Annotation>;
-    selection: Array<Annotation>;
+    added: Array<string>;
+    removed: Array<string>;
+    selection: Array<string>;
 };
 
 // @public (undocumented)
@@ -890,7 +890,7 @@ const _default: {
 };
 
 // @public (undocumented)
-function deselectAnnotation(annotation?: Annotation): void;
+function deselectAnnotation(annotationUID?: string): void;
 
 // @public (undocumented)
 export function destroy(): void;
@@ -1285,19 +1285,16 @@ function getAnnotationNearPointOnEnabledElement(enabledElement: Types_2.IEnabled
 function getAnnotations(element: HTMLDivElement, toolName: string): Annotations;
 
 // @public (undocumented)
-function getAnnotationSelected(annotationUID: string): Annotation;
-
-// @public (undocumented)
 function getAnnotationsLocked(): Array<Annotation>;
 
 // @public (undocumented)
 function getAnnotationsLockedCount(): number;
 
 // @public (undocumented)
-function getAnnotationsSelected(): Array<Annotation>;
+function getAnnotationsSelected(): Array<string>;
 
 // @public (undocumented)
-function getAnnotationsSelectedByToolName(toolName: string): Array<Annotation>;
+function getAnnotationsSelectedByToolName(toolName: string): Array<string>;
 
 // @public (undocumented)
 function getAnnotationsSelectedCount(): number;
@@ -1770,7 +1767,7 @@ interface IRenderingEngine {
 function isAnnotationLocked(annotation: Annotation): boolean;
 
 // @public (undocumented)
-function isAnnotationSelected(annotation: Annotation): boolean;
+function isAnnotationSelected(annotationUID: string): boolean;
 
 // @public (undocumented)
 function isObject(value: any): boolean;
@@ -3042,7 +3039,6 @@ declare namespace selection {
     export {
         setAnnotationSelected,
         getAnnotationsSelected,
-        getAnnotationSelected,
         getAnnotationsSelectedByToolName,
         getAnnotationsSelectedCount,
         deselectAnnotation,
@@ -3060,7 +3056,7 @@ function setActiveSegmentIndex(segmentationId: string, segmentIndex: number): vo
 function setAnnotationLocked(annotation: Annotation, locked?: boolean): void;
 
 // @public (undocumented)
-function setAnnotationSelected(annotation: Annotation, selected?: boolean, preserveSelected?: boolean): void;
+function setAnnotationSelected(annotationUID: string, selected?: boolean, preserveSelected?: boolean): void;
 
 // @public (undocumented)
 function setAnnotationStyle(toolName: string, annotation: Record<string, unknown>, style: Record<string, unknown>): boolean;

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -126,7 +126,7 @@ class StackViewport extends Viewport implements IStackViewport {
   // TODO: These should not be here and will be nuked
   public modality: string; // this is needed for tools
   public scaling: Scaling;
-  private scalingCache: { [key: string]: ScalingParameters } = {};
+  private scalingCache: Record<string, ScalingParameters> = {};
 
   /**
    * Constructor for the StackViewport class
@@ -1110,6 +1110,7 @@ class StackViewport extends Viewport implements IStackViewport {
     this.imageIds = imageIds;
     this.currentImageIdIndex = currentImageIdIndex;
     this.stackInvalidated = true;
+    this.scalingCache = {};
     this.rotationCache = 0;
     this.flipVertical = false;
     this.flipHorizontal = false;

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1228,20 +1228,20 @@ class StackViewport extends Viewport implements IStackViewport {
    * @param imageId - string representing the imageId
    * @param imageIdIndex - index of the imageId in the imageId list
    */
-  private async _loadImage(
+  private async _loadAndDisplayImage(
     imageId: string,
     imageIdIndex: number
   ): Promise<string> {
     if (this.useCPURendering) {
-      await this._loadImageCPU(imageId, imageIdIndex);
+      await this._loadAndDisplayImageCPU(imageId, imageIdIndex);
     } else {
-      await this._loadImageGPU(imageId, imageIdIndex);
+      await this._loadAndDisplayImageGPU(imageId, imageIdIndex);
     }
 
     return imageId;
   }
 
-  private _loadImageCPU(
+  private _loadAndDisplayImageCPU(
     imageId: string,
     imageIdIndex: number
   ): Promise<string> {
@@ -1388,7 +1388,7 @@ class StackViewport extends Viewport implements IStackViewport {
     });
   }
 
-  private _loadImageGPU(imageId: string, imageIdIndex: number) {
+  private _loadAndDisplayImageGPU(imageId: string, imageIdIndex: number) {
     return new Promise((resolve, reject) => {
       // 1. Load the image using the Image Loader
       function successCallback(image, imageIdIndex, imageId) {
@@ -1475,6 +1475,13 @@ class StackViewport extends Viewport implements IStackViewport {
           scalingParameters,
         },
       };
+
+      const eventDetail: EventTypes.PreStackNewImageEventDetail = {
+        imageId,
+        viewportId: this.id,
+        renderingEngineId: this.renderingEngineId,
+      };
+      triggerEvent(this.element, Events.PRE_STACK_NEW_IMAGE, eventDetail);
 
       imageLoadPoolManager.addRequest(
         sendRequest.bind(this, imageId, imageIdIndex, options),
@@ -1643,7 +1650,7 @@ class StackViewport extends Viewport implements IStackViewport {
     // Todo: trigger an event to allow applications to hook into START of loading state
     // Currently we use loadHandlerManagers for this
 
-    const imageId = await this._loadImage(
+    const imageId = await this._loadAndDisplayImage(
       this.imageIds[imageIdIndex],
       imageIdIndex
     );
@@ -1708,7 +1715,7 @@ class StackViewport extends Viewport implements IStackViewport {
   public calibrateSpacing(imageId: string): void {
     const imageIdIndex = this.getImageIds().indexOf(imageId);
     this.stackInvalidated = true;
-    this._loadImage(imageId, imageIdIndex);
+    this._loadAndDisplayImage(imageId, imageIdIndex);
   }
 
   /**

--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/getDefaultViewport.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/getDefaultViewport.ts
@@ -34,7 +34,12 @@ export default function (
 
   let voi;
 
-  if (image.windowWidth && image.windowCenter) {
+  if (modality === 'PT' && image.isPreScaled) {
+    voi = {
+      windowWidth: 5,
+      windowCenter: 2.5,
+    };
+  } else if (image.windowWidth && image.windowCenter) {
     voi = {
       windowWidth: Array.isArray(image.windowWidth)
         ? image.windowWidth[0]
@@ -42,11 +47,6 @@ export default function (
       windowCenter: Array.isArray(image.windowCenter)
         ? image.windowCenter[0]
         : image.windowCenter,
-    };
-  } else if (modality === 'PT') {
-    voi = {
-      windowWidth: 5,
-      windowCenter: 2.5,
     };
   }
 

--- a/packages/core/src/enums/Events.ts
+++ b/packages/core/src/enums/Events.ts
@@ -125,6 +125,13 @@ enum Events {
    */
   STACK_NEW_IMAGE = 'CORNERSTONE_STACK_NEW_IMAGE',
   /**
+   * Triggers on the element when a new image is about to be set on the stackViewport, pre display
+   *
+   * Make use of {@link EventTypes.PreStackNewImageEvent | PreStackNewImage Event Type } for typing your event listeners for PRE_STACK_NEW_IMAGE event,
+   * and see what event detail is included in {@link EventTypes.PreStackNewImageEventDetail | PreStackNewImage Event Detail }
+   */
+  PRE_STACK_NEW_IMAGE = 'CORNERSTONE_PRE_STACK_NEW_IMAGE',
+  /**
    * Triggers on the element when the viewport's image has calibrated its pixel spacings
    *
    * Make use of {@link EventTypes.ImageSpacingCalibratedEvent | ImageSpacingCalibrated Event Type } for typing your event listeners for IMAGE_SPACING_CALIBRATED event,

--- a/packages/core/src/requestPool/imageLoadPoolManager.ts
+++ b/packages/core/src/requestPool/imageLoadPoolManager.ts
@@ -31,7 +31,7 @@ import { RequestPoolManager } from './requestPoolManager';
  * )
  * ```
  */
-const imageLoadPoolManager = new RequestPoolManager();
+const imageLoadPoolManager = new RequestPoolManager('imageLoadPool');
 
 imageLoadPoolManager.maxNumRequests = {
   interaction: 1000,

--- a/packages/core/src/requestPool/imageRetrievalPoolManager.ts
+++ b/packages/core/src/requestPool/imageRetrievalPoolManager.ts
@@ -8,7 +8,7 @@ import { RequestPoolManager } from './requestPoolManager';
  *
  * Retrieval (usually) === XHR requests
  */
-const imageRetrievalPoolManager = new RequestPoolManager();
+const imageRetrievalPoolManager = new RequestPoolManager('imageRetrievalPool');
 
 imageRetrievalPoolManager.maxNumRequests = {
   interaction: 200,

--- a/packages/core/src/requestPool/requestPoolManager.ts
+++ b/packages/core/src/requestPool/requestPoolManager.ts
@@ -69,8 +69,8 @@ type RequestPool = {
  * maximum number of concurrent requests can be set by calling `setMaxConcurrentRequests`.
  */
 class RequestPoolManager {
+  private id = 'requestPoolManager';
   private requestPool: RequestPool;
-  private awake: boolean;
   private numRequests = {
     interaction: 0,
     thumbnail: 0,
@@ -91,14 +91,17 @@ class RequestPoolManager {
    * of the request types, is created. Maximum number of requests of each type
    * is set to 6.
    */
-  constructor() {
+  constructor(id?: string) {
+    if (id) {
+      this.id = id;
+    }
+
     this.requestPool = {
       interaction: { 0: [] },
       thumbnail: { 0: [] },
       prefetch: { 0: [] },
     };
 
-    this.awake = false;
     this.grabDelay = 5;
 
     this.numRequests = {
@@ -157,11 +160,7 @@ class RequestPoolManager {
     // Adding the request to the correct priority group of the request type
     this.requestPool[type][priority].push(requestDetails);
 
-    // Wake up
-    if (!this.awake) {
-      this.awake = true;
-      this.startGrabbing();
-    }
+    this.startGrabbing();
   }
 
   /**
@@ -199,52 +198,44 @@ class RequestPoolManager {
     this.requestPool[type] = { 0: [] };
   }
 
-  protected sendRequest({ requestFn, type }: RequestDetailsInterface): void {
-    // Increment the number of current requests of this type
-    this.numRequests[type]++;
-    this.awake = true;
+  sendRequests(type) {
+    const requestsToSend = this.maxNumRequests[type] - this.numRequests[type];
 
-    requestFn().finally(() => {
-      this.numRequests[type]--;
+    for (let i = 0; i < requestsToSend; i++) {
+      const requestDetails = this.getNextRequest(type);
+      if (requestDetails === null) {
+        return false;
+      } else if (requestDetails) {
+        this.numRequests[type]++;
 
-      this.startAgain();
-    });
+        requestDetails.requestFn().finally(() => {
+          this.numRequests[type]--;
+          this.startAgain();
+        });
+      }
+    }
+
+    return true;
+  }
+
+  getNextRequest(type): RequestDetailsInterface | null {
+    const interactionPriorities = this.getSortedPriorityGroups(type);
+    for (const priority of interactionPriorities) {
+      if (this.requestPool[type][priority].length) {
+        return this.requestPool[type][priority].shift();
+      }
+    }
+
+    return null;
   }
 
   protected startGrabbing(): void {
-    // TODO: This is the reason things aren't going as fast as expected
-    // const maxSimultaneousRequests = getMaxSimultaneousRequests()
-    // this.maxNumRequests = {
-    //   interaction: Math.max(maxSimultaneousRequests, 1),
-    //   thumbnail: Math.max(maxSimultaneousRequests - 2, 1),
-    //   prefetch: Math.max(maxSimultaneousRequests - 1, 1),
-    // }
-
-    const maxRequests =
-      this.maxNumRequests.interaction +
-      this.maxNumRequests.thumbnail +
-      this.maxNumRequests.prefetch;
-    const currentRequests =
-      this.numRequests.interaction +
-      this.numRequests.thumbnail +
-      this.numRequests.prefetch;
-
-    const requestsToSend = maxRequests - currentRequests;
-    for (let i = 0; i < requestsToSend; i++) {
-      const requestDetails = this.getNextRequest();
-      if (requestDetails === false) {
-        break;
-      } else if (requestDetails) {
-        this.sendRequest(requestDetails);
-      }
-    }
+    this.sendRequests('interaction');
+    this.sendRequests('thumbnail');
+    this.sendRequests('prefetch');
   }
 
   protected startAgain(): void {
-    if (!this.awake) {
-      return;
-    }
-
     if (this.grabDelay !== undefined) {
       this.timeoutHandle = window.setTimeout(() => {
         this.startGrabbing();
@@ -260,45 +251,6 @@ class RequestPoolManager {
       .filter((priority) => this.requestPool[type][priority].length)
       .sort();
     return priorities;
-  }
-
-  protected getNextRequest(): RequestDetailsInterface | false {
-    const interactionPriorities = this.getSortedPriorityGroups('interaction');
-    for (const priority of interactionPriorities) {
-      if (
-        this.requestPool.interaction[priority].length &&
-        this.numRequests.interaction < this.maxNumRequests.interaction
-      ) {
-        return this.requestPool.interaction[priority].shift();
-      }
-    }
-    const thumbnailPriorities = this.getSortedPriorityGroups('thumbnail');
-    for (const priority of thumbnailPriorities) {
-      if (
-        this.requestPool.thumbnail[priority].length &&
-        this.numRequests.thumbnail < this.maxNumRequests.thumbnail
-      ) {
-        return this.requestPool.thumbnail[priority].shift();
-      }
-    }
-    const prefetchPriorities = this.getSortedPriorityGroups('prefetch');
-    for (const priority of prefetchPriorities) {
-      if (
-        this.requestPool.prefetch[priority].length &&
-        this.numRequests.prefetch < this.maxNumRequests.prefetch
-      ) {
-        return this.requestPool.prefetch[priority].shift();
-      }
-    }
-
-    if (
-      !interactionPriorities.length &&
-      !thumbnailPriorities.length &&
-      !prefetchPriorities.length
-    ) {
-      this.awake = false;
-    }
-    return false;
   }
 
   /**

--- a/packages/core/src/requestPool/requestPoolManager.ts
+++ b/packages/core/src/requestPool/requestPoolManager.ts
@@ -1,4 +1,5 @@
 import RequestType from '../enums/RequestType';
+import { uuidv4 } from '../utilities';
 
 type AdditionalDetails = {
   imageId?: string;
@@ -92,9 +93,7 @@ class RequestPoolManager {
    * is set to 6.
    */
   constructor(id?: string) {
-    if (id) {
-      this.id = id;
-    }
+    this.id = id ? id : uuidv4();
 
     this.requestPool = {
       interaction: { 0: [] },

--- a/packages/core/src/types/EventTypes.ts
+++ b/packages/core/src/types/EventTypes.ts
@@ -150,6 +150,18 @@ type VolumeCacheVolumeAddedEventDetail = {
 };
 
 /**
+ * PRE_STACK_NEW_IMAGE Event's data
+ */
+type PreStackNewImageEventDetail = {
+  /** the image imageId */
+  imageId: string;
+  /** unique id for the viewport */
+  viewportId: string;
+  /** unique id for the renderingEngine */
+  renderingEngineId: string;
+};
+
+/**
  * STACK_NEW_IMAGE Event's data
  */
 type StackNewImageEventDetail = {
@@ -273,6 +285,11 @@ type VolumeCacheVolumeRemovedEvent =
 type StackNewImageEvent = CustomEventType<StackNewImageEventDetail>;
 
 /**
+ * START_NEW_IMAGE
+ */
+type PreStackNewImageEvent = CustomEventType<PreStackNewImageEventDetail>;
+
+/**
  * IMAGE_SPACING_CALIBRATED
  */
 type ImageSpacingCalibratedEvent =
@@ -314,6 +331,8 @@ export type {
   VolumeCacheVolumeRemovedEventDetail,
   StackNewImageEvent,
   StackNewImageEventDetail,
+  PreStackNewImageEvent,
+  PreStackNewImageEventDetail,
   ImageSpacingCalibratedEvent,
   ImageSpacingCalibratedEventDetail,
   ImageLoadProgressEvent,

--- a/packages/core/src/types/IImage.ts
+++ b/packages/core/src/types/IImage.ts
@@ -9,6 +9,8 @@ interface IImage {
   /** Image Id */
   imageId: string;
   sharedCacheKey?: string;
+  /** Whether the image is Pre-scaled during loading */
+  isPreScaled?: boolean;
   /** minimum pixel value of the image */
   minPixelValue: number;
   /* maximum pixel value of the image */

--- a/packages/core/src/utilities/loadImageToCanvas.ts
+++ b/packages/core/src/utilities/loadImageToCanvas.ts
@@ -27,7 +27,7 @@ import renderToCanvas from './renderToCanvas';
 export default function loadImageToCanvas(
   canvas: HTMLCanvasElement,
   imageId: string,
-  requestType = RequestType.Interaction,
+  requestType = RequestType.Thumbnail,
   priority = -5
 ): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -66,6 +66,8 @@ export default function loadImageToCanvas(
       suvbw: suvFactor.suvbw,
     };
 
+    // IMPORTANT: Request type should be passed if not the 'interaction'
+    // highest priority will be used for the request type in the imageRetrievalPool
     const options = {
       targetBuffer: {
         type: 'Float32Array',
@@ -75,6 +77,7 @@ export default function loadImageToCanvas(
       preScale: {
         scalingParameters,
       },
+      requestType,
     };
 
     imageLoadPoolManager.addRequest(

--- a/packages/core/src/utilities/prefetchStack.ts
+++ b/packages/core/src/utilities/prefetchStack.ts
@@ -31,12 +31,15 @@ function prefetchStack(
     );
   }
 
+  // IMPORTANT: Request type should be passed if not the 'interaction'
+  // highest priority will be used for the request type in the imageRetrievalPool
   const options = {
     targetBuffer: {
       type: 'Float32Array',
       offset: null,
       length: null,
     },
+    requestType,
   };
 
   imageIds.forEach((imageId, imageIdIndex) => {

--- a/packages/docs/docs/concepts/cornerstone-tools/annotation/selection.md
+++ b/packages/docs/docs/concepts/cornerstone-tools/annotation/selection.md
@@ -15,7 +15,7 @@ There are various APIs for selecting and deselecting annotations along with get/
 import { annotations } from '@cornerstonejs/tools';
 
 // selection of an annotation
-annotations.selection.setAnnotationSelected(annotation);
+annotations.selection.setAnnotationSelected(annotationUID);
 
 // get all the selected annotations
 annotations.selection.getAnnotationsSelected();

--- a/packages/tools/examples/annotationSelectionAndLocking/index.ts
+++ b/packages/tools/examples/annotationSelectionAndLocking/index.ts
@@ -75,10 +75,14 @@ function randomIntFromInterval(min, max) {
 addButtonToToolbar({
   title: 'Lock Selected Annotation',
   onClick: () => {
-    const annotations = selection.getAnnotationsSelected();
+    const annotationUIDs = selection.getAnnotationsSelected();
 
-    if (annotations && annotations.length) {
-      const annotation = annotations[0];
+    if (annotationUIDs && annotationUIDs.length) {
+      const annotationUID = annotationUIDs[0];
+      const annotation =
+        defaultFrameOfReferenceSpecificAnnotationManager.getAnnotation(
+          annotationUID
+        );
 
       locking.setAnnotationLocked(annotation, true);
       selection.deselectAnnotation();
@@ -112,13 +116,7 @@ addButtonToToolbar({
 
     const annotationUID = annotationState[randomIndex].annotationUID;
 
-    // Get actual annotation
-    const annotation =
-      defaultFrameOfReferenceSpecificAnnotationManager.getAnnotation(
-        annotationUID
-      );
-
-    selection.setAnnotationSelected(annotation, true);
+    selection.setAnnotationSelected(annotationUID, true);
   },
 });
 

--- a/packages/tools/examples/rectangleROIThreshold/index.ts
+++ b/packages/tools/examples/rectangleROIThreshold/index.ts
@@ -106,15 +106,22 @@ let upperThreshold = 500;
 addButtonToToolbar({
   title: 'Execute threshold',
   onClick: () => {
-    const selectedAnnotations = selection.getAnnotationsSelectedByToolName(
+    const selectedAnnotationUIDs = selection.getAnnotationsSelectedByToolName(
       RectangleROIThresholdTool.toolName
-    ) as Array<cornerstoneTools.Types.ToolSpecificAnnotationTypes.RectangleROIThresholdAnnotation>;
+    ) as Array<string>;
 
-    if (!selectedAnnotations) {
+    if (!selectedAnnotationUIDs) {
       throw new Error('No annotation selected ');
     }
 
-    const annotation = selectedAnnotations[0];
+    const annotationUID = selectedAnnotationUIDs[0];
+    const annotation = cornerstoneTools.annotation.state.getAnnotation(
+      annotationUID
+    ) as cornerstoneTools.Types.ToolSpecificAnnotationTypes.RectangleROIThresholdAnnotation;
+
+    if (!annotation) {
+      return;
+    }
 
     const { metadata } = annotation; // assuming they are all overlayed on the same toolGroup
     const viewport = metadata.enabledElement.viewport as Types.IVolumeViewport;

--- a/packages/tools/examples/rectangleROIThreshold/index.ts
+++ b/packages/tools/examples/rectangleROIThreshold/index.ts
@@ -138,8 +138,16 @@ addButtonToToolbar({
         segmentationRepresentationByUID
       );
 
+    const annotations = selectedAnnotationUIDs.map((annotationUID) => {
+      const annotation = cornerstoneTools.annotation.state.getAnnotation(
+        annotationUID
+      ) as cornerstoneTools.Types.ToolSpecificAnnotationTypes.RectangleROIThresholdAnnotation;
+
+      return annotation;
+    });
+
     csToolsUtils.segmentation.thresholdVolumeByRange(
-      selectedAnnotations,
+      annotations,
       [referenceVolume],
       segmentationRepresentation,
       {

--- a/packages/tools/src/eventDispatchers/mouseEventHandlers/mouseDown.ts
+++ b/packages/tools/src/eventDispatchers/mouseEventHandlers/mouseDown.ts
@@ -109,7 +109,7 @@ export default function mouseDown(evt: EventTypes.MouseDownEventType) {
       annotationToolsWithMoveableHandles
     ) as ToolsWithMoveableHandles;
 
-    toggleAnnotationSelection(annotation, isMultiSelect);
+    toggleAnnotationSelection(annotation.annotationUID, isMultiSelect);
     tool.handleSelectedCallback(evt, annotation, handle, 'Mouse');
 
     return;
@@ -131,7 +131,7 @@ export default function mouseDown(evt: EventTypes.MouseDownEventType) {
       moveableAnnotationTools
     );
 
-    toggleAnnotationSelection(annotation, isMultiSelect);
+    toggleAnnotationSelection(annotation.annotationUID, isMultiSelect);
     tool.toolSelectedCallback(evt, annotation, 'Mouse');
 
     return;
@@ -170,24 +170,24 @@ function getAnnotationForSelection(
 
 /**
  * If the annotation is selected, deselect it. If it's not selected, select it
- * @param annotation - The Annotation object that we
+ * @param annotationUID - The AnnotationUID that we
  * want to toggle the selection of.
  * @param isMultiSelect - If true, the annotation. will be deselected if it is
  * already selected, or deselected if it is selected.
  */
 function toggleAnnotationSelection(
-  annotation: Annotation,
+  annotationUID: string,
   isMultiSelect = false
 ): void {
   if (isMultiSelect) {
-    if (isAnnotationSelected(annotation)) {
-      setAnnotationSelected(annotation, false);
+    if (isAnnotationSelected(annotationUID)) {
+      setAnnotationSelected(annotationUID, false);
     } else {
       const preserveSelected = true;
-      setAnnotationSelected(annotation, true, preserveSelected);
+      setAnnotationSelected(annotationUID, true, preserveSelected);
     }
   } else {
     const preserveSelected = false;
-    setAnnotationSelected(annotation, true, preserveSelected);
+    setAnnotationSelected(annotationUID, true, preserveSelected);
   }
 }

--- a/packages/tools/src/eventDispatchers/mouseEventHandlers/mouseDown.ts
+++ b/packages/tools/src/eventDispatchers/mouseEventHandlers/mouseDown.ts
@@ -1,6 +1,6 @@
 import { state } from '../../store';
 import { ToolModes } from '../../enums';
-import { Annotation, EventTypes } from '../../types';
+import { EventTypes } from '../../types';
 import {
   ToolAnnotationPair,
   ToolsWithMoveableHandles,

--- a/packages/tools/src/eventDispatchers/mouseEventHandlers/mouseDownActivate.ts
+++ b/packages/tools/src/eventDispatchers/mouseEventHandlers/mouseDownActivate.ts
@@ -30,6 +30,6 @@ export default function mouseDownActivate(
 
   if (activeTool.addNewAnnotation) {
     const annotation = activeTool.addNewAnnotation(evt, 'mouse');
-    setAnnotationSelected(annotation);
+    setAnnotationSelected(annotation.annotationUID);
   }
 }

--- a/packages/tools/src/stateManagement/annotation/annotationSelection.ts
+++ b/packages/tools/src/stateManagement/annotation/annotationSelection.ts
@@ -1,23 +1,23 @@
 import { eventTarget, triggerEvent } from '@cornerstonejs/core';
 import { Events } from '../../enums';
-import { Annotation } from '../../types';
 import { AnnotationSelectionChangeEventDetail } from '../../types/EventTypes';
+import { getAnnotation } from './annotationState';
 
 /*
  * Constants
  */
 
-const selectedAnnotations: Set<Annotation> = new Set();
+const selectedAnnotationUIDs: Set<string> = new Set();
 
 /*
  * Interface (Public API)
  */
 
 /**
- * Set a given annotation as selected or deselected based on the provided
+ * Set a given annotationUID as selected or deselected based on the provided
  * selected value.
  *
- * @param annotation - The annotation to be selected
+ * @param annotationUID - The annotation UID to be selected
  * @param selected - When true, the annotation is selected. When false, the annotation is deselected.
  * @param preserveSelected - When true, preserves existing
  *  selections (i.e., the given annotation is appended to the selection set).
@@ -25,98 +25,87 @@ const selectedAnnotations: Set<Annotation> = new Set();
  *  (i.e., the given annotation instance replaces the currently selected ones).
  */
 function setAnnotationSelected(
-  annotation: Annotation,
+  annotationUID: string,
   selected = true,
   preserveSelected = false
 ): void {
   if (selected) {
-    selectAnnotation(annotation, preserveSelected);
+    selectAnnotation(annotationUID, preserveSelected);
   } else {
-    deselectAnnotation(annotation);
+    deselectAnnotation(annotationUID);
   }
 }
 
 /**
  * Set a given annotation as selected.
  *
- * @param annotation - The annotation to be selected
+ * @param annotationUID - The annotation UID to be selected
  * @param preserveSelected - When true, preserves existing
  *  selections (i.e., the given annotation is appended to the selection set).
  *  When false (the default behavior) the currently selected items are discarded
  *  (i.e., the given annotation instance replaces the currently selected ones).
  */
 function selectAnnotation(
-  annotation: Annotation,
+  annotationUID: string,
   preserveSelected = false
 ): void {
   const detail = makeEventDetail();
   if (!preserveSelected) {
-    clearSelectionSet(selectedAnnotations, detail);
+    clearSelectionSet(selectedAnnotationUIDs, detail);
   }
-  if (annotation && !selectedAnnotations.has(annotation)) {
-    selectedAnnotations.add(annotation);
-    detail.added.push(annotation);
+  if (annotationUID && !selectedAnnotationUIDs.has(annotationUID)) {
+    selectedAnnotationUIDs.add(annotationUID);
+    detail.added.push(annotationUID);
   }
-  publish(detail, selectedAnnotations);
+  publish(detail, selectedAnnotationUIDs);
 }
 
 /**
- * Deselect one or all annotation instances.
+ * Deselect one or all annotations.
  *
- * @param annotation - If an annotation is provided that instance will be removed from
+ * @param annotationUID - If an annotation is provided that instance will be removed from
  * the internal selection set. If none is given, ALL selections will be cleared.
  */
-function deselectAnnotation(annotation?: Annotation): void {
+function deselectAnnotation(annotationUID?: string): void {
   const detail = makeEventDetail();
-  if (annotation) {
-    if (selectedAnnotations.delete(annotation)) {
-      detail.removed.push(annotation);
+  if (annotationUID) {
+    if (selectedAnnotationUIDs.delete(annotationUID)) {
+      detail.removed.push(annotationUID);
     }
   } else {
-    clearSelectionSet(selectedAnnotations, detail);
+    clearSelectionSet(selectedAnnotationUIDs, detail);
   }
-  publish(detail, selectedAnnotations);
+  publish(detail, selectedAnnotationUIDs);
 }
 
 /**
- * Return an array of ALL the selected annotation
- * @returns An array of Annotation objects.
+ * Return an array of ALL the selected annotationUIDs
+ * @returns An array of Annotation UIDs
  */
-function getAnnotationsSelected(): Array<Annotation> {
-  return Array.from(selectedAnnotations);
+function getAnnotationsSelected(): Array<string> {
+  return Array.from(selectedAnnotationUIDs);
 }
 
 /**
- * Given a annotationUID, return the Annotation object that has that
- * annotationUID
- * @param annotationUID - The UID of the annotation to be retrieved.
- * @returns A Annotation object.
- */
-function getAnnotationSelected(annotationUID: string): Annotation {
-  return getAnnotationsSelected().find((annotation) => {
-    return annotation.annotationUID === annotationUID;
-  });
-}
-
-/**
- * Given a tool name, return ALL the annotation for that tool that are selected
+ * Given a tool name, return ALL the annotationUIDs for that tool that are selected
  * @param toolName - The name of the tool you want to get the selected annotation for
- * @returns An array of tool specific annotation that are selected
+ * @returns An array of annotationUIDs
  */
-function getAnnotationsSelectedByToolName(toolName: string): Array<Annotation> {
-  return getAnnotationsSelected().filter((annotation) => {
+function getAnnotationsSelectedByToolName(toolName: string): Array<string> {
+  return getAnnotationsSelected().filter((annotationUID) => {
+    const annotation = getAnnotation(annotationUID);
     return annotation.metadata.toolName === toolName;
   });
 }
 
 /**
- * Given an annotation object, return true if it is selected, false
+ * Given an annotationUID, return true if it is selected, false
  * otherwise.
- * @param annotation - Annotation
+ * @param annotationUID - Annotation UID
  * @returns A boolean value.
  */
-function isAnnotationSelected(annotation: Annotation): boolean {
-  return selectedAnnotations.has(annotation);
+function isAnnotationSelected(annotationUID: string): boolean {
+  return selectedAnnotationUIDs.has(annotationUID);
 }
 
 /**
@@ -124,7 +113,7 @@ function isAnnotationSelected(annotation: Annotation): boolean {
  * @returns The size of the selected annotation set
  */
 function getAnnotationsSelectedCount(): number {
-  return selectedAnnotations.size;
+  return selectedAnnotationUIDs.size;
 }
 
 /*
@@ -140,7 +129,7 @@ function makeEventDetail(): AnnotationSelectionChangeEventDetail {
 }
 
 function clearSelectionSet(
-  selectionSet: Set<Annotation>,
+  selectionSet: Set<string>,
   detail: AnnotationSelectionChangeEventDetail
 ): void {
   selectionSet.forEach((value) => {
@@ -152,7 +141,7 @@ function clearSelectionSet(
 
 function publish(
   detail: AnnotationSelectionChangeEventDetail,
-  selectionSet: Set<Annotation>
+  selectionSet: Set<string>
 ) {
   if (detail.added.length > 0 || detail.removed.length > 0) {
     selectionSet.forEach((item) => void detail.selection.push(item));
@@ -167,7 +156,6 @@ function publish(
 export {
   setAnnotationSelected,
   getAnnotationsSelected,
-  getAnnotationSelected,
   getAnnotationsSelectedByToolName,
   getAnnotationsSelectedCount,
   deselectAnnotation,

--- a/packages/tools/src/stateManagement/annotation/config/getState.ts
+++ b/packages/tools/src/stateManagement/annotation/config/getState.ts
@@ -13,7 +13,10 @@ function getState(annotation?: Annotation): AnnotationStyleStates {
   if (annotation) {
     if (annotation.data && annotation.highlighted)
       return AnnotationStyleStates.Highlighted;
-    if (isAnnotationSelected(annotation)) return AnnotationStyleStates.Selected;
+    if (isAnnotationSelected(annotation.annotationUID))
+      return AnnotationStyleStates.Selected;
+
+    // Todo: make annotation lock api not to rely on the annotation itself
     if (isAnnotationLocked(annotation)) return AnnotationStyleStates.Locked;
   }
 

--- a/packages/tools/src/types/EventTypes.ts
+++ b/packages/tools/src/types/EventTypes.ts
@@ -59,12 +59,12 @@ type AnnotationRemovedEventDetail = {
  * The data that is passed to the event handler when an annotation selection status changes.
  */
 type AnnotationSelectionChangeEventDetail = {
-  /** Annotation added to the selection */
-  added: Array<Annotation>;
-  /** Annotation removed from the selection */
-  removed: Array<Annotation>;
+  /** AnnotationUID added to the selection */
+  added: Array<string>;
+  /** AnnotationUID removed from the selection */
+  removed: Array<string>;
   /** Updated selection */
-  selection: Array<Annotation>;
+  selection: Array<string>;
 };
 
 /**

--- a/packages/tools/src/utilities/index.ts
+++ b/packages/tools/src/utilities/index.ts
@@ -22,6 +22,7 @@ import * as math from './math';
 import * as planar from './planar';
 import * as stackScrollTool from './stackScrollTool';
 import * as viewportFilters from './viewportFilters';
+import * as orientation from './orientation';
 
 // Events
 import { triggerEvent } from '@cornerstonejs/core';
@@ -35,6 +36,7 @@ export {
   debounce,
   deepMerge,
   throttle,
+  orientation,
   isObject,
   triggerEvent,
   calibrateImageSpacing,

--- a/packages/tools/src/utilities/orientation/getOrientationString.ts
+++ b/packages/tools/src/utilities/orientation/getOrientationString.ts
@@ -1,0 +1,52 @@
+import { Types } from '@cornerstonejs/core';
+
+/**
+ * Returns the orientation of the vector in the patient coordinate system.
+ * @public
+ *
+ * @param vector - Input array
+ * @returns The orientation in the patient coordinate system.
+ */
+export default function getOrientationString(vector: Types.Point3): string {
+  // Thanks to David Clunie
+  // https://sites.google.com/site/dicomnotes/
+
+  let orientation = '';
+  const orientationX = vector[0] < 0 ? 'R' : 'L';
+  const orientationY = vector[1] < 0 ? 'A' : 'P';
+  const orientationZ = vector[2] < 0 ? 'F' : 'H';
+
+  // Should probably make this a function vector3.abs
+  const abs = [Math.abs(vector[0]), Math.abs(vector[1]), Math.abs(vector[2])];
+
+  const MIN = 0.0001;
+
+  for (let i = 0; i < 3; i++) {
+    if (abs[0] > MIN && abs[0] > abs[1] && abs[0] > abs[2]) {
+      orientation += orientationX;
+      abs[0] = 0;
+    } else if (abs[1] > MIN && abs[1] > abs[0] && abs[1] > abs[2]) {
+      orientation += orientationY;
+      abs[1] = 0;
+    } else if (abs[2] > MIN && abs[2] > abs[0] && abs[2] > abs[1]) {
+      orientation += orientationZ;
+      abs[2] = 0;
+    } else if (abs[0] > MIN && abs[1] > MIN && abs[0] === abs[1]) {
+      orientation += orientationX + orientationY;
+      abs[0] = 0;
+      abs[1] = 0;
+    } else if (abs[0] > MIN && abs[2] > MIN && abs[0] === abs[2]) {
+      orientation += orientationX + orientationZ;
+      abs[0] = 0;
+      abs[2] = 0;
+    } else if (abs[1] > MIN && abs[2] > MIN && abs[1] === abs[2]) {
+      orientation += orientationY + orientationZ;
+      abs[1] = 0;
+      abs[2] = 0;
+    } else {
+      break;
+    }
+  }
+
+  return orientation;
+}

--- a/packages/tools/src/utilities/orientation/getOrientationStringLPS.ts
+++ b/packages/tools/src/utilities/orientation/getOrientationStringLPS.ts
@@ -7,7 +7,7 @@ import { Types } from '@cornerstonejs/core';
  * @param vector - Input array
  * @returns The orientation in the patient coordinate system.
  */
-export default function getOrientationString(vector: Types.Point3): string {
+export default function getOrientationStringLPS(vector: Types.Point3): string {
   // Thanks to David Clunie
   // https://sites.google.com/site/dicomnotes/
 

--- a/packages/tools/src/utilities/orientation/index.ts
+++ b/packages/tools/src/utilities/orientation/index.ts
@@ -1,0 +1,4 @@
+import getOrientationString from './getOrientationString';
+import invertOrientationString from './invertOrientationString';
+
+export { getOrientationString, invertOrientationString };

--- a/packages/tools/src/utilities/orientation/index.ts
+++ b/packages/tools/src/utilities/orientation/index.ts
@@ -1,4 +1,4 @@
-import getOrientationString from './getOrientationString';
-import invertOrientationString from './invertOrientationString';
+import getOrientationStringLPS from './getOrientationStringLPS';
+import invertOrientationStringLPS from './invertOrientationStringLPS';
 
-export { getOrientationString, invertOrientationString };
+export { getOrientationStringLPS, invertOrientationStringLPS };

--- a/packages/tools/src/utilities/orientation/invertOrientationString.ts
+++ b/packages/tools/src/utilities/orientation/invertOrientationString.ts
@@ -1,0 +1,21 @@
+/**
+ * Inverts an orientation string.
+ * @public
+ *
+ * @param orientationString - The orientation.
+ * @returns The inverted orientationString.
+ */
+export default function invertOrientationString(
+  orientationString: string
+): string {
+  let inverted = orientationString.replace('H', 'f');
+
+  inverted = inverted.replace('F', 'h');
+  inverted = inverted.replace('R', 'l');
+  inverted = inverted.replace('L', 'r');
+  inverted = inverted.replace('A', 'p');
+  inverted = inverted.replace('P', 'a');
+  inverted = inverted.toUpperCase();
+
+  return inverted;
+}

--- a/packages/tools/src/utilities/orientation/invertOrientationStringLPS.ts
+++ b/packages/tools/src/utilities/orientation/invertOrientationStringLPS.ts
@@ -5,7 +5,7 @@
  * @param orientationString - The orientation.
  * @returns The inverted orientationString.
  */
-export default function invertOrientationString(
+export default function invertOrientationStringLPS(
   orientationString: string
 ): string {
   let inverted = orientationString.replace('H', 'f');


### PR DESCRIPTION
- change the selection api to not rely on the annotation object (UID is enough)
- add PRE_NEW_STACK_IMAGE event for consumers
- add a check for if the loaded image is prescaled (if it was loaded with the scaling parameters), if so it handles the PT non scaled images
- Fix the CPU rendering for PT images 
- Add id to the pool managers
- Fix a bug in the requestPoolManager when a new image is added (interaction priority), it was waiting for a request to be finished before sending the high priority image request
- Fix a bug in requestPool to set the maximum number of requests based on the requestType, previously it was summing all up and comparing them with the current number of requests, it should be per requestType
- Fix prefetching imageIds requests to properly set the prefetch requestType
- Port over the orientation helpers from cornerstone-tools