### PR TITLE
Fix/camera events

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1078,6 +1078,8 @@ interface IStackViewport extends IViewport {
     // (undocumented)
     hasImageURI: (imageURI: string) => boolean;
     // (undocumented)
+    isImagePreScaled(imageId: string): boolean;
+    // (undocumented)
     modality: string;
     // (undocumented)
     resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
@@ -1603,6 +1605,8 @@ export class StackViewport extends Viewport implements IStackViewport {
     hasImageId: (imageId: string) => boolean;
     // (undocumented)
     hasImageURI: (imageURI: string) => boolean;
+    // (undocumented)
+    isImagePreScaled(imageId: string): boolean;
     // (undocumented)
     modality: string;
     // (undocumented)

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -51,6 +51,7 @@ type CameraModifiedEventDetail = {
     element: HTMLDivElement;
     viewportId: string;
     renderingEngineId: string;
+    rotation?: number;
 };
 
 // @public (undocumented)
@@ -606,6 +607,10 @@ interface ICamera {
     // (undocumented)
     clippingRange?: Point2;
     // (undocumented)
+    flipHorizontal?: boolean;
+    // (undocumented)
+    flipVertical?: boolean;
+    // (undocumented)
     focalPoint?: Point3;
     // (undocumented)
     parallelProjection?: boolean;
@@ -1089,7 +1094,7 @@ interface IStackViewport extends IViewport {
     // (undocumented)
     setImageIdIndex(imageIdIndex: number): Promise<string>;
     // (undocumented)
-    setProperties({ voiRange, invert, interpolationType, rotation, flipHorizontal, flipVertical, }: StackViewportProperties): void;
+    setProperties({ voiRange, invert, interpolationType, rotation, }: StackViewportProperties): void;
     // (undocumented)
     setStack(imageIds: Array<string>, currentImageIdIndex?: number): Promise<string>;
     // (undocumented)
@@ -1619,7 +1624,7 @@ export class StackViewport extends Viewport implements IStackViewport {
     // (undocumented)
     setImageIdIndex(imageIdIndex: number): Promise<string>;
     // (undocumented)
-    setProperties({ voiRange, invert, interpolationType, rotation, flipHorizontal, flipVertical, }?: StackViewportProperties): void;
+    setProperties({ voiRange, invert, interpolationType, rotation, }?: StackViewportProperties): void;
     // (undocumented)
     setStack(imageIds: Array<string>, currentImageIdIndex?: number): Promise<string>;
     // (undocumented)
@@ -1636,8 +1641,6 @@ type StackViewportProperties = {
     invert?: boolean;
     interpolationType?: InterpolationType;
     rotation?: number;
-    flipHorizontal?: boolean;
-    flipVertical?: boolean;
 };
 
 // @public (undocumented)
@@ -1838,6 +1841,8 @@ export class Viewport implements IViewport {
     // (undocumented)
     resize: () => void;
     // (undocumented)
+    protected rotation: number;
+    // (undocumented)
     setActors(actors: Array<ActorEntry>): void;
     // (undocumented)
     setCamera(cameraInterface: ICamera): void;
@@ -1984,8 +1989,6 @@ export class VolumeViewport extends Viewport implements IVolumeViewport {
     getImageData(): IImageData | undefined;
     // (undocumented)
     getIntensityFromWorld(point: Point3): number;
-    // (undocumented)
-    getProperties: () => FlipDirection;
     // (undocumented)
     getSlabThickness(): number;
     // (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -33,6 +33,7 @@ type CameraModifiedEventDetail = {
     element: HTMLDivElement;
     viewportId: string;
     renderingEngineId: string;
+    rotation?: number;
 };
 
 // @public (undocumented)
@@ -469,6 +470,8 @@ interface ICachedVolume {
 // @public
 interface ICamera {
     clippingRange?: Point2;
+    flipHorizontal?: boolean;
+    flipVertical?: boolean;
     focalPoint?: Point3;
     parallelProjection?: boolean;
     parallelScale?: number;
@@ -786,8 +789,6 @@ interface IStackViewport extends IViewport {
         invert,
         interpolationType,
         rotation,
-        flipHorizontal,
-        flipVertical,
     }: StackViewportProperties): void;
     setStack(
     imageIds: Array<string>,
@@ -1047,8 +1048,6 @@ type StackViewportProperties = {
     invert?: boolean;
     interpolationType?: InterpolationType;
     rotation?: number;
-    flipHorizontal?: boolean;
-    flipVertical?: boolean;
 };
 
 // @public (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -775,6 +775,7 @@ interface IStackViewport extends IViewport {
     getRenderer(): any;
     hasImageId: (imageId: string) => boolean;
     hasImageURI: (imageURI: string) => boolean;
+    isImagePreScaled(imageId: string): boolean;
     // (undocumented)
     modality: string;
     resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -355,6 +355,7 @@ type CameraModifiedEventDetail = {
     element: HTMLDivElement;
     viewportId: string;
     renderingEngineId: string;
+    rotation?: number;
 };
 
 // @public (undocumented)
@@ -1465,6 +1466,8 @@ interface ICachedVolume {
 // @public
 interface ICamera {
     clippingRange?: Point2;
+    flipHorizontal?: boolean;
+    flipVertical?: boolean;
     focalPoint?: Point3;
     parallelProjection?: boolean;
     parallelScale?: number;
@@ -1818,8 +1821,6 @@ interface IStackViewport extends IViewport {
         invert,
         interpolationType,
         rotation,
-        flipHorizontal,
-        flipVertical,
     }: StackViewportProperties): void;
     setStack(
     imageIds: Array<string>,
@@ -3227,8 +3228,6 @@ type StackViewportProperties = {
     invert?: boolean;
     interpolationType?: InterpolationType;
     rotation?: number;
-    flipHorizontal?: boolean;
-    flipVertical?: boolean;
 };
 
 declare namespace state {

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1807,6 +1807,7 @@ interface IStackViewport extends IViewport {
     getRenderer(): any;
     hasImageId: (imageId: string) => boolean;
     hasImageURI: (imageURI: string) => boolean;
+    isImagePreScaled(imageId: string): boolean;
     // (undocumented)
     modality: string;
     resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;

--- a/packages/core/examples/stackAPI/index.ts
+++ b/packages/core/examples/stackAPI/index.ts
@@ -116,9 +116,8 @@ addButtonToToolbar({
       renderingEngine.getViewport(viewportId)
     );
 
-    const { flipHorizontal } = viewport.getProperties();
-
-    viewport.setProperties({ flipHorizontal: !flipHorizontal });
+    const { flipHorizontal } = viewport.getCamera();
+    viewport.setCamera({ flipHorizontal: !flipHorizontal });
 
     viewport.render();
   },
@@ -135,9 +134,9 @@ addButtonToToolbar({
       renderingEngine.getViewport(viewportId)
     );
 
-    const { flipVertical } = viewport.getProperties();
+    const { flipVertical } = viewport.getCamera();
 
-    viewport.setProperties({ flipVertical: !flipVertical });
+    viewport.setCamera({ flipVertical: !flipVertical });
 
     viewport.render();
   },

--- a/packages/core/examples/volumeAPI/index.ts
+++ b/packages/core/examples/volumeAPI/index.ts
@@ -89,9 +89,8 @@ addButtonToToolbar({
     );
 
     // Flip the viewport horizontally
-    const { flipHorizontal } = viewport.getProperties();
-
-    viewport.flip({ flipHorizontal: !flipHorizontal });
+    const { flipHorizontal } = viewport.getCamera();
+    viewport.setCamera({ flipHorizontal: !flipHorizontal });
 
     viewport.render();
   },
@@ -109,9 +108,9 @@ addButtonToToolbar({
     );
 
     // Flip the viewport vertically
-    const { flipVertical } = viewport.getProperties();
+    const { flipVertical } = viewport.getCamera();
 
-    viewport.flip({ flipVertical: !flipVertical });
+    viewport.setCamera({ flipVertical: !flipVertical });
 
     viewport.render();
   },

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1275,7 +1275,7 @@ class StackViewport extends Viewport implements IStackViewport {
         triggerEvent(this.element, Events.STACK_NEW_IMAGE, eventDetail);
 
         const metadata = this._getImageDataMetadata(image) as ImageDataMetaData;
-        image.isPreScaled = this._isImagePreScaled(imageId);
+        image.isPreScaled = this.isImagePreScaled(imageId);
 
         const viewport = getDefaultViewport(
           this.canvas,
@@ -1511,7 +1511,7 @@ class StackViewport extends Viewport implements IStackViewport {
    * @param imageId  - imageId of the image
    * @returns boolean
    */
-  private _isImagePreScaled(imageId) {
+  public isImagePreScaled(imageId: string): boolean {
     const scalingParameters = this.scalingCache[imageId];
 
     if (!scalingParameters) {
@@ -1661,7 +1661,7 @@ class StackViewport extends Viewport implements IStackViewport {
         : undefined;
 
     // check if the image is already prescaled
-    const isPreScaled = this._isImagePreScaled(image.imageId);
+    const isPreScaled = this.isImagePreScaled(image.imageId);
     if (imagePixelModule.modality === 'PT' && isPreScaled) {
       voiRange = { lower: 0, upper: 5 };
     }

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -331,20 +331,6 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
   }
 
   /**
-   * Currently only returning the flip direction of the viewport, Todo: should
-   * be like StackViewport to be able to return and also set other properties
-   * such as voi, invert, etc.
-   *
-   * @returns FlipDirection of the viewport
-   */
-  public getProperties = (): FlipDirection => {
-    return {
-      flipHorizontal: this.flipHorizontal,
-      flipVertical: this.flipVertical,
-    };
-  };
-
-  /**
    * Attaches the volume actors to the viewport.
    *
    * @param volumeActorEntries - The volume actors to add the viewport.

--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/renderGrayscaleImage.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/renderGrayscaleImage.ts
@@ -64,11 +64,11 @@ function getRenderCanvas(
 
   const { viewport } = enabledElement;
 
-  // If modality is 'PT' the resulting scaled image is floatting point, and
-  // we cannot create a lut for it (cannot have float indices). Therefore,
+  // If modality is 'PT' and the image is scaled then the results are floating points,
+  // and we cannot create a lut for it (cannot have float indices). Therefore,
   // we use a mapping function to get the voiLUT from the values by applying
   // the windowLevel and windowWidth.
-  if (viewport.modality === 'PT') {
+  if (viewport.modality === 'PT' && image.isPreScaled) {
     const { windowWidth, windowCenter } = viewport.voi;
     const minimum = windowCenter - windowWidth / 2;
     const maximum = windowCenter + windowWidth / 2;

--- a/packages/core/src/types/EventTypes.ts
+++ b/packages/core/src/types/EventTypes.ts
@@ -1,3 +1,5 @@
+import type { mat4 } from 'gl-matrix';
+import type { vtkImageData } from '@kitware/vtk.js/Common/DataModel/ImageData';
 import type CustomEventType from '../types/CustomEventType';
 import type ICachedImage from './ICachedImage';
 import type ICachedVolume from './ICachedVolume';
@@ -5,8 +7,6 @@ import type ICamera from './ICamera';
 import type IImage from './IImage';
 import type IImageVolume from './IImageVolume';
 import type { VOIRange } from './voi';
-import type { mat4 } from 'gl-matrix';
-import type { vtkImageData } from '@kitware/vtk.js/Common/DataModel/ImageData';
 
 /**
  * CAMERA_MODIFIED Event's data
@@ -22,6 +22,8 @@ type CameraModifiedEventDetail = {
   viewportId: string;
   /** Unique ID for the renderingEngine */
   renderingEngineId: string;
+  /** Rotation Optional */
+  rotation?: number;
 };
 
 /**

--- a/packages/core/src/types/ICamera.ts
+++ b/packages/core/src/types/ICamera.ts
@@ -24,6 +24,10 @@ interface ICamera {
   viewUp?: Point3;
   /** Camera Slab Thickness */
   slabThickness?: number;
+  /** flip Horizontal */
+  flipHorizontal?: boolean;
+  /** flip Vertical */
+  flipVertical?: boolean;
 }
 
 export default ICamera;

--- a/packages/core/src/types/IStackViewport.ts
+++ b/packages/core/src/types/IStackViewport.ts
@@ -28,15 +28,12 @@ export default interface IStackViewport extends IViewport {
   /**
    * Sets the properties for the viewport on the default actor. Properties include
    * setting the VOI, inverting the colors and setting the interpolation type, rotation
-   * and flipHorizontal/Vertical.
    */
   setProperties({
     voiRange,
     invert,
     interpolationType,
     rotation,
-    flipHorizontal,
-    flipVertical,
   }: StackViewportProperties): void;
   /**
    * Retrieve the viewport properties

--- a/packages/core/src/types/IStackViewport.ts
+++ b/packages/core/src/types/IStackViewport.ts
@@ -136,4 +136,8 @@ export default interface IStackViewport extends IViewport {
    * It sets the colormap to the default colormap.
    */
   unsetColormap(): void;
+  /**
+   * Checks if the imageId is preScaled when loaded
+   */
+  isImagePreScaled(imageId: string): boolean;
 }

--- a/packages/core/src/types/StackViewportProperties.ts
+++ b/packages/core/src/types/StackViewportProperties.ts
@@ -13,10 +13,6 @@ type StackViewportProperties = {
   interpolationType?: InterpolationType;
   /** image rotation */
   rotation?: number;
-  /** flip horizontal flag */
-  flipHorizontal?: boolean;
-  /** flip vertical flag */
-  flipVertical?: boolean;
 };
 
 export default StackViewportProperties;

--- a/packages/core/src/types/ViewportInputOptions.ts
+++ b/packages/core/src/types/ViewportInputOptions.ts
@@ -6,7 +6,7 @@ import Orientation from './Orientation';
 type ViewportInputOptions = {
   /** background color */
   background?: [number, number, number];
-  /** orientation of the viewport - Axial, Coronal, Sagittal */
+  /** orientation of the viewport - e.g., Axial, Coronal, Sagittal, or custom oblique with sliceNormal and viewUp */
   orientation?: Orientation;
   /** whether the events should be suppressed and not fired*/
   suppressEvents?: boolean;

--- a/packages/core/test/stackViewport_gpu_render_test.js
+++ b/packages/core/test/stackViewport_gpu_render_test.js
@@ -933,8 +933,9 @@ describe('renderingCore -- Stack', () => {
         vp.setStack([imageId], 0).then(() => {
           vp.setProperties({
             interpolationType: InterpolationType.NEAREST,
-            flipHorizontal: true,
           });
+
+          vp.setCamera({ flipHorizontal: true });
 
           vp.render();
         });
@@ -966,8 +967,9 @@ describe('renderingCore -- Stack', () => {
           vp.setProperties({
             interpolationType: InterpolationType.NEAREST,
             rotation: 90,
-            flipHorizontal: true,
           });
+
+          vp.setCamera({ flipHorizontal: true });
 
           vp.render();
         });

--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -176,7 +176,7 @@ export default class CrosshairsTool extends AnnotationTool {
     const { position, focalPoint, viewPlaneNormal } = viewport.getCamera();
 
     // Check if there is already annotation for this viewport
-    let annotations = getAnnotations(element, CrosshairsTool.toolName);
+    let annotations = getAnnotations(element, this.getToolName());
     annotations = this.filterInteractableAnnotationsForElement(
       element,
       annotations
@@ -193,7 +193,7 @@ export default class CrosshairsTool extends AnnotationTool {
         cameraPosition: <Types.Point3>[...position],
         cameraFocalPoint: <Types.Point3>[...focalPoint],
         FrameOfReferenceUID,
-        toolName: CrosshairsTool.toolName,
+        toolName: this.getToolName(),
       },
       data: {
         handles: {
@@ -311,7 +311,7 @@ export default class CrosshairsTool extends AnnotationTool {
     const { viewport } = enabledElement;
     this._jump(enabledElement, jumpWorld);
 
-    const annotations = getAnnotations(element, CrosshairsTool.toolName);
+    const annotations = getAnnotations(element, this.getToolName());
     const filteredAnnotations = this.filterInteractableAnnotationsForElement(
       viewport.element,
       annotations
@@ -472,11 +472,11 @@ export default class CrosshairsTool extends AnnotationTool {
     const requireSameOrientation = false;
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      CrosshairsTool.toolName,
+      this.getToolName(),
       requireSameOrientation
     );
 
-    const annotations = getAnnotations(element, CrosshairsTool.toolName);
+    const annotations = getAnnotations(element, this.getToolName());
     const filteredToolAnnotations =
       this.filterInteractableAnnotationsForElement(element, annotations);
 
@@ -693,7 +693,7 @@ export default class CrosshairsTool extends AnnotationTool {
   ): void => {
     const { viewport, renderingEngine } = enabledElement;
     const { element } = viewport;
-    const annotations = getAnnotations(element, CrosshairsTool.toolName);
+    const annotations = getAnnotations(element, this.getToolName());
     const camera = viewport.getCamera();
 
     const filteredToolAnnotations =
@@ -1079,7 +1079,7 @@ export default class CrosshairsTool extends AnnotationTool {
         lineUID = `${lineIndex}One`;
         drawLineSvg(
           svgDrawingHelper,
-          CrosshairsTool.toolName,
+          this.getToolName(),
           annotationUID,
           lineUID,
           line[1],
@@ -1093,7 +1093,7 @@ export default class CrosshairsTool extends AnnotationTool {
         lineUID = `${lineIndex}Two`;
         drawLineSvg(
           svgDrawingHelper,
-          CrosshairsTool.toolName,
+          this.getToolName(),
           annotationUID,
           lineUID,
           line[3],
@@ -1106,7 +1106,7 @@ export default class CrosshairsTool extends AnnotationTool {
       } else {
         drawLineSvg(
           svgDrawingHelper,
-          CrosshairsTool.toolName,
+          this.getToolName(),
           annotationUID,
           lineUID,
           line[2],
@@ -1186,7 +1186,7 @@ export default class CrosshairsTool extends AnnotationTool {
           let handleUID = `${lineIndex}One`;
           drawHandlesSvg(
             svgDrawingHelper,
-            CrosshairsTool.toolName,
+            this.getToolName(),
             annotationUID,
             handleUID,
             rotationHandles,
@@ -1199,7 +1199,7 @@ export default class CrosshairsTool extends AnnotationTool {
           handleUID = `${lineIndex}Two`;
           drawHandlesSvg(
             svgDrawingHelper,
-            CrosshairsTool.toolName,
+            this.getToolName(),
             annotationUID,
             handleUID,
             slabThicknessHandles,
@@ -1219,7 +1219,7 @@ export default class CrosshairsTool extends AnnotationTool {
           // draw rotation handles inactive
           drawHandlesSvg(
             svgDrawingHelper,
-            CrosshairsTool.toolName,
+            this.getToolName(),
             annotationUID,
             handleUID,
             rotationHandles,
@@ -1239,7 +1239,7 @@ export default class CrosshairsTool extends AnnotationTool {
           // draw slab thickness handles inactive
           drawHandlesSvg(
             svgDrawingHelper,
-            CrosshairsTool.toolName,
+            this.getToolName(),
             annotationUID,
             handleUID,
             slabThicknessHandles,
@@ -1254,7 +1254,7 @@ export default class CrosshairsTool extends AnnotationTool {
           // draw all rotation handles as active
           drawHandlesSvg(
             svgDrawingHelper,
-            CrosshairsTool.toolName,
+            this.getToolName(),
             annotationUID,
             handleUID,
             rotationHandles,
@@ -1273,7 +1273,7 @@ export default class CrosshairsTool extends AnnotationTool {
           // draw only the slab thickness handles for the active viewport as active
           drawHandlesSvg(
             svgDrawingHelper,
-            CrosshairsTool.toolName,
+            this.getToolName(),
             annotationUID,
             lineUID,
             slabThicknessHandles,
@@ -1291,7 +1291,7 @@ export default class CrosshairsTool extends AnnotationTool {
           lineUID = `${lineIndex}STOne`;
           drawLineSvg(
             svgDrawingHelper,
-            CrosshairsTool.toolName,
+            this.getToolName(),
             annotationUID,
             lineUID,
             line[5],
@@ -1306,7 +1306,7 @@ export default class CrosshairsTool extends AnnotationTool {
           lineUID = `${lineIndex}STTwo`;
           drawLineSvg(
             svgDrawingHelper,
-            CrosshairsTool.toolName,
+            this.getToolName(),
             annotationUID,
             lineUID,
             line[7],
@@ -1336,7 +1336,7 @@ export default class CrosshairsTool extends AnnotationTool {
     const circleUID = '0';
     drawCircleSvg(
       svgDrawingHelper,
-      CrosshairsTool.toolName,
+      this.getToolName(),
       annotationUID,
       circleUID,
       referenceColorCoordinates,
@@ -1778,10 +1778,7 @@ export default class CrosshairsTool extends AnnotationTool {
     state.isInteractingWithTool = true;
     const { viewport, renderingEngine } = enabledElement;
 
-    const annotations = getAnnotations(
-      viewport.element,
-      CrosshairsTool.toolName
-    );
+    const annotations = getAnnotations(viewport.element, this.getToolName());
 
     const delta: Types.Point3 = [0, 0, 0];
     vtkMath.subtract(jumpWorld, this.toolCenter, delta);
@@ -1872,7 +1869,7 @@ export default class CrosshairsTool extends AnnotationTool {
     const requireSameOrientation = false;
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      CrosshairsTool.toolName,
+      this.getToolName(),
       requireSameOrientation
     );
 
@@ -1896,7 +1893,7 @@ export default class CrosshairsTool extends AnnotationTool {
     const { renderingEngine, viewport } = enabledElement;
     const annotations = getAnnotations(
       element,
-      CrosshairsTool.toolName
+      this.getToolName()
     ) as CrosshairsAnnotation[];
     const filteredToolAnnotations =
       this.filterInteractableAnnotationsForElement(element, annotations);

--- a/packages/tools/src/tools/annotation/BidirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/BidirectionalTool.ts
@@ -2,10 +2,8 @@ import { vec2, vec3 } from 'gl-matrix';
 import {
   Settings,
   getEnabledElement,
-  StackViewport,
   triggerEvent,
   eventTarget,
-  cache,
   utilities as csUtils,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
@@ -155,7 +153,7 @@ export default class BidirectionalTool extends AnnotationTool {
       highlighted: true,
       invalidated: true,
       metadata: {
-        toolName: BidirectionalTool.toolName,
+        toolName: this.getToolName(),
         viewPlaneNormal: <Types.Point3>[...viewPlaneNormal],
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
@@ -195,7 +193,7 @@ export default class BidirectionalTool extends AnnotationTool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      BidirectionalTool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -310,7 +308,7 @@ export default class BidirectionalTool extends AnnotationTool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      BidirectionalTool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -364,7 +362,7 @@ export default class BidirectionalTool extends AnnotationTool {
     // Find viewports to render on drag.
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      BidirectionalTool.toolName
+      this.getToolName()
     );
 
     hideElementCursor(element);
@@ -938,10 +936,7 @@ export default class BidirectionalTool extends AnnotationTool {
   ): void => {
     const { viewport } = enabledElement;
     const { element } = viewport;
-    let annotations = getAnnotations(
-      viewport.element,
-      BidirectionalTool.toolName
-    );
+    let annotations = getAnnotations(viewport.element, this.getToolName());
 
     if (!annotations?.length) {
       return;
@@ -1011,7 +1006,7 @@ export default class BidirectionalTool extends AnnotationTool {
 
         drawHandlesSvg(
           svgDrawingHelper,
-          BidirectionalTool.toolName,
+          this.getToolName(),
           annotationUID,
           handleGroupUID,
           activeHandleCanvasCoords,
@@ -1024,7 +1019,7 @@ export default class BidirectionalTool extends AnnotationTool {
       const lineUID = '0';
       drawLineSvg(
         svgDrawingHelper,
-        BidirectionalTool.toolName,
+        this.getToolName(),
         annotationUID,
         lineUID,
         canvasCoordinates[0],
@@ -1039,7 +1034,7 @@ export default class BidirectionalTool extends AnnotationTool {
       const secondLineUID = '1';
       drawLineSvg(
         svgDrawingHelper,
-        BidirectionalTool.toolName,
+        this.getToolName(),
         annotationUID,
         secondLineUID,
         canvasCoordinates[2],
@@ -1072,7 +1067,7 @@ export default class BidirectionalTool extends AnnotationTool {
       const textBoxUID = '1';
       const boundingBox = drawLinkedTextBoxSvg(
         svgDrawingHelper,
-        BidirectionalTool.toolName,
+        this.getToolName(),
         annotationUID,
         textBoxUID,
         textLines,

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -3,11 +3,9 @@ import { AnnotationTool } from '../base';
 import {
   getEnabledElement,
   Settings,
-  StackViewport,
   VolumeViewport,
   eventTarget,
   triggerEvent,
-  cache,
   utilities as csUtils,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
@@ -169,7 +167,7 @@ export default class EllipticalROITool extends AnnotationTool {
       highlighted: true,
       invalidated: true,
       metadata: {
-        toolName: EllipticalROITool.toolName,
+        toolName: this.getToolName(),
         viewPlaneNormal: <Types.Point3>[...viewPlaneNormal],
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
@@ -207,7 +205,7 @@ export default class EllipticalROITool extends AnnotationTool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      EllipticalROITool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -305,7 +303,7 @@ export default class EllipticalROITool extends AnnotationTool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      EllipticalROITool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -371,7 +369,7 @@ export default class EllipticalROITool extends AnnotationTool {
     // Find viewports to render on drag.
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      EllipticalROITool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -692,7 +690,7 @@ export default class EllipticalROITool extends AnnotationTool {
     const { viewport } = enabledElement;
     const { element } = viewport;
 
-    let annotations = getAnnotations(element, EllipticalROITool.toolName);
+    let annotations = getAnnotations(element, this.getToolName());
 
     if (!annotations?.length) {
       return;
@@ -812,7 +810,7 @@ export default class EllipticalROITool extends AnnotationTool {
         const handleGroupUID = '0';
         drawHandlesSvg(
           svgDrawingHelper,
-          EllipticalROITool.toolName,
+          this.getToolName(),
           annotationUID,
           handleGroupUID,
           activeHandleCanvasCoords,
@@ -825,7 +823,7 @@ export default class EllipticalROITool extends AnnotationTool {
       const ellipseUID = '0';
       drawEllipseSvg(
         svgDrawingHelper,
-        EllipticalROITool.toolName,
+        this.getToolName(),
         annotationUID,
         ellipseUID,
         canvasCorners[0],
@@ -859,7 +857,7 @@ export default class EllipticalROITool extends AnnotationTool {
       const textBoxUID = '1';
       const boundingBox = drawLinkedTextBoxSvg(
         svgDrawingHelper,
-        EllipticalROITool.toolName,
+        this.getToolName(),
         annotationUID,
         textBoxUID,
         textLines,

--- a/packages/tools/src/tools/annotation/LengthTool.ts
+++ b/packages/tools/src/tools/annotation/LengthTool.ts
@@ -1,8 +1,6 @@
 import { Events } from '../../enums';
 import {
   getEnabledElement,
-  cache,
-  StackViewport,
   Settings,
   triggerEvent,
   eventTarget,
@@ -153,7 +151,7 @@ class LengthTool extends AnnotationTool {
       highlighted: true,
       invalidated: true,
       metadata: {
-        toolName: LengthTool.toolName,
+        toolName: this.getToolName(),
         viewPlaneNormal: <Types.Point3>[...viewPlaneNormal],
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
@@ -186,7 +184,7 @@ class LengthTool extends AnnotationTool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      LengthTool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -266,7 +264,7 @@ class LengthTool extends AnnotationTool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      LengthTool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -311,7 +309,7 @@ class LengthTool extends AnnotationTool {
     // Find viewports to render on drag.
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      LengthTool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -513,7 +511,7 @@ class LengthTool extends AnnotationTool {
     const { viewport } = enabledElement;
     const { element } = viewport;
 
-    let annotations = getAnnotations(element, LengthTool.toolName);
+    let annotations = getAnnotations(element, this.getToolName());
 
     // Todo: We don't need this anymore, filtering happens in triggerAnnotationRender
     if (!annotations?.length) {
@@ -561,7 +559,7 @@ class LengthTool extends AnnotationTool {
 
         drawHandlesSvg(
           svgDrawingHelper,
-          LengthTool.toolName,
+          this.getToolName(),
           annotationUID,
           handleGroupUID,
           canvasCoordinates,
@@ -576,7 +574,7 @@ class LengthTool extends AnnotationTool {
       const lineUID = '1';
       drawLineSvg(
         svgDrawingHelper,
-        LengthTool.toolName,
+        this.getToolName(),
         annotationUID,
         lineUID,
         canvasCoordinates[0],
@@ -625,7 +623,7 @@ class LengthTool extends AnnotationTool {
       const textBoxUID = '1';
       const boundingBox = drawLinkedTextBoxSvg(
         svgDrawingHelper,
-        LengthTool.toolName,
+        this.getToolName(),
         annotationUID,
         textBoxUID,
         textLines,

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -4,8 +4,6 @@ import { vec2 } from 'gl-matrix';
 import {
   getEnabledElement,
   Settings,
-  cache,
-  StackViewport,
   VolumeViewport,
   triggerEvent,
   eventTarget,
@@ -154,7 +152,7 @@ export default class ProbeTool extends AnnotationTool {
       invalidated: true,
       highlighted: true,
       metadata: {
-        toolName: ProbeTool.toolName,
+        toolName: this.getToolName(),
         viewPlaneNormal: <Types.Point3>[...viewPlaneNormal],
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
@@ -174,7 +172,7 @@ export default class ProbeTool extends AnnotationTool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      ProbeTool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -238,7 +236,7 @@ export default class ProbeTool extends AnnotationTool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      ProbeTool.toolName
+      this.getToolName()
     );
 
     // Find viewports to render on drag.
@@ -377,7 +375,7 @@ export default class ProbeTool extends AnnotationTool {
     const { viewport } = enabledElement;
     const { element } = viewport;
 
-    let annotations = getAnnotations(element, ProbeTool.toolName);
+    let annotations = getAnnotations(element, this.getToolName());
 
     if (!annotations?.length) {
       return;
@@ -461,7 +459,7 @@ export default class ProbeTool extends AnnotationTool {
 
       drawHandlesSvg(
         svgDrawingHelper,
-        ProbeTool.toolName,
+        this.getToolName(),
         annotationUID,
         handleGroupUID,
         [canvasCoordinates],
@@ -478,7 +476,7 @@ export default class ProbeTool extends AnnotationTool {
         const textUID = '0';
         drawTextBoxSvg(
           svgDrawingHelper,
-          ProbeTool.toolName,
+          this.getToolName(),
           annotationUID,
           textUID,
           textLines,

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -2,9 +2,7 @@ import { AnnotationTool } from '../base';
 
 import {
   getEnabledElement,
-  cache,
   Settings,
-  StackViewport,
   VolumeViewport,
   triggerEvent,
   eventTarget,
@@ -69,15 +67,15 @@ const { transformWorldToIndex } = csUtils;
  * or similar methods.
  *
  * ```js
- * cornerstoneTools.addTool(RectangleROIAnnotation)
+ * cornerstoneTools.addTool(RectangleROITool)
  *
  * const toolGroup = ToolGroupManager.createToolGroup('toolGroupId')
  *
- * toolGroup.addTool(RectangleROIAnnotation.toolName)
+ * toolGroup.addTool(RectangleROITool.toolName)
  *
  * toolGroup.addViewport('viewportId', 'renderingEngineId')
  *
- * toolGroup.setToolActive(RectangleROIAnnotation.toolName, {
+ * toolGroup.setToolActive(RectangleROITool.toolName, {
  *   bindings: [
  *    {
  *       mouseButton: MouseBindings.Primary, // Left Click
@@ -156,7 +154,7 @@ export default class RectangleROITool extends AnnotationTool {
       invalidated: true,
       highlighted: true,
       metadata: {
-        toolName: RectangleROITool.toolName,
+        toolName: this.getToolName(),
         viewPlaneNormal: <Types.Point3>[...viewPlaneNormal],
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
@@ -194,7 +192,7 @@ export default class RectangleROITool extends AnnotationTool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      RectangleROITool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -274,7 +272,7 @@ export default class RectangleROITool extends AnnotationTool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      RectangleROITool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -319,7 +317,7 @@ export default class RectangleROITool extends AnnotationTool {
     // Find viewports to render on drag.
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      RectangleROITool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -590,7 +588,7 @@ export default class RectangleROITool extends AnnotationTool {
     const { viewport } = enabledElement;
     const { element } = viewport;
 
-    let annotations = getAnnotations(element, RectangleROITool.toolName);
+    let annotations = getAnnotations(element, this.getToolName());
 
     if (!annotations?.length) {
       return;
@@ -705,7 +703,7 @@ export default class RectangleROITool extends AnnotationTool {
 
         drawHandlesSvg(
           svgDrawingHelper,
-          RectangleROITool.toolName,
+          this.getToolName(),
           annotationUID,
           handleGroupUID,
           activeHandleCanvasCoords,
@@ -718,7 +716,7 @@ export default class RectangleROITool extends AnnotationTool {
       const rectangleUID = '0';
       drawRectSvg(
         svgDrawingHelper,
-        RectangleROITool.toolName,
+        this.getToolName(),
         annotationUID,
         rectangleUID,
         canvasCoordinates[0],
@@ -749,7 +747,7 @@ export default class RectangleROITool extends AnnotationTool {
       const textBoxUID = '1';
       const boundingBox = drawLinkedTextBoxSvg(
         svgDrawingHelper,
-        RectangleROITool.toolName,
+        this.getToolName(),
         annotationUID,
         textBoxUID,
         textLines,

--- a/packages/tools/src/tools/segmentation/BrushTool.ts
+++ b/packages/tools/src/tools/segmentation/BrushTool.ts
@@ -128,7 +128,7 @@ export default class BrushTool extends BaseTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
         referencedImageId: '',
-        toolName: BrushTool.toolName,
+        toolName: this.getToolName(),
         segmentColor,
       },
       data: {
@@ -241,7 +241,7 @@ export default class BrushTool extends BaseTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
         referencedImageId: '',
-        toolName: BrushTool.toolName,
+        toolName: this.getToolName(),
         segmentColor,
       },
       data: {
@@ -459,7 +459,7 @@ export default class BrushTool extends BaseTool {
     const circleUID = '0';
     drawCircleSvg(
       svgDrawingHelper,
-      BrushTool.toolName,
+      this.getToolName(),
       annotationUID,
       circleUID,
       center as Types.Point2,

--- a/packages/tools/src/tools/segmentation/CircleScissorsTool.ts
+++ b/packages/tools/src/tools/segmentation/CircleScissorsTool.ts
@@ -123,7 +123,7 @@ export default class CircleScissorsTool extends BaseTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
         referencedImageId: '',
-        toolName: CircleScissorsTool.toolName,
+        toolName: this.getToolName(),
         segmentColor,
       },
       data: {
@@ -342,7 +342,7 @@ export default class CircleScissorsTool extends BaseTool {
     const circleUID = '0';
     drawCircleSvg(
       svgDrawingHelper,
-      CircleScissorsTool.toolName,
+      this.getToolName(),
       annotationUID,
       circleUID,
       center as Types.Point2,

--- a/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
@@ -136,7 +136,7 @@ export default class RectangleROIStartEndThresholdTool extends RectangleROITool 
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
         referencedImageId,
-        toolName: RectangleROIStartEndThresholdTool.toolName,
+        toolName: this.getToolName(),
         volumeId,
         spacingInNormal,
       },
@@ -179,7 +179,7 @@ export default class RectangleROIStartEndThresholdTool extends RectangleROITool 
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      RectangleROIStartEndThresholdTool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -302,7 +302,7 @@ export default class RectangleROIStartEndThresholdTool extends RectangleROITool 
   ): void => {
     const annotations = getAnnotations(
       enabledElement.viewport.element,
-      RectangleROIStartEndThresholdTool.toolName
+      this.getToolName()
     );
 
     if (!annotations?.length) {
@@ -384,7 +384,7 @@ export default class RectangleROIStartEndThresholdTool extends RectangleROITool 
 
         drawHandlesSvg(
           svgDrawingHelper,
-          RectangleROIStartEndThresholdTool.toolName,
+          this.getToolName(),
           annotationUID,
           handleGroupUID,
           activeHandleCanvasCoords,
@@ -403,7 +403,7 @@ export default class RectangleROIStartEndThresholdTool extends RectangleROITool 
       const rectangleUID = '0';
       drawRectSvg(
         svgDrawingHelper,
-        RectangleROIStartEndThresholdTool.toolName,
+        this.getToolName(),
         annotationUID,
         rectangleUID,
         canvasCoordinates[0],

--- a/packages/tools/src/tools/segmentation/RectangleROIThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleROIThresholdTool.ts
@@ -106,7 +106,7 @@ export default class RectangleROIThresholdTool extends RectangleROITool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
         referencedImageId,
-        toolName: RectangleROIThresholdTool.toolName,
+        toolName: this.getToolName(),
         volumeId,
       },
       data: {
@@ -137,7 +137,7 @@ export default class RectangleROIThresholdTool extends RectangleROITool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      RectangleROIThresholdTool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -171,10 +171,7 @@ export default class RectangleROIThresholdTool extends RectangleROITool {
   ): void => {
     const { viewport, renderingEngineId } = enabledElement;
     const { element } = viewport;
-    let annotations = getAnnotations(
-      element,
-      RectangleROIThresholdTool.toolName
-    );
+    let annotations = getAnnotations(element, this.getToolName());
 
     if (!annotations?.length) {
       return;
@@ -239,7 +236,7 @@ export default class RectangleROIThresholdTool extends RectangleROITool {
 
         drawHandlesSvg(
           svgDrawingHelper,
-          RectangleROIThresholdTool.toolName,
+          this.getToolName(),
           annotationUID,
           handleGroupUID,
           activeHandleCanvasCoords,
@@ -252,7 +249,7 @@ export default class RectangleROIThresholdTool extends RectangleROITool {
       const rectangleUID = '0';
       drawRectSvg(
         svgDrawingHelper,
-        RectangleROIThresholdTool.toolName,
+        this.getToolName(),
         annotationUID,
         rectangleUID,
         canvasCoordinates[0],

--- a/packages/tools/src/tools/segmentation/RectangleScissorsTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleScissorsTool.ts
@@ -132,7 +132,7 @@ export default class RectangleScissorsTool extends BaseTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
         referencedImageId: '',
-        toolName: RectangleScissorsTool.toolName,
+        toolName: this.getToolName(),
         segmentColor,
       },
       data: {
@@ -153,7 +153,7 @@ export default class RectangleScissorsTool extends BaseTool {
 
     const viewportIdsToRender = getViewportIdsWithToolToRender(
       element,
-      RectangleScissorsTool.toolName
+      this.getToolName()
     );
 
     this.editData = {
@@ -369,7 +369,7 @@ export default class RectangleScissorsTool extends BaseTool {
     const rectangleUID = '0';
     drawRectSvg(
       svgDrawingHelper,
-      RectangleScissorsTool.toolName,
+      this.getToolName(),
       annotationUID,
       rectangleUID,
       canvasCoordinates[0],

--- a/packages/tools/src/tools/segmentation/SphereScissorsTool.ts
+++ b/packages/tools/src/tools/segmentation/SphereScissorsTool.ts
@@ -124,7 +124,7 @@ export default class SphereScissorsTool extends BaseTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
         referencedImageId: '',
-        toolName: SphereScissorsTool.toolName,
+        toolName: this.getToolName(),
         segmentColor,
       },
       data: {
@@ -343,7 +343,7 @@ export default class SphereScissorsTool extends BaseTool {
     const circleUID = '0';
     drawCircleSvg(
       svgDrawingHelper,
-      SphereScissorsTool.toolName,
+      this.getToolName(),
       annotationUID,
       circleUID,
       center as Types.Point2,


### PR DESCRIPTION
- change the camera interface to include flipHorizontal and flipVertical
- move the rotation to the camera modified event detail
- remove the flipHorizontal and flipVertical properties from the setProperties and add it to the setCamera
- fix the CPU rendering for the non-scaled PT images 
- trigger camera modified for the setRotation and setFlip methods
- fix the tools to use the constructor toolName to avoid problem with inherited tools
- fix the windowLevel tool to work for non-scaled PT images