### PR TITLE
feat: remove unnecessary event firing for annotations

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1696,7 +1696,7 @@ export class StackViewport extends Viewport implements IStackViewport {
     // (undocumented)
     setImageIdIndex(imageIdIndex: number): Promise<string>;
     // (undocumented)
-    setProperties({ voiRange, invert, interpolationType, rotation, }?: StackViewportProperties): void;
+    setProperties({ voiRange, invert, interpolationType, rotation, suppressEvents, }?: StackViewportProperties): void;
     // (undocumented)
     setStack(imageIds: Array<string>, currentImageIdIndex?: number): Promise<string>;
     // (undocumented)
@@ -1724,6 +1724,7 @@ type StackViewportProperties = {
     invert?: boolean;
     interpolationType?: InterpolationType;
     rotation?: number;
+    suppressEvents?: boolean;
 };
 
 // @public (undocumented)

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -295,6 +295,8 @@ interface CPUFallbackTransform {
 // @public (undocumented)
 type CPUFallbackViewport = {
     scale?: number;
+    parallelScale?: number;
+    focalPoint?: number[];
     translation?: {
         x: number;
         y: number;
@@ -653,6 +655,8 @@ interface ICamera {
     parallelScale?: number;
     // (undocumented)
     position?: Point3;
+    // (undocumented)
+    scale?: number;
     // (undocumented)
     viewAngle?: number;
     // (undocumented)
@@ -1696,7 +1700,7 @@ export class StackViewport extends Viewport implements IStackViewport {
     // (undocumented)
     setImageIdIndex(imageIdIndex: number): Promise<string>;
     // (undocumented)
-    setProperties({ voiRange, invert, interpolationType, rotation, suppressEvents, }?: StackViewportProperties): void;
+    setProperties({ voiRange, invert, interpolationType, rotation, }?: StackViewportProperties, suppressEvents?: boolean): void;
     // (undocumented)
     setStack(imageIds: Array<string>, currentImageIdIndex?: number): Promise<string>;
     // (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1109,6 +1109,7 @@ type StackViewportProperties = {
     invert?: boolean;
     interpolationType?: InterpolationType;
     rotation?: number;
+    suppressEvents?: boolean;
 };
 
 // @public (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -263,6 +263,8 @@ interface CPUFallbackTransform {
 // @public (undocumented)
 type CPUFallbackViewport = {
     scale?: number;
+    parallelScale?: number;
+    focalPoint?: number[];
     translation?: {
         x: number;
         y: number;
@@ -503,6 +505,7 @@ interface ICamera {
     parallelProjection?: boolean;
     parallelScale?: number;
     position?: Point3;
+    scale?: number;
     viewAngle?: number;
     viewPlaneNormal?: Point3;
     viewUp?: Point3;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -140,7 +140,7 @@ export class AngleTool extends AnnotationTool {
     // (undocumented)
     _mouseUpCallback: (evt: EventTypes_2.MouseUpEventType | EventTypes_2.MouseClickEventType) => void;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -329,7 +329,7 @@ export abstract class AnnotationTool extends BaseTool {
     // (undocumented)
     onImageSpacingCalibrated: (evt: Types_2.EventTypes.ImageSpacingCalibratedEvent) => void;
     // (undocumented)
-    abstract renderAnnotation(enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any): any;
+    abstract renderAnnotation(enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper): any;
     // (undocumented)
     static toolName: string;
     // (undocumented)
@@ -391,7 +391,7 @@ export class ArrowAnnotateTool extends AnnotationTool {
     // (undocumented)
     _mouseUpCallback: (evt: EventTypes_2.MouseUpEventType | EventTypes_2.MouseClickEventType) => void;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -535,7 +535,7 @@ export class BidirectionalTool extends AnnotationTool {
     // (undocumented)
     preventHandleOutsideImage: boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -564,7 +564,7 @@ export class BrushTool extends BaseTool {
     // (undocumented)
     preMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => boolean;
     // (undocumented)
-    renderAnnotation(enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any): void;
+    renderAnnotation(enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper): void;
     // (undocumented)
     static toolName: string;
 }
@@ -647,7 +647,7 @@ export class CircleScissorsTool extends BaseTool {
     // (undocumented)
     preMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     static toolName: string;
 }
@@ -911,6 +911,8 @@ interface CPUFallbackTransform {
 // @public (undocumented)
 type CPUFallbackViewport = {
     scale?: number;
+    parallelScale?: number;
+    focalPoint?: number[];
     translation?: {
         x: number;
         y: number;
@@ -1085,7 +1087,7 @@ export class CrosshairsTool extends AnnotationTool {
     // (undocumented)
     _pointNearTool(element: any, annotation: any, canvasCoords: any, proximity: any): boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     setSlabThickness(viewport: any, slabThickness: any): void;
     // (undocumented)
@@ -1195,7 +1197,7 @@ export class DragProbeTool extends ProbeTool {
     // (undocumented)
     postMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => ProbeAnnotation;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     static toolName: string;
     // (undocumented)
@@ -1206,16 +1208,16 @@ export class DragProbeTool extends ProbeTool {
 function draw(element: HTMLDivElement, fn: (svgDrawingElement: any) => any): void;
 
 // @public (undocumented)
-function drawArrow(svgDrawingHelper: any, annotationUID: string, arrowUID: string, start: Types_2.Point2, end: Types_2.Point2, options?: {}): void;
+function drawArrow(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, arrowUID: string, start: Types_2.Point2, end: Types_2.Point2, options?: {}): void;
 
 // @public (undocumented)
-function drawCircle(svgDrawingHelper: any, annotationUID: string, circleUID: string, center: Types_2.Point2, radius: number, options?: {}): void;
+function drawCircle(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, circleUID: string, center: Types_2.Point2, radius: number, options?: {}): void;
 
 // @public (undocumented)
-function drawEllipse(svgDrawingHelper: any, annotationUID: string, ellipseUID: string, corner1: Types_2.Point2, corner2: Types_2.Point2, options?: {}): void;
+function drawEllipse(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, ellipseUID: string, corner1: Types_2.Point2, corner2: Types_2.Point2, options?: {}): void;
 
 // @public (undocumented)
-function drawHandles(svgDrawingHelper: any, annotationUID: string, handleGroupUID: string, handlePoints: Array<Types_2.Point2>, options?: {}): void;
+function drawHandles(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, handleGroupUID: string, handlePoints: Array<Types_2.Point2>, options?: {}): void;
 
 declare namespace drawing {
     export {
@@ -1240,13 +1242,13 @@ declare namespace drawing_2 {
 }
 
 // @public (undocumented)
-function drawLine(svgDrawingHelper: any, annotationUID: string, lineUID: string, start: Types_2.Point2, end: Types_2.Point2, options?: {}): void;
+function drawLine(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, lineUID: string, start: Types_2.Point2, end: Types_2.Point2, options?: {}): void;
 
 // @public (undocumented)
-function drawLinkedTextBox(svgDrawingHelper: Record<string, unknown>, annotationUID: string, textBoxUID: string, textLines: Array<string>, textBoxPosition: Types_2.Point2, annotationAnchorPoints: Array<Types_2.Point2>, textBox: unknown, options?: {}): SVGRect;
+function drawLinkedTextBox(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, textBoxUID: string, textLines: Array<string>, textBoxPosition: Types_2.Point2, annotationAnchorPoints: Array<Types_2.Point2>, textBox: unknown, options?: {}): SVGRect;
 
 // @public (undocumented)
-function drawPolyline(svgDrawingHelper: any, annotationUID: string, polylineUID: string, points: Types_2.Point2[], options: {
+function drawPolyline(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, polylineUID: string, points: Types_2.Point2[], options: {
     color?: string;
     width?: number;
     lineWidth?: number;
@@ -1255,10 +1257,10 @@ function drawPolyline(svgDrawingHelper: any, annotationUID: string, polylineUID:
 }): void;
 
 // @public (undocumented)
-function drawRect(svgDrawingHelper: any, annotationUID: string, rectangleUID: string, start: Types_2.Point2, end: Types_2.Point2, options?: {}): void;
+function drawRect(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, rectangleUID: string, start: Types_2.Point2, end: Types_2.Point2, options?: {}): void;
 
 // @public (undocumented)
-function drawTextBox(svgDrawingHelper: Record<string, unknown>, annotationUID: string, textUID: string, textLines: Array<string>, position: Types_2.Point2, options?: {}): SVGRect;
+function drawTextBox(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, textUID: string, textLines: Array<string>, position: Types_2.Point2, options?: {}): SVGRect;
 
 declare namespace elementCursor {
     export {
@@ -1374,7 +1376,7 @@ export class EllipticalROITool extends AnnotationTool {
     // (undocumented)
     _pointInEllipseCanvas(ellipse: any, location: Types_2.Point2): boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -1817,6 +1819,7 @@ interface ICamera {
     parallelProjection?: boolean;
     parallelScale?: number;
     position?: Point3;
+    scale?: number;
     viewAngle?: number;
     viewPlaneNormal?: Point3;
     viewUp?: Point3;
@@ -2554,7 +2557,7 @@ export class LengthTool extends AnnotationTool {
     // (undocumented)
     _mouseUpCallback: (evt: EventTypes_2.MouseUpEventType | EventTypes_2.MouseClickEventType) => void;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -2904,7 +2907,7 @@ export class PlanarFreehandROITool extends AnnotationTool {
     // (undocumented)
     mouseDragCallback: any;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -3044,7 +3047,7 @@ export class ProbeTool extends AnnotationTool {
     // (undocumented)
     _mouseUpCallback: (evt: EventTypes_2.MouseUpEventType | EventTypes_2.MouseClickEventType) => void;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     static toolName: string;
     // (undocumented)
@@ -3192,7 +3195,7 @@ export class RectangleROIStartEndThresholdTool extends RectangleROITool {
     // (undocumented)
     isHandleOutsideImage: boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -3267,7 +3270,7 @@ export class RectangleROIThresholdTool extends RectangleROITool {
     // (undocumented)
     isHandleOutsideImage: boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -3327,7 +3330,7 @@ export class RectangleROITool extends AnnotationTool {
     // (undocumented)
     _mouseUpCallback: (evt: EventTypes_2.MouseUpEventType | EventTypes_2.MouseClickEventType) => void;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -3374,7 +3377,7 @@ export class RectangleScissorsTool extends BaseTool {
     // (undocumented)
     preMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -3696,7 +3699,7 @@ export class SphereScissorsTool extends BaseTool {
     // (undocumented)
     preMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => true;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
     static toolName: string;
 }
@@ -3854,6 +3857,16 @@ type SVGCursorDescriptor = {
     viewBox: SVGPoint_2;
     mousePoint: SVGPoint_2;
     mousePointerGroupString: string;
+};
+
+// @public (undocumented)
+type SVGDrawingHelper = {
+    svgLayerElement: HTMLDivElement;
+    svgNodeCacheForCanvas: Record<string, unknown>;
+    getSvgNode: (cacheKey: string) => SVGGElement | undefined;
+    appendNode: (svgNode: SVGElement, cacheKey: string) => void;
+    setNodeTouched: (cacheKey: string) => void;
+    clearUntouched: () => void;
 };
 
 // @public (undocumented)
@@ -4145,7 +4158,8 @@ declare namespace Types {
         SVGPoint_2 as SVGPoint,
         ScrollOptions_2 as ScrollOptions,
         CINETypes,
-        BoundsIJK
+        BoundsIJK,
+        SVGDrawingHelper
     }
 }
 export { Types }
@@ -4367,20 +4381,11 @@ export class ZoomTool extends BaseTool {
     // (undocumented)
     _dragCallback(evt: EventTypes_2.MouseDragEventType): void;
     // (undocumented)
-    _dragParallelProjection: (evt: EventTypes_2.MouseDragEventType, camera: Types_2.ICamera) => void;
+    _dragParallelProjection: (evt: EventTypes_2.MouseDragEventType, viewport: Types_2.IStackViewport | Types_2.IVolumeViewport, camera: Types_2.ICamera) => void;
     // (undocumented)
-    _dragPerspectiveProjection: (evt: any, camera: any) => void;
-    // (undocumented)
-    _getCappedParallelScale: (viewport: Types_2.IStackViewport | Types_2.IVolumeViewport, parallelScale: number) => {
-        parallelScale: number;
-        thresholdExceeded: boolean;
-    };
+    _dragPerspectiveProjection: (evt: any, viewport: any, camera: any) => void;
     // (undocumented)
     initialMousePosWorld: Types_2.Point3;
-    // (undocumented)
-    maxZoomScale: number;
-    // (undocumented)
-    minZoomScale: number;
     // (undocumented)
     mouseDragCallback: () => void;
     // (undocumented)

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -140,7 +140,7 @@ export class AngleTool extends AnnotationTool {
     // (undocumented)
     _mouseUpCallback: (evt: EventTypes_2.MouseUpEventType | EventTypes_2.MouseClickEventType) => void;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -391,7 +391,7 @@ export class ArrowAnnotateTool extends AnnotationTool {
     // (undocumented)
     _mouseUpCallback: (evt: EventTypes_2.MouseUpEventType | EventTypes_2.MouseClickEventType) => void;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -535,7 +535,7 @@ export class BidirectionalTool extends AnnotationTool {
     // (undocumented)
     preventHandleOutsideImage: boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -647,7 +647,7 @@ export class CircleScissorsTool extends BaseTool {
     // (undocumented)
     preMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     static toolName: string;
 }
@@ -1085,7 +1085,7 @@ export class CrosshairsTool extends AnnotationTool {
     // (undocumented)
     _pointNearTool(element: any, annotation: any, canvasCoords: any, proximity: any): boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     setSlabThickness(viewport: any, slabThickness: any): void;
     // (undocumented)
@@ -1195,7 +1195,7 @@ export class DragProbeTool extends ProbeTool {
     // (undocumented)
     postMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => ProbeAnnotation;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     static toolName: string;
     // (undocumented)
@@ -1374,7 +1374,7 @@ export class EllipticalROITool extends AnnotationTool {
     // (undocumented)
     _pointInEllipseCanvas(ellipse: any, location: Types_2.Point2): boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -2554,7 +2554,7 @@ export class LengthTool extends AnnotationTool {
     // (undocumented)
     _mouseUpCallback: (evt: EventTypes_2.MouseUpEventType | EventTypes_2.MouseClickEventType) => void;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -2904,7 +2904,7 @@ export class PlanarFreehandROITool extends AnnotationTool {
     // (undocumented)
     mouseDragCallback: any;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -3044,7 +3044,7 @@ export class ProbeTool extends AnnotationTool {
     // (undocumented)
     _mouseUpCallback: (evt: EventTypes_2.MouseUpEventType | EventTypes_2.MouseClickEventType) => void;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     static toolName: string;
     // (undocumented)
@@ -3192,7 +3192,7 @@ export class RectangleROIStartEndThresholdTool extends RectangleROITool {
     // (undocumented)
     isHandleOutsideImage: boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -3267,7 +3267,7 @@ export class RectangleROIThresholdTool extends RectangleROITool {
     // (undocumented)
     isHandleOutsideImage: boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -3327,7 +3327,7 @@ export class RectangleROITool extends AnnotationTool {
     // (undocumented)
     _mouseUpCallback: (evt: EventTypes_2.MouseUpEventType | EventTypes_2.MouseClickEventType) => void;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -3374,7 +3374,7 @@ export class RectangleScissorsTool extends BaseTool {
     // (undocumented)
     preMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => boolean;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)
@@ -3696,7 +3696,7 @@ export class SphereScissorsTool extends BaseTool {
     // (undocumented)
     preMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => true;
     // (undocumented)
-    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => void;
+    renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: any) => boolean;
     // (undocumented)
     static toolName: string;
 }
@@ -3776,6 +3776,7 @@ type StackViewportProperties = {
     invert?: boolean;
     interpolationType?: InterpolationType;
     rotation?: number;
+    suppressEvents?: boolean;
 };
 
 // @public (undocumented)
@@ -4370,8 +4371,8 @@ export class ZoomTool extends BaseTool {
     // (undocumented)
     _dragPerspectiveProjection: (evt: any, camera: any) => void;
     // (undocumented)
-    _getCappedParallelScale: (viewport: any, parallelScale: any) => {
-        parallelScale: any;
+    _getCappedParallelScale: (viewport: Types_2.IStackViewport | Types_2.IVolumeViewport, parallelScale: number) => {
+        parallelScale: number;
         thresholdExceeded: boolean;
     };
     // (undocumented)

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -62,6 +62,7 @@ import {
 } from '../types/EventTypes';
 import getScalingParameters from '../utilities/getScalingParameters';
 import cache from '../cache';
+import correctShift from './helpers/cpuFallback/rendering/correctShift';
 
 const EPSILON = 1; // Slice Thickness
 
@@ -686,6 +687,8 @@ class StackViewport extends Viewport implements IStackViewport {
         viewPlaneNormal[2],
       ],
       viewUp: [viewUp[0], viewUp[1], viewUp[2]],
+      flipHorizontal: this.flipHorizontal,
+      flipVertical: this.flipVertical,
     };
   }
 
@@ -726,8 +729,13 @@ class StackViewport extends Viewport implements IStackViewport {
         vec2.fromValues(prevFocalPointPixel[0], prevFocalPointPixel[1])
       );
 
-      viewport.translation.x -= deltaPixel[0];
-      viewport.translation.y -= deltaPixel[1];
+      const shift = correctShift(
+        { x: deltaPixel[0], y: deltaPixel[1] },
+        viewport
+      );
+
+      viewport.translation.x -= shift.x;
+      viewport.translation.y -= shift.y;
     }
 
     if (parallelScale) {
@@ -749,7 +757,7 @@ class StackViewport extends Viewport implements IStackViewport {
       viewport.parallelScale = (clientHeight * rowPixelSpacing * 0.5) / scale;
     }
 
-    if (flipHorizontal || flipVertical) {
+    if (flipHorizontal !== undefined || flipVertical !== undefined) {
       this.setFlipCPU({ flipHorizontal, flipVertical });
     }
 

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -637,7 +637,7 @@ class StackViewport extends Viewport implements IStackViewport {
   }
 
   private getCameraCPU(): Partial<ICamera> {
-    const { metadata, viewport, image } = this._cpuFallbackEnabledElement;
+    const { metadata, viewport } = this._cpuFallbackEnabledElement;
     const { direction } = metadata;
 
     // focalPoint and position of CPU camera is just a placeholder since
@@ -665,15 +665,15 @@ class StackViewport extends Viewport implements IStackViewport {
       this.element.clientHeight / 2,
     ];
 
-    // Focal point is the center of the canvas in world coordinate by design
+    // Focal point is the center of the canvas in world coordinate by construction
     const canvasCenterWorld = this.canvasToWorld(canvasCenter);
 
     // parallel scale is half of the viewport height in the world units (mm)
 
-    const topLeftCanvas = this.canvasToWorld([0, 0]);
-    const bottomLeftCanvas = this.canvasToWorld([0, this.element.clientHeight]);
+    const topLeftWorld = this.canvasToWorld([0, 0]);
+    const bottomLeftWorld = this.canvasToWorld([0, this.element.clientHeight]);
 
-    const parallelScale = vec3.distance(topLeftCanvas, bottomLeftCanvas) / 2;
+    const parallelScale = vec3.distance(topLeftWorld, bottomLeftWorld) / 2;
 
     return {
       parallelProjection: true,

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -530,9 +530,9 @@ class StackViewport extends Viewport implements IStackViewport {
       invert,
       interpolationType,
       rotation,
-      suppressEvents,
-    }: StackViewportProperties = { suppressEvents: false }
-  ) {
+    }: StackViewportProperties = {},
+    suppressEvents = false
+  ): void {
     // if voi is not applied for the first time, run the setVOI function
     // which will apply the default voi
     if (typeof voiRange !== 'undefined' || !this.voiApplied) {
@@ -623,13 +623,16 @@ class StackViewport extends Viewport implements IStackViewport {
   }
 
   private _setPropertiesFromCache(): void {
-    this.setProperties({
-      voiRange: this.voiRange,
-      rotation: this.rotation,
-      interpolationType: this.interpolationType,
-      invert: this.invert,
-      suppressEvents: true,
-    });
+    const suppressEvents = true;
+    this.setProperties(
+      {
+        voiRange: this.voiRange,
+        rotation: this.rotation,
+        interpolationType: this.interpolationType,
+        invert: this.invert,
+      },
+      suppressEvents
+    );
   }
 
   private getCameraCPU(): Partial<ICamera> {

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -524,16 +524,19 @@ class StackViewport extends Viewport implements IStackViewport {
    * @param interpolationType - Changes the interpolation type (1:linear, 0: nearest)
    * @param rotation - image rotation in degrees
    */
-  public setProperties({
-    voiRange,
-    invert,
-    interpolationType,
-    rotation,
-  }: StackViewportProperties = {}): void {
+  public setProperties(
+    {
+      voiRange,
+      invert,
+      interpolationType,
+      rotation,
+      suppressEvents,
+    }: StackViewportProperties = { suppressEvents: false }
+  ) {
     // if voi is not applied for the first time, run the setVOI function
     // which will apply the default voi
     if (typeof voiRange !== 'undefined' || !this.voiApplied) {
-      this.setVOI(voiRange);
+      this.setVOI(voiRange, suppressEvents);
     }
 
     if (typeof invert !== 'undefined') {
@@ -625,6 +628,7 @@ class StackViewport extends Viewport implements IStackViewport {
       rotation: this.rotation,
       interpolationType: this.interpolationType,
       invert: this.invert,
+      suppressEvents: true,
     });
   }
 
@@ -742,13 +746,13 @@ class StackViewport extends Viewport implements IStackViewport {
     this.flipVertical = viewport.vflip;
   }
 
-  private setVOI(voiRange: VOIRange): void {
+  private setVOI(voiRange: VOIRange, suppressEvents?: boolean): void {
     if (this.useCPURendering) {
-      this.setVOICPU(voiRange);
+      this.setVOICPU(voiRange, suppressEvents);
       return;
     }
 
-    this.setVOIGPU(voiRange);
+    this.setVOIGPU(voiRange, suppressEvents);
   }
 
   private setRotation(rotationCache: number, rotation: number): void {
@@ -873,7 +877,7 @@ class StackViewport extends Viewport implements IStackViewport {
     this.invert = invert;
   }
 
-  private setVOICPU(voiRange: VOIRange): void {
+  private setVOICPU(voiRange: VOIRange, suppressEvents?: boolean): void {
     const { viewport, image } = this._cpuFallbackEnabledElement;
 
     if (!viewport || !image) {
@@ -917,10 +921,12 @@ class StackViewport extends Viewport implements IStackViewport {
       range: voiRange,
     };
 
-    triggerEvent(this.element, Events.VOI_MODIFIED, eventDetail);
+    if (!suppressEvents) {
+      triggerEvent(this.element, Events.VOI_MODIFIED, eventDetail);
+    }
   }
 
-  private setVOIGPU(voiRange: VOIRange): void {
+  private setVOIGPU(voiRange: VOIRange, suppressEvents?: boolean): void {
     const defaultActor = this.getDefaultActor();
     if (!defaultActor) {
       return;
@@ -951,7 +957,9 @@ class StackViewport extends Viewport implements IStackViewport {
       range: voiRange,
     };
 
-    triggerEvent(this.element, Events.VOI_MODIFIED, eventDetail);
+    if (!suppressEvents) {
+      triggerEvent(this.element, Events.VOI_MODIFIED, eventDetail);
+    }
   }
 
   /**

--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/drawImageSync.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/drawImageSync.ts
@@ -15,7 +15,6 @@ export default function (
   invalidated: boolean
 ): void {
   const image = enabledElement.image;
-  const canvas = enabledElement.canvas;
 
   // Check if enabledElement can be redrawn
   if (!enabledElement.canvas || !enabledElement.image) {

--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/correctShift.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/correctShift.ts
@@ -1,0 +1,38 @@
+import { CPUFallbackViewport, Point2 } from '../../../../types';
+
+type Shift = {
+  x: number;
+  y: number;
+};
+/**
+ * Corrects the shift by accounting for viewport rotation and flips.
+ *
+ * @param shift - The shift to correct.
+ * @param viewportOrientation - Object containing information on the viewport orientation.
+ */
+export default function (
+  shift: Shift,
+  viewportOrientation: CPUFallbackViewport
+): Shift {
+  const { hflip, vflip, rotation } = viewportOrientation;
+
+  // Apply Flips
+  shift.x *= hflip ? -1 : 1;
+  shift.y *= vflip ? -1 : 1;
+
+  // Apply rotations
+  if (rotation !== 0) {
+    const angle = (rotation * Math.PI) / 180;
+
+    const cosA = Math.cos(angle);
+    const sinA = Math.sin(angle);
+
+    const newX = shift.x * cosA - shift.y * sinA;
+    const newY = shift.x * sinA + shift.y * cosA;
+
+    shift.x = newX;
+    shift.y = newY;
+  }
+
+  return shift;
+}

--- a/packages/core/src/RenderingEngine/helpers/createVolumeActor.ts
+++ b/packages/core/src/RenderingEngine/helpers/createVolumeActor.ts
@@ -11,7 +11,7 @@ import setDefaultVolumeVOI from './setDefaultVolumeVOI';
 
 interface createVolumeActorInterface {
   volumeId: string;
-  callback?: ({ volumeActor: any, volumeId: string }) => void;
+  callback?: ({ volumeActor: VolumeActor, volumeId: string }) => void;
   blendMode?: BlendModes;
 }
 

--- a/packages/core/src/metaData.ts
+++ b/packages/core/src/metaData.ts
@@ -70,7 +70,7 @@ export function removeAllProviders(): void {
  * @returns The metadata retrieved from the metadata store
  * @category MetaData
  */
-function getMetaData(type: string, imageId: string): unknown {
+function getMetaData(type: string, imageId: string): any {
   // Invoke each provider in priority order until one returns something
   for (let i = 0; i < providers.length; i++) {
     const result = providers[i].provider(type, imageId);

--- a/packages/core/src/metaData.ts
+++ b/packages/core/src/metaData.ts
@@ -70,7 +70,7 @@ export function removeAllProviders(): void {
  * @returns The metadata retrieved from the metadata store
  * @category MetaData
  */
-function getMetaData(type: string, imageId: string): any {
+function getMetaData(type: string, imageId: string): unknown {
   // Invoke each provider in priority order until one returns something
   for (let i = 0; i < providers.length; i++) {
     const result = providers[i].provider(type, imageId);

--- a/packages/core/src/types/CPUFallbackViewport.ts
+++ b/packages/core/src/types/CPUFallbackViewport.ts
@@ -4,6 +4,8 @@ import CPUFallbackLUT from './CPUFallbackLUT';
 
 type CPUFallbackViewport = {
   scale?: number;
+  parallelScale?: number;
+  focalPoint?: number[];
   translation?: {
     x: number;
     y: number;

--- a/packages/core/src/types/ICamera.ts
+++ b/packages/core/src/types/ICamera.ts
@@ -1,4 +1,3 @@
-import Point2 from './Point2';
 import Point3 from './Point3';
 
 /**
@@ -12,6 +11,11 @@ interface ICamera {
   parallelProjection?: boolean;
   /** Camera parallel scale - used for parallel projection zoom, smaller values zoom in */
   parallelScale?: number;
+  /**
+   * Scale factor for the camera, it is the ratio of how much an image pixel takes
+   * up one screen pixel
+   */
+  scale?: number;
   /** Camera position */
   position?: Point3;
   /** Camera view angle - 90 degrees is orthographic */

--- a/packages/core/src/types/StackViewportProperties.ts
+++ b/packages/core/src/types/StackViewportProperties.ts
@@ -13,6 +13,8 @@ type StackViewportProperties = {
   interpolationType?: InterpolationType;
   /** image rotation */
   rotation?: number;
+  /** suppress events (optional) */
+  suppressEvents?: boolean;
 };
 
 export default StackViewportProperties;

--- a/packages/streaming-image-volume-loader/src/helpers/autoLoad.ts
+++ b/packages/streaming-image-volume-loader/src/helpers/autoLoad.ts
@@ -1,9 +1,10 @@
 import { getRenderingEngines, utilities } from '@cornerstonejs/core';
+import type { Types } from '@cornerstonejs/core';
 
 //import type { Types } from '@cornerstonejs/core'
 
 type RenderingEngineAndViewportIds = {
-  renderingEngine: any | undefined; //Types.IRenderingEngine | undefined
+  renderingEngine: Types.IRenderingEngine | undefined; //Types.IRenderingEngine | undefined
   viewportIds: Array<string>;
 };
 

--- a/packages/tools/examples/stackAnnotationTools/index.ts
+++ b/packages/tools/examples/stackAnnotationTools/index.ts
@@ -20,6 +20,7 @@ const {
   BidirectionalTool,
   AngleTool,
   ToolGroupManager,
+  ArrowAnnotateTool,
   Enums: csToolsEnums,
 } = cornerstoneTools;
 
@@ -59,6 +60,7 @@ const toolsNames = [
   EllipticalROITool.toolName,
   BidirectionalTool.toolName,
   AngleTool.toolName,
+  ArrowAnnotateTool.toolName,
 ];
 let selectedToolName = toolsNames[0];
 
@@ -98,6 +100,7 @@ async function run() {
   cornerstoneTools.addTool(EllipticalROITool);
   cornerstoneTools.addTool(BidirectionalTool);
   cornerstoneTools.addTool(AngleTool);
+  cornerstoneTools.addTool(ArrowAnnotateTool);
 
   // Define a tool group, which defines how mouse events map to tool commands for
   // Any viewport using the group
@@ -110,6 +113,7 @@ async function run() {
   toolGroup.addTool(EllipticalROITool.toolName);
   toolGroup.addTool(BidirectionalTool.toolName);
   toolGroup.addTool(AngleTool.toolName);
+  toolGroup.addTool(ArrowAnnotateTool.toolName);
 
   // Set the initial state of the tools, here we set one tool active on left click.
   // This means left click will draw that tool.
@@ -127,6 +131,7 @@ async function run() {
   toolGroup.setToolPassive(EllipticalROITool.toolName);
   toolGroup.setToolPassive(BidirectionalTool.toolName);
   toolGroup.setToolPassive(AngleTool.toolName);
+  toolGroup.setToolPassive(ArrowAnnotateTool.toolName);
 
   // Get Cornerstone imageIds and fetch metadata into RAM
   const imageIds = await createImageIdsAndCacheMetaData({

--- a/packages/tools/src/drawingSvg/clearByToolType.ts
+++ b/packages/tools/src/drawingSvg/clearByToolType.ts
@@ -8,7 +8,7 @@ import getSvgDrawingHelper from './getSvgDrawingHelper';
  */
 function clearByToolType(element: HTMLDivElement, toolType: string): void {
   const svgDrawingHelper = getSvgDrawingHelper(element);
-  const nodes = svgDrawingHelper._svgLayerElement.querySelectorAll(
+  const nodes = svgDrawingHelper.svgLayerElement.querySelectorAll(
     'svg > *'
   ) as NodeListOf<SVGElement>;
 
@@ -18,7 +18,7 @@ function clearByToolType(element: HTMLDivElement, toolType: string): void {
     const toolUID = node.dataset.toolUid;
 
     if (toolUID === toolType) {
-      svgDrawingHelper._svgLayerElement.removeChild(node);
+      svgDrawingHelper.svgLayerElement.removeChild(node);
     }
   }
 }

--- a/packages/tools/src/drawingSvg/draw.ts
+++ b/packages/tools/src/drawingSvg/draw.ts
@@ -10,7 +10,7 @@ function draw(
   fn(svgDrawingHelper);
   // Restore...
 
-  svgDrawingHelper._clearUntouched();
+  svgDrawingHelper.clearUntouched();
 }
 
 export default draw;

--- a/packages/tools/src/drawingSvg/drawArrow.ts
+++ b/packages/tools/src/drawingSvg/drawArrow.ts
@@ -1,8 +1,9 @@
 import type { Types } from '@cornerstonejs/core';
+import { SVGDrawingHelper } from '../types';
 import drawLine from './drawLine';
 
 export default function drawArrow(
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   arrowUID: string,
   start: Types.Point2,

--- a/packages/tools/src/drawingSvg/drawCircle.ts
+++ b/packages/tools/src/drawingSvg/drawCircle.ts
@@ -1,4 +1,5 @@
 import type { Types } from '@cornerstonejs/core';
+import { SVGDrawingHelper } from '../types';
 
 import _getHash from './_getHash';
 
@@ -6,7 +7,7 @@ import _setAttributesIfNecessary from './_setAttributesIfNecessary';
 import _setNewAttributesIfValid from './_setNewAttributesIfValid';
 
 function drawCircle(
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   circleUID: string,
   center: Types.Point2,
@@ -29,7 +30,7 @@ function drawCircle(
   // variable for the namespace
   const svgns = 'http://www.w3.org/2000/svg';
   const svgNodeHash = _getHash(annotationUID, 'circle', circleUID);
-  const existingCircleElement = svgDrawingHelper._getSvgNode(svgNodeHash);
+  const existingCircleElement = svgDrawingHelper.getSvgNode(svgNodeHash);
 
   const attributes = {
     cx: `${center[0]}`,
@@ -43,13 +44,13 @@ function drawCircle(
   if (existingCircleElement) {
     _setAttributesIfNecessary(attributes, existingCircleElement);
 
-    svgDrawingHelper._setNodeTouched(svgNodeHash);
+    svgDrawingHelper.setNodeTouched(svgNodeHash);
   } else {
     const newCircleElement = document.createElementNS(svgns, 'circle');
 
     _setNewAttributesIfValid(attributes, newCircleElement);
 
-    svgDrawingHelper._appendNode(newCircleElement, svgNodeHash);
+    svgDrawingHelper.appendNode(newCircleElement, svgNodeHash);
   }
 }
 

--- a/packages/tools/src/drawingSvg/drawEllipse.ts
+++ b/packages/tools/src/drawingSvg/drawEllipse.ts
@@ -1,11 +1,12 @@
 import type { Types } from '@cornerstonejs/core';
+import { SVGDrawingHelper } from '../types';
 
 import _getHash from './_getHash';
 import _setAttributesIfNecessary from './_setAttributesIfNecessary';
 import _setNewAttributesIfValid from './_setNewAttributesIfValid';
 
 function drawEllipse(
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   ellipseUID: string,
   corner1: Types.Point2,
@@ -27,7 +28,7 @@ function drawEllipse(
 
   const svgns = 'http://www.w3.org/2000/svg';
   const svgNodeHash = _getHash(annotationUID, 'ellipse', ellipseUID);
-  const existingEllipse = svgDrawingHelper._getSvgNode(svgNodeHash);
+  const existingEllipse = svgDrawingHelper.getSvgNode(svgNodeHash);
 
   const w = Math.abs(corner1[0] - corner2[0]);
   const h = Math.abs(corner1[1] - corner2[1]);
@@ -52,13 +53,13 @@ function drawEllipse(
   if (existingEllipse) {
     _setAttributesIfNecessary(attributes, existingEllipse);
 
-    svgDrawingHelper._setNodeTouched(svgNodeHash);
+    svgDrawingHelper.setNodeTouched(svgNodeHash);
   } else {
     const svgEllipseElement = document.createElementNS(svgns, 'ellipse');
 
     _setNewAttributesIfValid(attributes, svgEllipseElement);
 
-    svgDrawingHelper._appendNode(svgEllipseElement, svgNodeHash);
+    svgDrawingHelper.appendNode(svgEllipseElement, svgNodeHash);
   }
 }
 

--- a/packages/tools/src/drawingSvg/drawHandles.ts
+++ b/packages/tools/src/drawingSvg/drawHandles.ts
@@ -3,9 +3,10 @@ import type { Types } from '@cornerstonejs/core';
 import _getHash from './_getHash';
 import _setNewAttributesIfValid from './_setNewAttributesIfValid';
 import _setAttributesIfNecessary from './_setAttributesIfNecessary';
+import { SVGDrawingHelper } from '../types';
 
 function drawHandles(
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   handleGroupUID: string,
   handlePoints: Array<Types.Point2>,
@@ -67,18 +68,18 @@ function drawHandles(
       throw new Error(`Unsupported handle type: ${type}`);
     }
 
-    const existingHandleElement = svgDrawingHelper._getSvgNode(svgNodeHash);
+    const existingHandleElement = svgDrawingHelper.getSvgNode(svgNodeHash);
 
     if (existingHandleElement) {
       _setAttributesIfNecessary(attributes, existingHandleElement);
 
-      svgDrawingHelper._setNodeTouched(svgNodeHash);
+      svgDrawingHelper.setNodeTouched(svgNodeHash);
     } else {
       const newHandleElement = document.createElementNS(svgns, type);
 
       _setNewAttributesIfValid(attributes, newHandleElement);
 
-      svgDrawingHelper._appendNode(newHandleElement, svgNodeHash);
+      svgDrawingHelper.appendNode(newHandleElement, svgNodeHash);
     }
   }
 }

--- a/packages/tools/src/drawingSvg/drawLine.ts
+++ b/packages/tools/src/drawingSvg/drawLine.ts
@@ -3,9 +3,10 @@ import type { Types } from '@cornerstonejs/core';
 import _getHash from './_getHash';
 import _setNewAttributesIfValid from './_setNewAttributesIfValid';
 import _setAttributesIfNecessary from './_setAttributesIfNecessary';
+import { SVGDrawingHelper } from '../types';
 
 export default function drawLine(
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   lineUID: string,
   start: Types.Point2,
@@ -32,7 +33,7 @@ export default function drawLine(
 
   const svgns = 'http://www.w3.org/2000/svg';
   const svgNodeHash = _getHash(annotationUID, 'line', lineUID);
-  const existingLine = svgDrawingHelper._getSvgNode(svgNodeHash);
+  const existingLine = svgDrawingHelper.getSvgNode(svgNodeHash);
 
   const attributes = {
     x1: `${start[0]}`,
@@ -48,12 +49,12 @@ export default function drawLine(
     // This is run to avoid re-rendering annotations that actually haven't changed
     _setAttributesIfNecessary(attributes, existingLine);
 
-    svgDrawingHelper._setNodeTouched(svgNodeHash);
+    svgDrawingHelper.setNodeTouched(svgNodeHash);
   } else {
     const newLine = document.createElementNS(svgns, 'line');
 
     _setNewAttributesIfValid(attributes, newLine);
 
-    svgDrawingHelper._appendNode(newLine, svgNodeHash);
+    svgDrawingHelper.appendNode(newLine, svgNodeHash);
   }
 }

--- a/packages/tools/src/drawingSvg/drawLink.ts
+++ b/packages/tools/src/drawingSvg/drawLink.ts
@@ -2,13 +2,13 @@ import type { Types } from '@cornerstonejs/core';
 
 import drawLine from './drawLine';
 import findClosestPoint from '../utilities/math/vec2/findClosestPoint';
-import { PlanarBoundingBox } from '../types';
+import { PlanarBoundingBox, SVGDrawingHelper } from '../types';
 
 /**
  * Draw a link between an annotation to a box.
  */
 function drawLink(
-  svgDrawingHelper: Record<string, unknown>,
+  svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   linkUID: string,
   // Find closest point to approx. bounding box

--- a/packages/tools/src/drawingSvg/drawLinkedTextBox.ts
+++ b/packages/tools/src/drawingSvg/drawLinkedTextBox.ts
@@ -2,9 +2,10 @@ import type { Types } from '@cornerstonejs/core';
 
 import drawTextBox from './drawTextBox';
 import drawLink from './drawLink';
+import { SVGDrawingHelper } from '../types';
 
 function drawLinkedTextBox(
-  svgDrawingHelper: Record<string, unknown>,
+  svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   textBoxUID: string,
   //

--- a/packages/tools/src/drawingSvg/drawPolyline.ts
+++ b/packages/tools/src/drawingSvg/drawPolyline.ts
@@ -2,6 +2,7 @@ import type { Types } from '@cornerstonejs/core';
 import _getHash from './_getHash';
 import _setNewAttributesIfValid from './_setNewAttributesIfValid';
 import _setAttributesIfNecessary from './_setAttributesIfNecessary';
+import { SVGDrawingHelper } from '../types';
 
 /**
  * Draws an SVG polyline with the given points.
@@ -10,7 +11,7 @@ import _setAttributesIfNecessary from './_setAttributesIfNecessary';
  * last point connected to the first.
  */
 export default function drawPolyline(
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   polylineUID: string,
   points: Types.Point2[],
@@ -42,7 +43,7 @@ export default function drawPolyline(
 
   const svgns = 'http://www.w3.org/2000/svg';
   const svgNodeHash = _getHash(annotationUID, 'polyline', polylineUID);
-  const existingPolyLine = svgDrawingHelper._getSvgNode(svgNodeHash);
+  const existingPolyLine = svgDrawingHelper.getSvgNode(svgNodeHash);
 
   let pointsAttribute = '';
 
@@ -68,12 +69,12 @@ export default function drawPolyline(
     // This is run to avoid re-rendering annotations that actually haven't changed
     _setAttributesIfNecessary(attributes, existingPolyLine);
 
-    svgDrawingHelper._setNodeTouched(svgNodeHash);
+    svgDrawingHelper.setNodeTouched(svgNodeHash);
   } else {
     const newPolyLine = document.createElementNS(svgns, 'polyline');
 
     _setNewAttributesIfValid(attributes, newPolyLine);
 
-    svgDrawingHelper._appendNode(newPolyLine, svgNodeHash);
+    svgDrawingHelper.appendNode(newPolyLine, svgNodeHash);
   }
 }

--- a/packages/tools/src/drawingSvg/drawRect.ts
+++ b/packages/tools/src/drawingSvg/drawRect.ts
@@ -3,10 +3,11 @@ import type { Types } from '@cornerstonejs/core';
 import _getHash from './_getHash';
 import _setAttributesIfNecessary from './_setAttributesIfNecessary';
 import _setNewAttributesIfValid from './_setNewAttributesIfValid';
+import { SVGDrawingHelper } from '../types';
 
 // <rect x="120" y="100" width="100" height="100" />
 export default function drawRect(
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   rectangleUID: string,
   start: Types.Point2,
@@ -33,7 +34,7 @@ export default function drawRect(
 
   const svgns = 'http://www.w3.org/2000/svg';
   const svgNodeHash = _getHash(annotationUID, 'rect', rectangleUID);
-  const existingRect = svgDrawingHelper._getSvgNode(svgNodeHash);
+  const existingRect = svgDrawingHelper.getSvgNode(svgNodeHash);
 
   const tlhc = [Math.min(start[0], end[0]), Math.min(start[1], end[1])];
   const width = Math.abs(start[0] - end[0]);
@@ -53,12 +54,12 @@ export default function drawRect(
   if (existingRect) {
     _setAttributesIfNecessary(attributes, existingRect);
 
-    svgDrawingHelper._setNodeTouched(svgNodeHash);
+    svgDrawingHelper.setNodeTouched(svgNodeHash);
   } else {
     const svgRectElement = document.createElementNS(svgns, 'rect');
 
     _setNewAttributesIfValid(attributes, svgRectElement);
 
-    svgDrawingHelper._appendNode(svgRectElement, svgNodeHash);
+    svgDrawingHelper.appendNode(svgRectElement, svgNodeHash);
   }
 }

--- a/packages/tools/src/drawingSvg/drawTextBox.ts
+++ b/packages/tools/src/drawingSvg/drawTextBox.ts
@@ -1,4 +1,5 @@
 import type { Types } from '@cornerstonejs/core';
+import { SVGDrawingHelper } from '../types';
 
 import _getHash from './_getHash';
 import _setAttributesIfNecessary from './_setAttributesIfNecessary';
@@ -12,7 +13,7 @@ import _setAttributesIfNecessary from './_setAttributesIfNecessary';
  * @returns Bounding box; can be used for isPointNearTool
  */
 function drawTextBox(
-  svgDrawingHelper: Record<string, unknown>,
+  svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   textUID: string,
   textLines: Array<string>,
@@ -46,7 +47,7 @@ function drawTextBox(
 }
 
 function _drawTextGroup(
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   textUID: string,
   textLines: Array<string>,
@@ -59,7 +60,7 @@ function _drawTextGroup(
   const [x, y] = [position[0] + padding, position[1] + padding];
   const svgns = 'http://www.w3.org/2000/svg';
   const svgNodeHash = _getHash(annotationUID, 'text', textUID);
-  const existingTextGroup = svgDrawingHelper._getSvgNode(svgNodeHash);
+  const existingTextGroup = svgDrawingHelper.getSvgNode(svgNodeHash);
 
   // Todo: right now textBox gets a re-render even if the textBox has not changed
   // and evenIf the attributes are not set again since they are the same.
@@ -85,7 +86,7 @@ function _drawTextGroup(
       }
 
       existingTextGroup.appendChild(textElement);
-      svgDrawingHelper._appendNode(existingTextGroup, svgNodeHash);
+      svgDrawingHelper.appendNode(existingTextGroup, svgNodeHash);
     }
 
     const textAttributes = {
@@ -104,7 +105,7 @@ function _drawTextGroup(
 
     textGroupBoundingBox = _drawTextBackground(existingTextGroup, background);
 
-    svgDrawingHelper._setNodeTouched(svgNodeHash);
+    svgDrawingHelper.setNodeTouched(svgNodeHash);
   } else {
     const textGroup = document.createElementNS(svgns, 'g');
 
@@ -120,7 +121,7 @@ function _drawTextGroup(
     }
 
     textGroup.appendChild(textElement);
-    svgDrawingHelper._appendNode(textGroup, svgNodeHash);
+    svgDrawingHelper.appendNode(textGroup, svgNodeHash);
     textGroupBoundingBox = _drawTextBackground(textGroup, background);
   }
 

--- a/packages/tools/src/drawingSvg/getSvgDrawingHelper.ts
+++ b/packages/tools/src/drawingSvg/getSvgDrawingHelper.ts
@@ -1,12 +1,13 @@
 import { state } from '../store';
 import { getEnabledElement } from '@cornerstonejs/core';
+import { SVGDrawingHelper } from '../types';
 
 /**
  * Returns the SVG drawing helper for the given HTML element.
  * @param element - The HTML element to get the SVG drawing helper for.
  * @private
  */
-function getSvgDrawingHelper(element: HTMLDivElement) {
+function getSvgDrawingHelper(element: HTMLDivElement): SVGDrawingHelper {
   const enabledElement = getEnabledElement(element);
   const { viewportId, renderingEngineId } = enabledElement;
   const canvasHash = `${viewportId}:${renderingEngineId}`;
@@ -18,22 +19,18 @@ function getSvgDrawingHelper(element: HTMLDivElement) {
   });
 
   return {
-    // Todo: not sure if we need enabledElement and _element anymore here
-    enabledElement: enabledElement,
-    _element: element,
-    _svgLayerElement: svgLayerElement,
-    _svgNodeCacheForCanvas: state.svgNodeCache,
-    _getSvgNode: getSvgNode.bind(this, canvasHash),
-    _appendNode: appendNode.bind(this, svgLayerElement, canvasHash),
-    _setNodeTouched: setNodeTouched.bind(this, canvasHash),
-    _clearUntouched: clearUntouched.bind(this, svgLayerElement, canvasHash),
-    // _drawnAnnotations: drawnAnnotations,
+    svgLayerElement: svgLayerElement,
+    svgNodeCacheForCanvas: state.svgNodeCache,
+    getSvgNode: getSvgNode.bind(this, canvasHash),
+    appendNode: appendNode.bind(this, svgLayerElement, canvasHash),
+    setNodeTouched: setNodeTouched.bind(this, canvasHash),
+    clearUntouched: clearUntouched.bind(this, svgLayerElement, canvasHash),
   };
 }
 
 /**
  *
- * @param canvasElement
+ * @param element
  * @private
  */
 function _getSvgLayer(element) {

--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -1295,27 +1295,25 @@ export default class CrosshairsTool extends AnnotationTool {
     data.handles.rotationPoints = newRtpoints;
     data.handles.slabThicknessPoints = newStpoints;
 
-    if (!this.configuration.viewportIndicators) {
-      return renderStatus;
+    if (this.configuration.viewportIndicators) {
+      // render a circle to pin point the viewport color
+      // TODO: This should not be part of the tool, and definitely not part of the renderAnnotation loop
+      const referenceColorCoordinates = [
+        sWidth * 0.95,
+        sHeight * 0.05,
+      ] as Types.Point2;
+      const circleRadius = canvasDiagonalLength * 0.01;
+
+      const circleUID = '0';
+      drawCircleSvg(
+        svgDrawingHelper,
+        annotationUID,
+        circleUID,
+        referenceColorCoordinates,
+        circleRadius,
+        { color, fill: color }
+      );
     }
-
-    // render a circle to pin point the viewport color
-    // TODO: This should not be part of the tool, and definitely not part of the renderAnnotation loop
-    const referenceColorCoordinates = [
-      sWidth * 0.95,
-      sHeight * 0.05,
-    ] as Types.Point2;
-    const circleRadius = canvasDiagonalLength * 0.01;
-
-    const circleUID = '0';
-    drawCircleSvg(
-      svgDrawingHelper,
-      annotationUID,
-      circleUID,
-      referenceColorCoordinates,
-      circleRadius,
-      { color, fill: color }
-    );
 
     return renderStatus;
   };

--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -669,7 +669,8 @@ export default class CrosshairsTool extends AnnotationTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     const { viewport, renderingEngine } = enabledElement;
     const { element } = viewport;
     const annotations = getAnnotations(element, this.getToolName());
@@ -681,7 +682,7 @@ export default class CrosshairsTool extends AnnotationTool {
     const viewportAnnotation = filteredToolAnnotations[0];
     if (!annotations || !viewportAnnotation || !viewportAnnotation.data) {
       // No annotations yet, and didn't just create it as we likely don't have a FrameOfReference/any data loaded yet.
-      return;
+      return renderStatus;
     }
 
     const annotationUID = viewportAnnotation.annotationUID;
@@ -1288,17 +1289,18 @@ export default class CrosshairsTool extends AnnotationTool {
       }
     });
 
+    renderStatus = true;
+
     // Save new handles points in annotation
     data.handles.rotationPoints = newRtpoints;
     data.handles.slabThicknessPoints = newStpoints;
 
-    // render a circle to pin point the viewport color
-    // TODO: This should not be part of the tool, and definitely not part of the renderAnnotation loop
-
     if (!this.configuration.viewportIndicators) {
-      return;
+      return renderStatus;
     }
 
+    // render a circle to pin point the viewport color
+    // TODO: This should not be part of the tool, and definitely not part of the renderAnnotation loop
     const referenceColorCoordinates = [
       sWidth * 0.95,
       sHeight * 0.05,
@@ -1314,6 +1316,8 @@ export default class CrosshairsTool extends AnnotationTool {
       circleRadius,
       { color, fill: color }
     );
+
+    return renderStatus;
   };
 
   _autoPanViewportIfNecessary(

--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -43,6 +43,7 @@ import {
   PublicToolProps,
   ToolProps,
   InteractionTypes,
+  SVGDrawingHelper,
 } from '../types';
 import { isAnnotationLocked } from '../stateManagement/annotation/annotationLocking';
 import triggerAnnotationRenderForViewportIds from '../utilities/triggerAnnotationRenderForViewportIds';
@@ -668,7 +669,7 @@ export default class CrosshairsTool extends AnnotationTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     const { viewport, renderingEngine } = enabledElement;

--- a/packages/tools/src/tools/ZoomTool.ts
+++ b/packages/tools/src/tools/ZoomTool.ts
@@ -148,10 +148,10 @@ export default class ZoomTool extends BaseTool {
     // has a physical meaning and we can use that to determine the threshold
     const imageData = viewport.getImageData();
 
-    const { dimensions, spacing } = imageData;
+    const { spacing } = imageData;
     const { minZoomScale, maxZoomScale } = this.configuration;
 
-    const t = dimensions[0] * spacing[0];
+    const t = element.clientHeight * spacing[1] * 0.5;
     const scale = t / parallelScaleToSet;
 
     let cappedParallelScale = parallelScaleToSet;

--- a/packages/tools/src/tools/ZoomTool.ts
+++ b/packages/tools/src/tools/ZoomTool.ts
@@ -16,8 +16,6 @@ export default class ZoomTool extends BaseTool {
   mouseDragCallback: () => void;
   initialMousePosWorld: Types.Point3;
   dirVec: Types.Point3;
-  minZoomScale = 0.1;
-  maxZoomScale = 10;
 
   // Apparently TS says super _must_ be the first call? This seems a bit opinionated.
   constructor(
@@ -27,6 +25,8 @@ export default class ZoomTool extends BaseTool {
       configuration: {
         // whether zoom to the center of the image OR zoom to the mouse position
         zoomToCenter: false,
+        minZoomScale: 0.1,
+        maxZoomScale: 30,
       },
     }
   ) {
@@ -83,9 +83,9 @@ export default class ZoomTool extends BaseTool {
     const camera = viewport.getCamera();
 
     if (camera.parallelProjection) {
-      this._dragParallelProjection(evt, camera);
+      this._dragParallelProjection(evt, viewport, camera);
     } else {
-      this._dragPerspectiveProjection(evt, camera);
+      this._dragPerspectiveProjection(evt, viewport, camera);
     }
 
     viewport.render();
@@ -93,20 +93,19 @@ export default class ZoomTool extends BaseTool {
 
   _dragParallelProjection = (
     evt: EventTypes.MouseDragEventType,
+    viewport: Types.IStackViewport | Types.IVolumeViewport,
     camera: Types.ICamera
-  ) => {
+  ): void => {
     const { element, deltaPoints } = evt.detail;
-    const enabledElement = getEnabledElement(element);
-    const { viewport } = enabledElement;
-    const size = [element.clientWidth, element.clientHeight];
 
+    const size = [element.clientWidth, element.clientHeight];
     const { parallelScale, focalPoint, position } = camera;
 
     const zoomScale = 1.5 / size[1];
     const deltaY = deltaPoints.canvas[1];
     const k = deltaY * zoomScale;
 
-    let newParallelScale = (1.0 - k) * parallelScale;
+    let parallelScaleToSet = (1.0 - k) * parallelScale;
 
     let focalPointToSet = focalPoint;
     let positionToSet = position;
@@ -121,13 +120,14 @@ export default class ZoomTool extends BaseTool {
         focalPoint,
         this.initialMousePosWorld
       );
+      // const initialYDistanceBetweenInitialAndFocalPoint;
 
       // we need to move in the direction of the vector between the focal point
       // and the initial mouse position by some amount until ultimately we
       // reach the mouse position at the focal point
-      const zoomScale = 10 / size[1];
+      const zoomScale = 5 / size[1];
       const k = deltaY * zoomScale;
-      newParallelScale = (1.0 - k) * parallelScale;
+      parallelScaleToSet = (1.0 - k) * parallelScale;
 
       positionToSet = vec3.scaleAndAdd(
         vec3.create(),
@@ -144,21 +144,26 @@ export default class ZoomTool extends BaseTool {
       ) as Types.Point3;
     }
 
-    const customViewport =
-      Object.getPrototypeOf(viewport).constructor.useCustomRenderingPipeline;
+    // If it is a regular GPU accelerated viewport, then parallel scale
+    // has a physical meaning and we can use that to determine the threshold
+    const imageData = viewport.getImageData();
 
-    // If it is a custom viewport, we can't rely on parallel scale physical
-    // values to determine if the threshold is exceeded.
-    if (customViewport) {
-      viewport.setCamera({
-        parallelScale: newParallelScale,
-      });
+    const { dimensions, spacing } = imageData;
+    const { minZoomScale, maxZoomScale } = this.configuration;
 
-      return;
+    const t = dimensions[0] * spacing[0];
+    const scale = t / parallelScaleToSet;
+
+    let cappedParallelScale = parallelScaleToSet;
+    let thresholdExceeded = false;
+
+    if (scale < minZoomScale) {
+      cappedParallelScale = t / minZoomScale;
+      thresholdExceeded = true;
+    } else if (scale >= maxZoomScale) {
+      cappedParallelScale = t / maxZoomScale;
+      thresholdExceeded = true;
     }
-
-    const { parallelScale: cappedParallelScale, thresholdExceeded } =
-      this._getCappedParallelScale(viewport, newParallelScale);
 
     viewport.setCamera({
       parallelScale: cappedParallelScale,
@@ -167,10 +172,8 @@ export default class ZoomTool extends BaseTool {
     });
   };
 
-  _dragPerspectiveProjection = (evt, camera) => {
+  _dragPerspectiveProjection = (evt, viewport, camera) => {
     const { element, deltaPoints } = evt.detail;
-    const enabledElement = getEnabledElement(element);
-    const { viewport } = enabledElement;
     const size = [element.clientWidth, element.clientHeight];
     const { position, focalPoint, viewPlaneNormal } = camera;
 
@@ -200,37 +203,5 @@ export default class ZoomTool extends BaseTool {
     focalPoint[2] += tmp;
 
     viewport.setCamera({ position, focalPoint });
-  };
-
-  _getCappedParallelScale = (
-    viewport: Types.IStackViewport | Types.IVolumeViewport,
-    parallelScale: number
-  ): { parallelScale: number; thresholdExceeded: boolean } => {
-    const imageData = viewport.getImageData();
-
-    if (!imageData) {
-      return;
-    }
-
-    const { dimensions, spacing } = imageData;
-
-    const t = dimensions[0] * spacing[0];
-    const scale = t / parallelScale;
-
-    let newParallelScale = parallelScale;
-    let thresholdExceeded = false;
-
-    if (scale < this.minZoomScale) {
-      newParallelScale = t / this.minZoomScale;
-      thresholdExceeded = true;
-    } else if (scale > this.maxZoomScale) {
-      newParallelScale = t / this.maxZoomScale;
-      thresholdExceeded = true;
-    }
-
-    return {
-      parallelScale: newParallelScale,
-      thresholdExceeded,
-    };
   };
 }

--- a/packages/tools/src/tools/ZoomTool.ts
+++ b/packages/tools/src/tools/ZoomTool.ts
@@ -144,6 +144,19 @@ export default class ZoomTool extends BaseTool {
       ) as Types.Point3;
     }
 
+    const customViewport =
+      Object.getPrototypeOf(viewport).constructor.useCustomRenderingPipeline;
+
+    // If it is a custom viewport, we can't rely on parallel scale physical
+    // values to determine if the threshold is exceeded.
+    if (customViewport) {
+      viewport.setCamera({
+        parallelScale: newParallelScale,
+      });
+
+      return;
+    }
+
     const { parallelScale: cappedParallelScale, thresholdExceeded } =
       this._getCappedParallelScale(viewport, newParallelScale);
 
@@ -189,7 +202,10 @@ export default class ZoomTool extends BaseTool {
     viewport.setCamera({ position, focalPoint });
   };
 
-  _getCappedParallelScale = (viewport, parallelScale) => {
+  _getCappedParallelScale = (
+    viewport: Types.IStackViewport | Types.IVolumeViewport,
+    parallelScale: number
+  ): { parallelScale: number; thresholdExceeded: boolean } => {
     const imageData = viewport.getImageData();
 
     if (!imageData) {

--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -43,6 +43,7 @@ import {
   PublicToolProps,
   ToolProps,
   InteractionTypes,
+  SVGDrawingHelper,
 } from '../../types';
 import { AngleAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
@@ -522,7 +523,7 @@ class AngleTool extends AnnotationTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
 

--- a/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
+++ b/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
@@ -564,7 +564,8 @@ class ArrowAnnotateTool extends AnnotationTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     const { viewport } = enabledElement;
     const { element } = viewport;
 
@@ -572,7 +573,7 @@ class ArrowAnnotateTool extends AnnotationTool {
 
     // Todo: We don't need this anymore, filtering happens in triggerAnnotationRender
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     annotations = this.filterInteractableAnnotationsForElement(
@@ -581,7 +582,7 @@ class ArrowAnnotateTool extends AnnotationTool {
     );
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     const styleSpecifier: StyleSpecifier = {
@@ -660,10 +661,12 @@ class ArrowAnnotateTool extends AnnotationTool {
         );
       }
 
+      renderStatus = true;
+
       // If rendering engine has been destroyed while rendering
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
-        return;
+        return renderStatus;
       }
 
       if (!text) {
@@ -703,6 +706,8 @@ class ArrowAnnotateTool extends AnnotationTool {
         bottomRight: viewport.canvasToWorld([left + width, top + height]),
       };
     }
+
+    return renderStatus;
   };
 
   _isInsideVolume(index1, index2, dimensions) {

--- a/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
+++ b/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
@@ -39,6 +39,7 @@ import {
   PublicToolProps,
   ToolProps,
   InteractionTypes,
+  SVGDrawingHelper,
 } from '../../types';
 import { ArrowAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
@@ -563,7 +564,7 @@ class ArrowAnnotateTool extends AnnotationTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     const { viewport } = enabledElement;

--- a/packages/tools/src/tools/annotation/BidirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/BidirectionalTool.ts
@@ -37,6 +37,7 @@ import {
   PublicToolProps,
   ToolProps,
   InteractionTypes,
+  SVGDrawingHelper,
 } from '../../types';
 import { BidirectionalAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 
@@ -951,7 +952,7 @@ export default class BidirectionalTool extends AnnotationTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = true;
     const { viewport } = enabledElement;

--- a/packages/tools/src/tools/annotation/BidirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/BidirectionalTool.ts
@@ -952,13 +952,14 @@ export default class BidirectionalTool extends AnnotationTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = true;
     const { viewport } = enabledElement;
     const { element } = viewport;
     let annotations = getAnnotations(viewport.element, this.getToolName());
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     annotations = this.filterInteractableAnnotationsForElement(
@@ -967,7 +968,7 @@ export default class BidirectionalTool extends AnnotationTool {
     );
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     const targetId = this.getTargetId(viewport);
@@ -1010,7 +1011,7 @@ export default class BidirectionalTool extends AnnotationTool {
       // If rendering engine has been destroyed while rendering
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
-        return;
+        return renderStatus;
       }
 
       let activeHandleCanvasCoords;
@@ -1070,6 +1071,8 @@ export default class BidirectionalTool extends AnnotationTool {
         }
       );
 
+      renderStatus = true;
+
       const textLines = this._getTextLines(data, targetId);
 
       if (!textLines || textLines.length === 0) {
@@ -1109,6 +1112,8 @@ export default class BidirectionalTool extends AnnotationTool {
         bottomRight: viewport.canvasToWorld([left + width, top + height]),
       };
     }
+
+    return renderStatus;
   };
 
   _movingLongAxisWouldPutItThroughShortAxis = (

--- a/packages/tools/src/tools/annotation/DragProbeTool.ts
+++ b/packages/tools/src/tools/annotation/DragProbeTool.ts
@@ -106,11 +106,12 @@ export default class DragProbeTool extends ProbeTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     const { viewport } = enabledElement;
 
     if (!this.editData) {
-      return;
+      return renderStatus;
     }
 
     const targetId = this.getTargetId(viewport);
@@ -147,7 +148,7 @@ export default class DragProbeTool extends ProbeTool {
     // If rendering engine has been destroyed while rendering
     if (!viewport.getRenderingEngine()) {
       console.warn('Rendering Engine has been destroyed');
-      return;
+      return renderStatus;
     }
 
     const handleGroupUID = '0';
@@ -159,6 +160,8 @@ export default class DragProbeTool extends ProbeTool {
       [canvasCoordinates],
       { color }
     );
+
+    renderStatus = true;
 
     const textLines = this._getTextLines(data, targetId);
     if (textLines) {
@@ -177,5 +180,7 @@ export default class DragProbeTool extends ProbeTool {
         this.getLinkedTextBoxStyle(styleSpecifier, annotation)
       );
     }
+
+    return renderStatus;
   };
 }

--- a/packages/tools/src/tools/annotation/DragProbeTool.ts
+++ b/packages/tools/src/tools/annotation/DragProbeTool.ts
@@ -8,7 +8,12 @@ import {
 } from '../../drawingSvg';
 import { getViewportIdsWithToolToRender } from '../../utilities/viewportFilters';
 import { hideElementCursor } from '../../cursors/elementCursor';
-import { EventTypes, PublicToolProps, ToolProps } from '../../types';
+import {
+  EventTypes,
+  PublicToolProps,
+  SVGDrawingHelper,
+  ToolProps,
+} from '../../types';
 import triggerAnnotationRenderForViewportIds from '../../utilities/triggerAnnotationRenderForViewportIds';
 import ProbeTool from './ProbeTool';
 import { ProbeAnnotation } from '../../types/ToolSpecificAnnotationTypes';
@@ -105,7 +110,7 @@ export default class DragProbeTool extends ProbeTool {
 
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     const { viewport } = enabledElement;

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -705,14 +705,15 @@ export default class EllipticalROITool extends AnnotationTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     const { viewport } = enabledElement;
     const { element } = viewport;
 
     let annotations = getAnnotations(element, this.getToolName());
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     annotations = this.filterInteractableAnnotationsForElement(
@@ -721,7 +722,7 @@ export default class EllipticalROITool extends AnnotationTool {
     );
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     const targetId = this.getTargetId(viewport);
@@ -812,7 +813,7 @@ export default class EllipticalROITool extends AnnotationTool {
       // If rendering engine has been destroyed while rendering
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
-        return;
+        return renderStatus;
       }
 
       let activeHandleCanvasCoords;
@@ -857,6 +858,8 @@ export default class EllipticalROITool extends AnnotationTool {
         }
       );
 
+      renderStatus = true;
+
       const textLines = this._getTextLines(data, targetId);
       if (!textLines || textLines.length === 0) {
         continue;
@@ -897,6 +900,8 @@ export default class EllipticalROITool extends AnnotationTool {
         bottomRight: viewport.canvasToWorld([left + width, top + height]),
       };
     }
+
+    return renderStatus;
   };
 
   _getTextLines = (data, targetId) => {

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -42,6 +42,7 @@ import {
   PublicToolProps,
   ToolProps,
   InteractionTypes,
+  SVGDrawingHelper,
 } from '../../types';
 import { EllipticalROIAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 
@@ -704,7 +705,7 @@ export default class EllipticalROITool extends AnnotationTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     const { viewport } = enabledElement;

--- a/packages/tools/src/tools/annotation/LengthTool.ts
+++ b/packages/tools/src/tools/annotation/LengthTool.ts
@@ -44,6 +44,7 @@ import {
   PublicToolProps,
   ToolProps,
   InteractionTypes,
+  SVGDrawingHelper,
 } from '../../types';
 import { LengthAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
@@ -527,7 +528,7 @@ class LengthTool extends AnnotationTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     const { viewport } = enabledElement;

--- a/packages/tools/src/tools/annotation/LengthTool.ts
+++ b/packages/tools/src/tools/annotation/LengthTool.ts
@@ -528,7 +528,8 @@ class LengthTool extends AnnotationTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     const { viewport } = enabledElement;
     const { element } = viewport;
 
@@ -536,7 +537,7 @@ class LengthTool extends AnnotationTool {
 
     // Todo: We don't need this anymore, filtering happens in triggerAnnotationRender
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     annotations = this.filterInteractableAnnotationsForElement(
@@ -545,7 +546,7 @@ class LengthTool extends AnnotationTool {
     );
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     const targetId = this.getTargetId(viewport);
@@ -631,10 +632,12 @@ class LengthTool extends AnnotationTool {
         }
       );
 
+      renderStatus = true;
+
       // If rendering engine has been destroyed while rendering
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
-        return;
+        return renderStatus;
       }
 
       const textLines = this._getTextLines(data, targetId);
@@ -672,6 +675,8 @@ class LengthTool extends AnnotationTool {
         bottomRight: viewport.canvasToWorld([left + width, top + height]),
       };
     }
+
+    return renderStatus;
   };
 
   // text line for the current active length annotation

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -36,6 +36,7 @@ import {
   PublicToolProps,
   ToolProps,
   InteractionTypes,
+  SVGDrawingHelper,
 } from '../../types';
 import { PlanarFreehandROIAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import { PlanarFreehandROICommonData } from '../../utilities/math/polyline/planarFreehandROIInternalTypes';
@@ -110,22 +111,22 @@ class PlanarFreehandROITool extends AnnotationTool {
 
   private renderContour: (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any,
+    svgDrawingHelper: SVGDrawingHelper,
     annotation: PlanarFreehandROIAnnotation
   ) => void;
   private renderContourBeingDrawn: (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any,
+    svgDrawingHelper: SVGDrawingHelper,
     annotation: PlanarFreehandROIAnnotation
   ) => void;
   private renderClosedContourBeingEdited: (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any,
+    svgDrawingHelper: SVGDrawingHelper,
     annotation: PlanarFreehandROIAnnotation
   ) => void;
   private renderOpenContourBeingEdited: (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any,
+    svgDrawingHelper: SVGDrawingHelper,
     annotation: PlanarFreehandROIAnnotation
   ) => void;
 
@@ -503,7 +504,7 @@ class PlanarFreehandROITool extends AnnotationTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     const renderStatus = false;
     const { viewport } = enabledElement;

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -504,7 +504,8 @@ class PlanarFreehandROITool extends AnnotationTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    const renderStatus = false;
     const { viewport } = enabledElement;
     const { element } = viewport;
 
@@ -514,7 +515,7 @@ class PlanarFreehandROITool extends AnnotationTool {
 
     // Todo: We don't need this anymore, filtering happens in triggerAnnotationRender
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     annotations = this.filterInteractableAnnotationsForElement(
@@ -523,7 +524,7 @@ class PlanarFreehandROITool extends AnnotationTool {
     ) as PlanarFreehandROIAnnotation[];
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     const isDrawing = this.isDrawing;
@@ -537,7 +538,7 @@ class PlanarFreehandROITool extends AnnotationTool {
         this.renderContour(enabledElement, svgDrawingHelper, annotation)
       );
 
-      return;
+      return renderStatus;
     }
 
     // One of the annotations will need special rendering treatment, render all
@@ -574,6 +575,9 @@ class PlanarFreehandROITool extends AnnotationTool {
         this.renderContour(enabledElement, svgDrawingHelper, annotation);
       }
     });
+
+    // Todo: return boolean flag for each rendering route in the planar tool.
+    return true;
   };
 }
 

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -40,6 +40,7 @@ import {
   ToolHandle,
   PublicToolProps,
   ToolProps,
+  SVGDrawingHelper,
 } from '../../types';
 import { ProbeAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
@@ -395,7 +396,7 @@ export default class ProbeTool extends AnnotationTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     const { viewport } = enabledElement;

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -396,14 +396,15 @@ export default class ProbeTool extends AnnotationTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     const { viewport } = enabledElement;
     const { element } = viewport;
 
     let annotations = getAnnotations(element, this.getToolName());
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     annotations = this.filterInteractableAnnotationsForElement(
@@ -412,7 +413,7 @@ export default class ProbeTool extends AnnotationTool {
     );
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     const targetId = this.getTargetId(viewport);
@@ -485,7 +486,7 @@ export default class ProbeTool extends AnnotationTool {
       // If rendering engine has been destroyed while rendering
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
-        return;
+        return renderStatus;
       }
 
       const handleGroupUID = '0';
@@ -497,6 +498,8 @@ export default class ProbeTool extends AnnotationTool {
         [canvasCoordinates],
         { color }
       );
+
+      renderStatus = true;
 
       const textLines = this._getTextLines(data, targetId);
       if (textLines) {
@@ -516,6 +519,8 @@ export default class ProbeTool extends AnnotationTool {
         );
       }
     }
+
+    return renderStatus;
   };
 
   _getTextLines(data, targetId) {

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -41,6 +41,7 @@ import {
   ToolProps,
   PublicToolProps,
   InteractionTypes,
+  SVGDrawingHelper,
 } from '../../types';
 import { RectangleROIAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import {
@@ -603,7 +604,7 @@ export default class RectangleROITool extends AnnotationTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     const { viewport } = enabledElement;

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -604,14 +604,15 @@ export default class RectangleROITool extends AnnotationTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     const { viewport } = enabledElement;
     const { element } = viewport;
 
     let annotations = getAnnotations(element, this.getToolName());
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     annotations = this.filterInteractableAnnotationsForElement(
@@ -620,7 +621,7 @@ export default class RectangleROITool extends AnnotationTool {
     );
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     const targetId = this.getTargetId(viewport);
@@ -710,7 +711,7 @@ export default class RectangleROITool extends AnnotationTool {
       // If rendering engine has been destroyed while rendering
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
-        return;
+        return renderStatus;
       }
 
       let activeHandleCanvasCoords;
@@ -756,6 +757,8 @@ export default class RectangleROITool extends AnnotationTool {
         }
       );
 
+      renderStatus = true;
+
       const textLines = this._getTextLines(data, targetId);
       if (!textLines || textLines.length === 0) {
         continue;
@@ -793,6 +796,8 @@ export default class RectangleROITool extends AnnotationTool {
         bottomRight: viewport.canvasToWorld([left + width, top + height]),
       };
     }
+
+    return renderStatus;
   };
 
   _getRectangleImageCoordinates = (

--- a/packages/tools/src/tools/annotation/planarFreehandROITool/renderMethods.ts
+++ b/packages/tools/src/tools/annotation/planarFreehandROITool/renderMethods.ts
@@ -7,6 +7,7 @@ import { polyline } from '../../../utilities/math';
 import { findOpenUShapedContourVectorToPeakOnRender } from './findOpenUShapedContourVectorToPeak';
 import { PlanarFreehandROIAnnotation } from '../../../types/ToolSpecificAnnotationTypes';
 import { StyleSpecifier } from '../../../types/AnnotationStyle';
+import { SVGDrawingHelper } from '../../../types';
 
 const { pointsAreWithinCloseContourProximity } = polyline;
 
@@ -48,7 +49,7 @@ function _getRenderingOptions(
  */
 function renderContour(
   enabledElement: Types.IEnabledElement,
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotation: PlanarFreehandROIAnnotation
 ): void {
   // Check if the contour is an open contour
@@ -94,7 +95,7 @@ function calculateUShapeContourVectorToPeakIfNotPresent(
  */
 function renderClosedContour(
   enabledElement: Types.IEnabledElement,
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotation: PlanarFreehandROIAnnotation
 ): void {
   const { viewport } = enabledElement;
@@ -125,7 +126,7 @@ function renderClosedContour(
  */
 function renderOpenContour(
   enabledElement: Types.IEnabledElement,
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotation: PlanarFreehandROIAnnotation
 ): void {
   const { viewport } = enabledElement;
@@ -203,7 +204,7 @@ function renderOpenContour(
 
 function renderOpenUShapedContour(
   enabledElement: Types.IEnabledElement,
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotation: PlanarFreehandROIAnnotation
 ): void {
   const { viewport } = enabledElement;
@@ -259,7 +260,7 @@ function renderOpenUShapedContour(
  */
 function renderContourBeingDrawn(
   enabledElement: Types.IEnabledElement,
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotation: PlanarFreehandROIAnnotation
 ): void {
   const options = this._getRenderingOptions(enabledElement, annotation);
@@ -349,7 +350,7 @@ function renderClosedContourBeingEdited(
  */
 function renderOpenContourBeingEdited(
   enabledElement: Types.IEnabledElement,
-  svgDrawingHelper: any,
+  svgDrawingHelper: SVGDrawingHelper,
   annotation: PlanarFreehandROIAnnotation
 ): void {
   const { fusedCanvasPoints } = this.editData;

--- a/packages/tools/src/tools/base/AnnotationTool.ts
+++ b/packages/tools/src/tools/base/AnnotationTool.ts
@@ -19,6 +19,7 @@ import {
   EventTypes,
   ToolHandle,
   InteractionTypes,
+  SVGDrawingHelper,
 } from '../../types';
 import triggerAnnotationRender from '../../utilities/triggerAnnotationRender';
 import filterAnnotationsForDisplay from '../../utilities/planar/filterAnnotationsForDisplay';
@@ -62,7 +63,7 @@ abstract class AnnotationTool extends BaseTool {
    */
   abstract renderAnnotation(
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   );
 
   /**

--- a/packages/tools/src/tools/segmentation/BrushTool.ts
+++ b/packages/tools/src/tools/segmentation/BrushTool.ts
@@ -1,7 +1,12 @@
 import { cache, getEnabledElement, StackViewport } from '@cornerstonejs/core';
 
 import type { Types } from '@cornerstonejs/core';
-import type { PublicToolProps, ToolProps, EventTypes } from '../../types';
+import type {
+  PublicToolProps,
+  ToolProps,
+  EventTypes,
+  SVGDrawingHelper,
+} from '../../types';
 import { BaseTool } from '../base';
 
 import { fillInsideCircle } from './strategies/fillCircle';
@@ -416,7 +421,7 @@ export default class BrushTool extends BaseTool {
 
   renderAnnotation(
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): void {
     if (!this._hoverData) {
       return;

--- a/packages/tools/src/tools/segmentation/CircleScissorsTool.ts
+++ b/packages/tools/src/tools/segmentation/CircleScissorsTool.ts
@@ -2,7 +2,12 @@ import { cache, getEnabledElement, StackViewport } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
 import { BaseTool } from '../base';
-import { PublicToolProps, ToolProps, EventTypes } from '../../types';
+import {
+  PublicToolProps,
+  ToolProps,
+  EventTypes,
+  SVGDrawingHelper,
+} from '../../types';
 
 import { fillInsideCircle } from './strategies/fillCircle';
 import { Events } from '../../enums';
@@ -298,7 +303,7 @@ export default class CircleScissorsTool extends BaseTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     if (!this.editData) {

--- a/packages/tools/src/tools/segmentation/CircleScissorsTool.ts
+++ b/packages/tools/src/tools/segmentation/CircleScissorsTool.ts
@@ -299,16 +299,17 @@ export default class CircleScissorsTool extends BaseTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     if (!this.editData) {
-      return;
+      return renderStatus;
     }
 
     const { viewport } = enabledElement;
     const { viewportIdsToRender } = this.editData;
 
     if (!viewportIdsToRender.includes(viewport.id)) {
-      return;
+      return renderStatus;
     }
 
     const { annotation } = this.editData;
@@ -336,7 +337,7 @@ export default class CircleScissorsTool extends BaseTool {
     // If rendering engine has been destroyed while rendering
     if (!viewport.getRenderingEngine()) {
       console.warn('Rendering Engine has been destroyed');
-      return;
+      return renderStatus;
     }
 
     const circleUID = '0';
@@ -350,5 +351,8 @@ export default class CircleScissorsTool extends BaseTool {
         color,
       }
     );
+
+    renderStatus = true;
+    return renderStatus;
   };
 }

--- a/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
@@ -24,7 +24,12 @@ import { isAnnotationVisible } from '../../stateManagement/annotation/annotation
 import { hideElementCursor } from '../../cursors/elementCursor';
 import triggerAnnotationRenderForViewportIds from '../../utilities/triggerAnnotationRenderForViewportIds';
 
-import { PublicToolProps, ToolProps, EventTypes } from '../../types';
+import {
+  PublicToolProps,
+  ToolProps,
+  EventTypes,
+  SVGDrawingHelper,
+} from '../../types';
 import { RectangleROIStartEndThresholdAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import RectangleROITool from '../annotation/RectangleROITool';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
@@ -296,7 +301,7 @@ export default class RectangleROIStartEndThresholdTool extends RectangleROITool 
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     const annotations = getAnnotations(

--- a/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
@@ -297,14 +297,15 @@ export default class RectangleROIStartEndThresholdTool extends RectangleROITool 
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     const annotations = getAnnotations(
       enabledElement.viewport.element,
       this.getToolName()
     );
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     const { viewport } = enabledElement;
@@ -358,7 +359,7 @@ export default class RectangleROIStartEndThresholdTool extends RectangleROITool 
       // If rendering engine has been destroyed while rendering
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
-        return;
+        return renderStatus;
       }
 
       let activeHandleCanvasCoords;
@@ -410,7 +411,11 @@ export default class RectangleROIStartEndThresholdTool extends RectangleROITool 
           lineWidth,
         }
       );
+
+      renderStatus = true;
     }
+
+    return renderStatus;
   };
 
   _getEndSliceIndex(

--- a/packages/tools/src/tools/segmentation/RectangleROIThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleROIThresholdTool.ts
@@ -20,7 +20,12 @@ import { getViewportIdsWithToolToRender } from '../../utilities/viewportFilters'
 import { hideElementCursor } from '../../cursors/elementCursor';
 import triggerAnnotationRenderForViewportIds from '../../utilities/triggerAnnotationRenderForViewportIds';
 import { isAnnotationVisible } from '../../stateManagement/annotation/annotationVisibility';
-import { PublicToolProps, ToolProps, EventTypes } from '../../types';
+import {
+  PublicToolProps,
+  ToolProps,
+  EventTypes,
+  SVGDrawingHelper,
+} from '../../types';
 import { RectangleROIThresholdAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import { AnnotationModifiedEventDetail } from '../../types/EventTypes';
 import RectangleROITool from '../annotation/RectangleROITool';
@@ -164,7 +169,7 @@ export default class RectangleROIThresholdTool extends RectangleROITool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     const { viewport, renderingEngineId } = enabledElement;

--- a/packages/tools/src/tools/segmentation/RectangleROIThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleROIThresholdTool.ts
@@ -165,13 +165,14 @@ export default class RectangleROIThresholdTool extends RectangleROITool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     const { viewport, renderingEngineId } = enabledElement;
     const { element } = viewport;
     let annotations = getAnnotations(element, this.getToolName());
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     annotations = this.filterInteractableAnnotationsForElement(
@@ -180,7 +181,7 @@ export default class RectangleROIThresholdTool extends RectangleROITool {
     );
 
     if (!annotations?.length) {
-      return;
+      return renderStatus;
     }
 
     const styleSpecifier: StyleSpecifier = {
@@ -204,7 +205,7 @@ export default class RectangleROIThresholdTool extends RectangleROITool {
       // If rendering engine has been destroyed while rendering
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
-        return;
+        return renderStatus;
       }
 
       // Todo: This is not correct way to add the event trigger,
@@ -262,6 +263,10 @@ export default class RectangleROIThresholdTool extends RectangleROITool {
           lineWidth,
         }
       );
+
+      renderStatus = true;
     }
+
+    return renderStatus;
   };
 }

--- a/packages/tools/src/tools/segmentation/RectangleScissorsTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleScissorsTool.ts
@@ -2,7 +2,12 @@ import { cache, getEnabledElement, StackViewport } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
 import { BaseTool } from '../base';
-import { PublicToolProps, ToolProps, EventTypes } from '../../types';
+import {
+  PublicToolProps,
+  ToolProps,
+  EventTypes,
+  SVGDrawingHelper,
+} from '../../types';
 import { fillInsideRectangle } from './strategies/fillRectangle';
 import { eraseInsideRectangle } from './strategies/eraseRectangle';
 import { getViewportIdsWithToolToRender } from '../../utilities/viewportFilters';
@@ -333,7 +338,7 @@ export default class RectangleScissorsTool extends BaseTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     if (!this.editData) {

--- a/packages/tools/src/tools/segmentation/RectangleScissorsTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleScissorsTool.ts
@@ -334,9 +334,10 @@ export default class RectangleScissorsTool extends BaseTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     if (!this.editData) {
-      return;
+      return renderStatus;
     }
 
     const { viewport } = enabledElement;
@@ -354,7 +355,7 @@ export default class RectangleScissorsTool extends BaseTool {
     // If rendering engine has been destroyed while rendering
     if (!viewport.getRenderingEngine()) {
       console.warn('Rendering Engine has been destroyed');
-      return;
+      return renderStatus;
     }
 
     const rectangleUID = '0';
@@ -368,5 +369,9 @@ export default class RectangleScissorsTool extends BaseTool {
         color,
       }
     );
+
+    renderStatus = true;
+
+    return renderStatus;
   };
 }

--- a/packages/tools/src/tools/segmentation/SphereScissorsTool.ts
+++ b/packages/tools/src/tools/segmentation/SphereScissorsTool.ts
@@ -2,7 +2,12 @@ import { cache, getEnabledElement, StackViewport } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
 import { BaseTool } from '../base';
-import { PublicToolProps, ToolProps, EventTypes } from '../../types';
+import {
+  PublicToolProps,
+  ToolProps,
+  EventTypes,
+  SVGDrawingHelper,
+} from '../../types';
 
 import { fillInsideSphere } from './strategies/fillSphere';
 import { Events } from '../../enums';
@@ -299,7 +304,7 @@ export default class SphereScissorsTool extends BaseTool {
    */
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
-    svgDrawingHelper: any
+    svgDrawingHelper: SVGDrawingHelper
   ): boolean => {
     let renderStatus = false;
     if (!this.editData) {

--- a/packages/tools/src/tools/segmentation/SphereScissorsTool.ts
+++ b/packages/tools/src/tools/segmentation/SphereScissorsTool.ts
@@ -300,16 +300,17 @@ export default class SphereScissorsTool extends BaseTool {
   renderAnnotation = (
     enabledElement: Types.IEnabledElement,
     svgDrawingHelper: any
-  ): void => {
+  ): boolean => {
+    let renderStatus = false;
     if (!this.editData) {
-      return;
+      return renderStatus;
     }
 
     const { viewport } = enabledElement;
     const { viewportIdsToRender } = this.editData;
 
     if (!viewportIdsToRender.includes(viewport.id)) {
-      return;
+      return renderStatus;
     }
 
     const { annotation } = this.editData;
@@ -337,7 +338,7 @@ export default class SphereScissorsTool extends BaseTool {
     // If rendering engine has been destroyed while rendering
     if (!viewport.getRenderingEngine()) {
       console.warn('Rendering Engine has been destroyed');
-      return;
+      return renderStatus;
     }
 
     const circleUID = '0';
@@ -351,5 +352,9 @@ export default class SphereScissorsTool extends BaseTool {
         color,
       }
     );
+
+    renderStatus = true;
+
+    return renderStatus;
   };
 }

--- a/packages/tools/src/types/SVGDrawingHelper.ts
+++ b/packages/tools/src/types/SVGDrawingHelper.ts
@@ -1,0 +1,10 @@
+type SVGDrawingHelper = {
+  svgLayerElement: HTMLDivElement;
+  svgNodeCacheForCanvas: Record<string, unknown>;
+  getSvgNode: (cacheKey: string) => SVGGElement | undefined;
+  appendNode: (svgNode: SVGElement, cacheKey: string) => void;
+  setNodeTouched: (cacheKey: string) => void;
+  clearUntouched: () => void;
+};
+
+export default SVGDrawingHelper;

--- a/packages/tools/src/types/index.ts
+++ b/packages/tools/src/types/index.ts
@@ -24,6 +24,7 @@ import type { SVGCursorDescriptor, SVGPoint } from './CursorTypes';
 import type JumpToSliceOptions from './JumpToSliceOptions';
 import type ScrollOptions from './ScrollOptions';
 import type BoundsIJK from './BoundsIJK';
+import type SVGDrawingHelper from './SVGDrawingHelper';
 import type * as CINETypes from './CINETypes';
 import type {
   Color,
@@ -86,4 +87,5 @@ export type {
   // CINE
   CINETypes,
   BoundsIJK,
+  SVGDrawingHelper,
 };

--- a/packages/tools/src/utilities/triggerAnnotationRender.ts
+++ b/packages/tools/src/utilities/triggerAnnotationRender.ts
@@ -7,8 +7,6 @@ import { Events, ToolModes } from '../enums';
 import { draw as drawSvg } from '../drawingSvg';
 import getToolsWithModesForElement from './getToolsWithModesForElement';
 import { AnnotationRenderedEventDetail } from '../types/EventTypes';
-import { getAnnotations } from '../stateManagement';
-
 const { Active, Passive, Enabled } = ToolModes;
 
 /**
@@ -159,10 +157,10 @@ class AnnotationRenderingEngine {
       viewportId,
     };
 
-    const enabledToolsWithAnnotations = enabledTools.filter((tool) => {
-      const annotations = getAnnotations(element, tool.getToolName());
-      return annotations && annotations.length;
-    });
+    // const enabledToolsWithAnnotations = enabledTools.filter((tool) => {
+    //   const annotations = getAnnotations(element, tool.getToolName());
+    //   return annotations && annotations.length;
+    // });
 
     drawSvg(element, (svgDrawingHelper) => {
       let anyRendered = false;
@@ -176,7 +174,13 @@ class AnnotationRenderingEngine {
         }
       };
 
-      enabledToolsWithAnnotations.forEach(handleDrawSvg);
+      /**
+       * We should be able to filter tools that don't have annotations, but
+       * currently some of tools have renderAnnotation method BUT
+       * don't keep annotation in the state, so if we do so, the tool will not be
+       * rendered.
+       */
+      enabledTools.forEach(handleDrawSvg);
 
       if (anyRendered) {
         triggerEvent(element, Events.ANNOTATION_RENDERED, { ...eventDetail });


### PR DESCRIPTION
Fix:
- ANNOTATION_RENDER events were firing even if no annotation were rendered 
- Camera API to be consistent between CPU and GPU rendering routes

Feat:
- Add new `suppressEvents` to StackViewport `setProperties`