### PR TITLE
fix: rename ArrowTool to ArrowAnnotate

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -221,29 +221,7 @@ export abstract class AnnotationTool extends BaseTool {
 }
 
 // @public (undocumented)
-interface ArrowAnnotation extends Annotation {
-    // (undocumented)
-    data: {
-        text: string;
-        handles: {
-            points: Types_2.Point3[];
-            activeHandleIndex: number | null;
-            textBox: {
-                hasMoved: boolean;
-                worldPosition: Types_2.Point3;
-                worldBoundingBox: {
-                    topLeft: Types_2.Point3;
-                    topRight: Types_2.Point3;
-                    bottomLeft: Types_2.Point3;
-                    bottomRight: Types_2.Point3;
-                };
-            };
-        };
-    };
-}
-
-// @public (undocumented)
-export class ArrowTool extends AnnotationTool {
+export class ArrowAnnotateTool extends AnnotationTool {
     constructor(toolProps?: PublicToolProps, defaultToolProps?: ToolProps);
     // (undocumented)
     _activateDraw: (element: HTMLDivElement) => void;
@@ -294,6 +272,28 @@ export class ArrowTool extends AnnotationTool {
     toolSelectedCallback: (evt: EventTypes_2.MouseDownEventType, annotation: ArrowAnnotation, interactionType: InteractionTypes) => void;
     // (undocumented)
     touchDragCallback: any;
+}
+
+// @public (undocumented)
+interface ArrowAnnotation extends Annotation {
+    // (undocumented)
+    data: {
+        text: string;
+        handles: {
+            points: Types_2.Point3[];
+            activeHandleIndex: number | null;
+            textBox: {
+                hasMoved: boolean;
+                worldPosition: Types_2.Point3;
+                worldBoundingBox: {
+                    topLeft: Types_2.Point3;
+                    topRight: Types_2.Point3;
+                    bottomLeft: Types_2.Point3;
+                    bottomRight: Types_2.Point3;
+                };
+            };
+        };
+    };
 }
 
 // @public (undocumented)

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -35,7 +35,7 @@ import {
   EllipticalROITool,
   BidirectionalTool,
   PlanarFreehandROITool,
-  ArrowTool,
+  ArrowAnnotateTool,
   CrosshairsTool,
   RectangleScissorsTool,
   CircleScissorsTool,
@@ -74,7 +74,7 @@ export {
   EllipticalROITool,
   BidirectionalTool,
   PlanarFreehandROITool,
-  ArrowTool,
+  ArrowAnnotateTool,
   // Segmentation Display
   SegmentationDisplayTool,
   // Segmentation Editing Tools

--- a/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
+++ b/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
@@ -43,8 +43,8 @@ import {
 } from '../../types';
 import { ArrowAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 
-class ArrowTool extends AnnotationTool {
-  static toolName = 'Arrow';
+class ArrowAnnotateTool extends AnnotationTool {
+  static toolName = 'ArrowAnnotate';
 
   public touchDragCallback: any;
   public mouseDragCallback: any;
@@ -137,7 +137,7 @@ class ArrowTool extends AnnotationTool {
     };
 
     // Ensure settings are initialized after annotation instantiation
-    Settings.getObjectSettings(annotation, ArrowTool);
+    Settings.getObjectSettings(annotation, ArrowAnnotateTool);
 
     addAnnotation(element, annotation);
 
@@ -573,7 +573,10 @@ class ArrowTool extends AnnotationTool {
     // Draw SVG
     for (let i = 0; i < annotations.length; i++) {
       const annotation = annotations[i] as ArrowAnnotation;
-      const settings = Settings.getObjectSettings(annotation, ArrowTool);
+      const settings = Settings.getObjectSettings(
+        annotation,
+        ArrowAnnotateTool
+      );
       const { annotationUID, data } = annotation;
       const { handles, text } = data;
       const { points, activeHandleIndex } = handles;
@@ -690,4 +693,4 @@ class ArrowTool extends AnnotationTool {
   }
 }
 
-export default ArrowTool;
+export default ArrowAnnotateTool;

--- a/packages/tools/src/tools/index.ts
+++ b/packages/tools/src/tools/index.ts
@@ -14,7 +14,7 @@ import ProbeTool from './annotation/ProbeTool';
 import RectangleROITool from './annotation/RectangleROITool';
 import EllipticalROITool from './annotation/EllipticalROITool';
 import PlanarFreehandROITool from './annotation/PlanarFreehandROITool';
-import ArrowTool from './annotation/ArrowTool';
+import ArrowAnnotateTool from './annotation/ArrowAnnotateTool';
 
 // Segmentation DisplayTool
 import SegmentationDisplayTool from './displayTools/SegmentationDisplayTool';
@@ -47,7 +47,7 @@ export {
   RectangleROITool,
   EllipticalROITool,
   PlanarFreehandROITool,
-  ArrowTool,
+  ArrowAnnotateTool,
   // Segmentations Display
   SegmentationDisplayTool,
   // Segmentations Tools


### PR DESCRIPTION
To be consistent with cornerstone tools legacy