### PR TITLE
fix prevent firing removed annotation event if there is no annotation…

### DIFF
--- a/packages/tools/src/stateManagement/annotation/annotationState.ts
+++ b/packages/tools/src/stateManagement/annotation/annotationState.ts
@@ -106,6 +106,12 @@ function removeAnnotation(
   }
 
   const annotation = annotationManager.getAnnotation(annotationUID);
+
+  // no need to continue in case there is no annotation.
+  if (!annotation) {
+    return;
+  }
+
   annotationManager.removeAnnotation(annotationUID);
 
   // trigger annotation removed


### PR DESCRIPTION
… to be deleted

### Includes
- Just preventing firing removed annotation if there is no annotation at all

### Related bug
https://github.com/cornerstonejs/cornerstone3D-beta/issues/128