### PR TITLE
fix: Pixel data array was the wrong length for color images

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1200,15 +1200,15 @@ class StackViewport extends Viewport implements IStackViewport {
     let pixelArray;
     switch (bitsAllocated) {
       case 8:
-        pixelArray = new Uint8Array(numVoxels);
+        pixelArray = new Uint8Array(numVoxels * numComps);
         break;
 
       case 16:
-        pixelArray = new Float32Array(numVoxels);
+        pixelArray = new Float32Array(numVoxels * numComps);
 
         break;
       case 24:
-        pixelArray = new Uint8Array(numVoxels * 3);
+        pixelArray = new Uint8Array(numVoxels * 3 * numComps);
 
         break;
       default:


### PR DESCRIPTION
Might fix https://github.com/cornerstonejs/cornerstone3D-beta/issues/106, not sure