### PR TITLE
fix: Attempt to resolve incompatible peerDeps situation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,6 @@
   },
   "peerDependencies": {
     "@kitware/vtk.js": "24.0.0",
-    "detect-gpu": "^4.0.7",
     "gl-matrix": "^3.4.3"
   },
   "dependencies": {

--- a/packages/streaming-image-volume-loader/package.json
+++ b/packages/streaming-image-volume-loader/package.json
@@ -24,11 +24,11 @@
     "example": "node ../../utils/ExampleRunner/example-runner-cli.js"
   },
   "dependencies": {
+    "@cornerstonejs/core": "^0.8.0",
     "cornerstone-wado-image-loader": "^4.1.2"
   },
   "peerDependencies": {
-    "@cornerstonejs/calculate-suv": "1.0.2",
-    "@cornerstonejs/core": "^0.4.3"
+    "@cornerstonejs/calculate-suv": "1.0.2"
   },
   "devDependencies": {
     "@cornerstonejs/calculate-suv": "1.0.2",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -24,12 +24,12 @@
     "example": "node ../../utils/ExampleRunner/example-runner-cli.js"
   },
   "dependencies": {
-    "lodash.clonedeep": "4.5.0"
+    "lodash.clonedeep": "4.5.0",
+    "@cornerstonejs/core": "^0.8.0"
   },
   "peerDependencies": {
-    "@cornerstonejs/core": "^0.3.0",
     "@kitware/vtk.js": "24.0.0",
-    "gl-matrix": "^3.3.0"
+    "gl-matrix": "^3.4.3"
   },
   "devDependencies": {
     "@cornerstonejs/core": "^0.8.0",


### PR DESCRIPTION
Attempts to address https://github.com/cornerstonejs/cornerstone3D-beta/issues/80

Basically Lerna won't update our peerDeps for us (see closed issue https://github.com/lerna/lerna/issues/1575) so I'm just moving everything to dependencies instead. I don't see a major downside of this.