### PR TITLE
Add the option to always render handles on open contours

### DIFF
--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -136,12 +136,13 @@ class PlanarFreehandROITool extends AnnotationTool {
       configuration: {
         shadow: true,
         preventHandleOutsideImage: false,
-        // When true, always render end points when you have an open contour, rather
-        // than just rendering a line.
-        allowsRenderOpenContourHandles: true,
-        // When `allowsRenderOpenContourHandles` is true, use this radius to draw
-        // the endpoints when not hovering.
-        alwaysRenderOpenContourHandlesRadius: 2,
+        alwaysRenderOpenContourHandles: {
+          // When true, always render end points when you have an open contour, rather
+          // than just rendering a line.
+          enabled: false,
+          // When enabled, use this radius to draw the endpoints whilst not hovering.
+          radius: 2,
+        },
         allowOpenContours: true,
         // Proximity in canvas coordinates used to join contours.
         closeContourProximity: 10,

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -136,6 +136,12 @@ class PlanarFreehandROITool extends AnnotationTool {
       configuration: {
         shadow: true,
         preventHandleOutsideImage: false,
+        // When true, always render end points when you have an open contour, rather
+        // than just rendering a line.
+        allowsRenderOpenContourHandles: true,
+        // When `allowsRenderOpenContourHandles` is true, use this radius to draw
+        // the endpoints when not hovering.
+        alwaysRenderOpenContourHandlesRadius: 2,
         allowOpenContours: true,
         // Proximity in canvas coordinates used to join contours.
         closeContourProximity: 10,

--- a/packages/tools/src/tools/annotation/planarFreehandROITool/renderMethods.ts
+++ b/packages/tools/src/tools/annotation/planarFreehandROITool/renderMethods.ts
@@ -147,8 +147,8 @@ function renderOpenContour(
 
   const activeHandleIndex = annotation.data.handles.activeHandleIndex;
 
-  if (this.configuration.allowsRenderOpenContourHandles === true) {
-    const radius = this.configuration.alwaysRenderOpenContourHandlesRadius;
+  if (this.configuration.alwaysRenderOpenContourHandles?.enabled === true) {
+    const radius = this.configuration.alwaysRenderOpenContourHandles.radius;
 
     // Draw highlighted points
     const handleGroupUID = '0';

--- a/packages/tools/src/tools/annotation/planarFreehandROITool/renderMethods.ts
+++ b/packages/tools/src/tools/annotation/planarFreehandROITool/renderMethods.ts
@@ -147,9 +147,42 @@ function renderOpenContour(
 
   const activeHandleIndex = annotation.data.handles.activeHandleIndex;
 
-  if (activeHandleIndex !== null) {
+  if (this.configuration.allowsRenderOpenContourHandles === true) {
+    const radius = this.configuration.alwaysRenderOpenContourHandlesRadius;
+
     // Draw highlighted points
     const handleGroupUID = '0';
+
+    // We already mapped all the points, so don't do the mapping again.
+    // The activeHandleIndex can only be one of two points.
+    const handlePoints = [
+      canvasPoints[0],
+      canvasPoints[canvasPoints.length - 1],
+    ];
+
+    // Don't render a hovered handle, as this will be rendered larger in
+    // the next block.
+    if (activeHandleIndex === 0) {
+      handlePoints.shift();
+    } else if (activeHandleIndex === 1) {
+      handlePoints.pop();
+    }
+
+    drawHandlesSvg(
+      svgDrawingHelper,
+      annotation.annotationUID,
+      handleGroupUID,
+      handlePoints,
+      {
+        color: options.color,
+        handleRadius: radius,
+      }
+    );
+  }
+
+  if (activeHandleIndex !== null) {
+    // Draw highlighted points
+    const handleGroupUID = '1';
 
     // We already mapped all the points, so don't do the mapping again.
     // The activeHandleIndex can only be one of two points.


### PR DESCRIPTION
Add optional configuration for the planar freehand roi tool:

- allowsRenderOpenContourHandles: boolean (default false)
    - When true, always render end points when you have an open contour, rather than just rendering a line.
- alwaysRenderOpenContourHandlesRadius: number (default 2)
    - When `allowsRenderOpenContourHandles` is true, use this radius to draw the endpoints when not hovering.