### PR TITLE
Freehand: Prevent very small annotations from being drawn

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -567,6 +567,9 @@ export function cancelActiveManipulations(element: HTMLDivElement): string | und
 // @public (undocumented)
 function checkAndDefineIsLockedProperty(annotation: Annotation): void;
 
+// @public (undocumented)
+function checkAndDefineIsVisibleProperty(annotation: Annotation): void;
+
 declare namespace cine {
     export {
         playClip,
@@ -583,9 +586,6 @@ declare namespace CINETypes {
         ToolData
     }
 }
-
-// @public (undocumented)
-function checkAndDefineIsVisibleProperty(annotation: Annotation): void;
 
 // @public (undocumented)
 export class CircleScissorsTool extends BaseTool {

--- a/utils/ExampleRunner/example-info.json
+++ b/utils/ExampleRunner/example-info.json
@@ -114,6 +114,10 @@
         "name": "Segmentation Swapping",
         "description": "Demonstrate how to display segmentations on a volume viewport, and swap which segmentation is being displayed"
       },
+      "planarFreehandROITool": {
+        "name": "Freehand ROI Tool",
+        "description": "Demonstrates drawing of both open and closed freehand ROIs on stack and volume viewports"
+      },
       "globalSegmentationConfiguration": {
         "name": "Global Segmentation Configuration",
         "description": "Demonstrates how to set a global configuration for segmentation representations"


### PR DESCRIPTION
- This PR prevents very small annotations that may even be too small to render from being created.
- These annotations are removed on mouse up, and no annotation completed event is fired.
