### PR TITLE
feat: Add camera sync relative to the canvas

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -658,6 +658,8 @@ interface ICamera {
     // (undocumented)
     position?: Point3;
     // (undocumented)
+    resetOffsets?: boolean;
+    // (undocumented)
     scale?: number;
     // (undocumented)
     viewAngle?: number;
@@ -1226,9 +1228,13 @@ interface IViewport {
     // (undocumented)
     getFrameOfReferenceUID: () => string;
     // (undocumented)
+    getPan(): Point2;
+    // (undocumented)
     getRenderer(): void;
     // (undocumented)
     getRenderingEngine(): any;
+    // (undocumented)
+    getZoom(): number;
     // (undocumented)
     id: string;
     // (undocumented)
@@ -1247,6 +1253,10 @@ interface IViewport {
     setCamera(cameraInterface: ICamera): void;
     // (undocumented)
     setOptions(options: ViewportInputOptions, immediate: boolean): void;
+    // (undocumented)
+    setPan(pan: Point2, resetOffsets?: boolean): any;
+    // (undocumented)
+    setZoom(zoom: number, resetOffsets?: boolean): any;
     // (undocumented)
     sHeight: number;
     // (undocumented)
@@ -1931,6 +1941,8 @@ export class Viewport implements IViewport {
     // (undocumented)
     getFrameOfReferenceUID: () => string;
     // (undocumented)
+    getPan(): Point2;
+    // (undocumented)
     getProperties: () => void;
     // (undocumented)
     getRenderer(): any;
@@ -1939,9 +1951,13 @@ export class Viewport implements IViewport {
     // (undocumented)
     protected getVtkActiveCamera(): vtkCamera | vtkSlabCamera;
     // (undocumented)
+    getZoom(): number;
+    // (undocumented)
     protected hasPixelSpacing: boolean;
     // (undocumented)
     readonly id: string;
+    // (undocumented)
+    protected initialCamera: ICamera;
     // (undocumented)
     _isInBounds(point: Point3, bounds: number[]): boolean;
     // (undocumented)
@@ -1959,9 +1975,11 @@ export class Viewport implements IViewport {
     // (undocumented)
     reset(immediate?: boolean): void;
     // (undocumented)
-    protected resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
+    protected resetCamera(resetPan?: boolean, resetZoom?: boolean, resetOffsets?: boolean): boolean;
     // (undocumented)
     protected resetCameraNoEvent(): void;
+    // (undocumented)
+    resetInitialOffsets(resetOffsets?: boolean): void;
     // (undocumented)
     resize: () => void;
     // (undocumented)
@@ -1976,6 +1994,10 @@ export class Viewport implements IViewport {
     setOptions(options: ViewportInputOptions, immediate?: boolean): void;
     // (undocumented)
     setOrientationOfClippingPlanes(vtkPlanes: Array<vtkPlane>, slabThickness: number, viewPlaneNormal: Point3, focalPoint: Point3): void;
+    // (undocumented)
+    setPan(pan: Point2, resetOffsets?: boolean): void;
+    // (undocumented)
+    setZoom(value: number, resetOffsets?: boolean): void;
     // (undocumented)
     sHeight: number;
     // (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -507,6 +507,7 @@ interface ICamera {
     parallelProjection?: boolean;
     parallelScale?: number;
     position?: Point3;
+    resetOffsets?: boolean;
     scale?: number;
     viewAngle?: number;
     viewPlaneNormal?: Point3;
@@ -877,8 +878,10 @@ interface IViewport {
     _getCorners(bounds: Array<number>): Array<number>[];
     getDefaultActor(): ActorEntry;
     getFrameOfReferenceUID: () => string;
+    getPan(): Point2;
     getRenderer(): void;
     getRenderingEngine(): any;
+    getZoom(): number;
     id: string;
     options: ViewportInputOptions;
     removeAllActors(): void;
@@ -888,6 +891,8 @@ interface IViewport {
     setActors(actors: Array<ActorEntry>): void;
     setCamera(cameraInterface: ICamera): void;
     setOptions(options: ViewportInputOptions, immediate: boolean): void;
+    setPan(pan: Point2, resetOffsets?:boolean);
+    setZoom(zoom: number, resetOffsets?:boolean);
     sHeight: number;
     suppressEvents: boolean;
     sWidth: number;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1825,6 +1825,7 @@ interface ICamera {
     parallelProjection?: boolean;
     parallelScale?: number;
     position?: Point3;
+    resetOffsets?: boolean;
     scale?: number;
     viewAngle?: number;
     viewPlaneNormal?: Point3;
@@ -2311,8 +2312,10 @@ interface IViewport {
     _getCorners(bounds: Array<number>): Array<number>[];
     getDefaultActor(): ActorEntry;
     getFrameOfReferenceUID: () => string;
+    getPan(): Point2;
     getRenderer(): void;
     getRenderingEngine(): any;
+    getZoom(): number;
     id: string;
     options: ViewportInputOptions;
     removeAllActors(): void;
@@ -2322,6 +2325,8 @@ interface IViewport {
     setActors(actors: Array<ActorEntry>): void;
     setCamera(cameraInterface: ICamera): void;
     setOptions(options: ViewportInputOptions, immediate: boolean): void;
+    setPan(pan: Point2, resetOffsets?:boolean);
+    setZoom(zoom: number, resetOffsets?:boolean);
     sHeight: number;
     suppressEvents: boolean;
     sWidth: number;

--- a/packages/core/examples/programaticPanZoom/index.ts
+++ b/packages/core/examples/programaticPanZoom/index.ts
@@ -1,0 +1,160 @@
+import {
+  getRenderingEngine,
+  RenderingEngine,
+  Types,
+  Enums,
+} from '@cornerstonejs/core';
+import {
+  initDemo,
+  createImageIdsAndCacheMetaData,
+  setTitleAndDescription,
+  ctVoiRange,
+  addButtonToToolbar,
+} from '../../../../utils/demo/helpers';
+
+// This is for debugging purposes
+console.warn(
+  'Click on index.ts to open source code for this example --------->'
+);
+
+const { ViewportType } = Enums;
+const renderingEngineId = 'myRenderingEngine';
+const viewportId = 'CT_STACK';
+
+// ======== Set up page ======== //
+setTitleAndDescription(
+  'Programmatic Pan and Zoom with initial pan and zoom',
+  'Displays an image at the top of the viewport, half off the screen, and has pan/zoom buttons.'
+);
+
+const content = document.getElementById('content');
+const element = document.createElement('div');
+element.id = 'cornerstone-element';
+element.style.width = '500px';
+element.style.height = '500px';
+
+content.appendChild(element);
+// ============================= //
+addButtonToToolbar({
+  title: 'Set Pan (+5,0)',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IVolumeViewport>(
+      renderingEngine.getViewport(viewportId)
+    );
+
+    const pan = viewport.getPan();
+    console.log('Current pan', JSON.stringify(pan));
+    viewport.setPan([pan[0] + 5, pan[1]]);
+    viewport.render();
+  },
+});
+
+addButtonToToolbar({
+  title: 'Set zoom * 1.05 ',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IVolumeViewport>(
+      renderingEngine.getViewport(viewportId)
+    );
+
+    const zoom = viewport.getZoom();
+    console.log('Current zoom', zoom);
+    viewport.setZoom(zoom * 1.05);
+    viewport.render();
+  },
+});
+
+addButtonToToolbar({
+  title: 'Reset Original',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IVolumeViewport>(
+      renderingEngine.getViewport(viewportId)
+    );
+    //viewport.resetCamera();
+    viewport.setZoom(0.8);
+    viewport.setPan([-128, 0]);
+    viewport.render();
+  },
+});
+
+addButtonToToolbar({
+  title: 'Reset current as initial',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IVolumeViewport>(
+      renderingEngine.getViewport(viewportId)
+    );
+    viewport.setZoom(viewport.getZoom(), true);
+  },
+});
+
+/**
+ * Runs the demo
+ */
+async function run() {
+  // Init Cornerstone and related libraries
+  await initDemo();
+
+  // Get Cornerstone imageIds and fetch metadata into RAM
+  const imageIds = await createImageIdsAndCacheMetaData({
+    StudyInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463',
+    SeriesInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561',
+    wadoRsRoot: 'https://d1qmxk7r72ysft.cloudfront.net/dicomweb',
+    type: 'STACK',
+  });
+
+  // Instantiate a rendering engine
+  const renderingEngine = new RenderingEngine(renderingEngineId);
+
+  // Create a stack viewport
+  const viewportInput = {
+    viewportId,
+    type: ViewportType.STACK,
+    element,
+    defaultOptions: {
+      background: <Types.Point3>[0.2, 0, 0.2],
+    },
+  };
+
+  renderingEngine.enableElement(viewportInput);
+
+  // Get the stack viewport that was created
+  const viewport = <Types.IStackViewport>(
+    renderingEngine.getViewport(viewportId)
+  );
+
+  // Define a stack containing a single image
+  const stack = [imageIds[0]];
+
+  // Set the stack on the viewport
+  await viewport.setStack(stack);
+
+  // Set the VOI of the stack
+  viewport.setProperties({ voiRange: ctVoiRange });
+
+  // Render the image
+  viewport.render();
+
+  viewport.setZoom(0.8);
+  viewport.setPan([-128, 0]);
+  // Second one should have no affect
+  viewport.setPan([-128, 0]);
+}
+
+run();

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -304,8 +304,6 @@ class Viewport implements IViewport {
       actor.setUserMatrix(mat);
     });
 
-    this.resetInitialOffsets();
-
     this.getRenderingEngine().render();
   }
 
@@ -669,8 +667,7 @@ class Viewport implements IViewport {
     if (this.flipHorizontal || this.flipVertical) {
       this.flip({ flipHorizontal: false, flipVertical: false });
     }
-
-    this.resetInitialOffsets(resetOffsets);
+    this.resetInitialOffsets(!!resetOffsets);
 
     const RESET_CAMERA_EVENT = {
       type: 'ResetCameraEvent',
@@ -697,7 +694,9 @@ class Viewport implements IViewport {
    * @param resetOffsets can be passed to skip resetting, ie a no-op on this call
    */
   public resetInitialOffsets(resetOffsets = true) {
-    if (!resetOffsets) return;
+    if (!resetOffsets) {
+      return;
+    }
     this.initialCamera = this.getCamera();
   }
 
@@ -920,7 +919,7 @@ class Viewport implements IViewport {
       renderer.resetCameraClippingRange();
     }
 
-    this.resetInitialOffsets(resetOffsets);
+    this.resetInitialOffsets(!!resetOffsets);
 
     this.triggerCameraModifiedEventIfNecessary(previousCamera, updatedCamera);
   }

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -3,7 +3,7 @@ import vtkMatrixBuilder from '@kitware/vtk.js/Common/Core/MatrixBuilder';
 import vtkMath from '@kitware/vtk.js/Common/Core/Math';
 import vtkPlane from '@kitware/vtk.js/Common/DataModel/Plane';
 
-import { vec3, mat4 } from 'gl-matrix';
+import { vec2, vec3, mat4 } from 'gl-matrix';
 import _cloneDeep from 'lodash.clonedeep';
 
 import Events from '../enums/Events';
@@ -66,6 +66,10 @@ class Viewport implements IViewport {
   /** A flag representing if viewport methods should fire events or not */
   readonly suppressEvents: boolean;
   protected hasPixelSpacing = true;
+  /** The camera that is initially defined on the reset for
+   * the relative pan/zoom
+   */
+  protected initialCamera: ICamera;
 
   constructor(props: ViewportInput) {
     this.id = props.id;
@@ -298,9 +302,9 @@ class Viewport implements IViewport {
       }
 
       actor.setUserMatrix(mat);
-
-      this.getRenderingEngine().render();
     });
+
+    this.resetInitialOffsets();
 
     this.getRenderingEngine().render();
   }
@@ -536,9 +540,14 @@ class Viewport implements IViewport {
    * is reset for the current view.
    * @param resetPan - If true, the camera focal point is reset to the center of the volume (slice)
    * @param resetZoom - If true, the camera zoom is reset to the default zoom
+   * @param resetOffsets - If true, the pan/zoom initial offsets are reset.
    * @returns boolean
    */
-  protected resetCamera(resetPan = true, resetZoom = true): boolean {
+  protected resetCamera(
+    resetPan = true,
+    resetZoom = true,
+    resetOffsets = true
+  ): boolean {
     const renderer = this.getRenderer();
     const previousCamera = _cloneDeep(this.getCamera());
 
@@ -623,11 +632,7 @@ class Viewport implements IViewport {
       activeCamera.setViewUp(-viewUp[2], viewUp[0], viewUp[1]);
     }
 
-    let focalPointToSet = focalPoint;
-
-    if (!resetPan) {
-      focalPointToSet = previousCamera.focalPoint;
-    }
+    const focalPointToSet = resetPan ? focalPoint : previousCamera.focalPoint;
 
     activeCamera.setFocalPoint(
       focalPointToSet[0],
@@ -661,14 +666,16 @@ class Viewport implements IViewport {
       RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE
     );
 
+    if (this.flipHorizontal || this.flipVertical) {
+      this.flip({ flipHorizontal: false, flipVertical: false });
+    }
+
+    this.resetInitialOffsets(resetOffsets);
+
     const RESET_CAMERA_EVENT = {
       type: 'ResetCameraEvent',
       renderer,
     };
-
-    if (this.flipHorizontal || this.flipVertical) {
-      this.flip({ flipHorizontal: false, flipVertical: false });
-    }
 
     // Here to let parallel/distributed compositing intercept
     // and do the right thing.
@@ -680,6 +687,97 @@ class Viewport implements IViewport {
     );
 
     return true;
+  }
+
+  /**
+   * Resets the stored initial offset values for
+   * zoom and pan.  These values are the offset
+   * values used to allow the getPan and getZoom
+   * to return fixed initial values.
+   * @param resetOffsets can be passed to skip resetting, ie a no-op on this call
+   */
+  public resetInitialOffsets(resetOffsets = true) {
+    if (!resetOffsets) return;
+    this.initialCamera = this.getCamera();
+  }
+
+  /**
+   * Helper function to return the current canvas pan value.
+   *
+   * @returns a Point2 containing the current pan values
+   * on the canvas,
+   * computed from the current camera, where the initial pan
+   * value is [0,0].
+   */
+  public getPan(): Point2 {
+    const activeCamera = this.getVtkActiveCamera();
+    const focalPoint = activeCamera.getFocalPoint() as Point3;
+
+    const zero3 = this.canvasToWorld([0, 0]);
+    const initialCanvasFocal = this.worldToCanvas(
+      <Point3>vec3.subtract(vec3.create(), this.initialCamera.focalPoint, zero3)
+    );
+    const currentCanvasFocal = this.worldToCanvas(
+      <Point3>vec3.subtract(vec3.create(), focalPoint, zero3)
+    );
+    const result = <Point2>(
+      vec2.subtract(vec2.create(), initialCanvasFocal, currentCanvasFocal)
+    );
+    return result;
+  }
+
+  /**
+   * Sets the canvas pan value relative to the initial view position of 0,0
+   * Modifies the camera to perform the pan.
+   */
+  public setPan(pan: Point2, resetOffsets = false) {
+    const previousCamera = this.getCamera();
+    const { focalPoint, position } = previousCamera;
+    const zero3 = this.canvasToWorld([0, 0]);
+    const delta2 = vec2.subtract(vec2.create(), pan, this.getPan());
+    if (Math.abs(delta2[0]) < 1 && Math.abs(delta2[1]) < 1 && !resetOffsets) {
+      return;
+    }
+    const delta = vec3.subtract(
+      vec3.create(),
+      this.canvasToWorld(<Point2>delta2),
+      zero3
+    );
+    const newFocal = vec3.subtract(vec3.create(), focalPoint, delta);
+    const newPosition = vec3.subtract(vec3.create(), position, delta);
+    this.setCamera({
+      ...previousCamera,
+      focalPoint: newFocal as Point3,
+      position: newPosition as Point3,
+      resetOffsets,
+    });
+  }
+
+  /**
+   * Returns a current zoom level relative to the initial parallel scale
+   * originally applied to the image.  That is, on initial display,
+   * the zoom level is 1.  Computed as a function of the camera.
+   */
+  public getZoom() {
+    const activeCamera = this.getVtkActiveCamera();
+    const { parallelScale: initialParallelScale } = this.initialCamera;
+    return initialParallelScale / activeCamera.getParallelScale();
+  }
+
+  /** Zooms the image using parallel scale by updating the camera value.
+   * @param value is the relative parallel scale to apply.  It is relative
+   * to the initial offsets value.
+   * @param resetOffsets can be set to true to reset the zoom to the specified
+   *    value as a "1" value.
+   */
+  public setZoom(value: number, resetOffsets = false) {
+    const camera = this.getCamera();
+    const { parallelScale: initialParallelScale } = this.initialCamera;
+    const parallelScale = initialParallelScale / value;
+    if (camera.parallelScale === parallelScale && !resetOffsets) {
+      return;
+    }
+    this.setCamera({ ...camera, parallelScale, resetOffsets });
   }
 
   /**
@@ -776,6 +874,7 @@ class Viewport implements IViewport {
       viewAngle,
       flipHorizontal,
       flipVertical,
+      resetOffsets,
     } = cameraInterface;
 
     if (flipHorizontal !== undefined || flipVertical !== undefined) {
@@ -820,6 +919,8 @@ class Viewport implements IViewport {
       const renderer = this.getRenderer();
       renderer.resetCameraClippingRange();
     }
+
+    this.resetInitialOffsets(resetOffsets);
 
     this.triggerCameraModifiedEventIfNecessary(previousCamera, updatedCamera);
   }

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -690,10 +690,10 @@ class Viewport implements IViewport {
    * Resets the stored initial offset values for
    * zoom and pan.  These values are the offset
    * values used to allow the getPan and getZoom
-   * to return fixed initial values.
+   * to return [0,0] and 1 for the initial values.
    * @param resetOffsets can be passed to skip resetting, ie a no-op on this call
    */
-  public resetInitialOffsets(resetOffsets = true) {
+  protected resetInitialOffsets(resetOffsets = true) {
     if (!resetOffsets) {
       return;
     }

--- a/packages/core/src/types/ICamera.ts
+++ b/packages/core/src/types/ICamera.ts
@@ -28,6 +28,11 @@ interface ICamera {
   flipHorizontal?: boolean;
   /** flip Vertical */
   flipVertical?: boolean;
+  /** resetOffsets set to true to reset the pan and zoom offsets
+   * such that the pan value becomes [0,0] and the zoom value 1.  Used to
+   * set the initial state.
+   */
+  resetOffsets?: boolean;
 }
 
 export default ICamera;

--- a/packages/core/src/types/IViewport.ts
+++ b/packages/core/src/types/IViewport.ts
@@ -73,6 +73,14 @@ interface IViewport {
   getCanvas(): HTMLCanvasElement;
   /** returns camera object */
   getCamera(): ICamera;
+  /** returns the parallel zoom relative to the default (eg returns 1 after reset) */
+  getZoom(): number;
+  /** Sets the relative zoom - set to 1 to reset it */
+  setZoom(zoom: number, resetOffsets?: boolean);
+  /** Gets the canvas pan value */
+  getPan(): Point2;
+  /** Sets the canvas pan value */
+  setPan(pan: Point2, resetOffsets?: boolean);
   /** sets the camera */
   setCamera(cameraInterface: ICamera): void;
   /** whether the viewport has custom rendering */

--- a/packages/tools/src/synchronizers/callbacks/cameraSyncCallback.ts
+++ b/packages/tools/src/synchronizers/callbacks/cameraSyncCallback.ts
@@ -39,12 +39,12 @@ export default function cameraSyncCallback(
   // TODO: only sync in-plane movements if one viewport is a stack viewport
   if (camera.parallelProjection) {
     const sViewport = renderingEngine.getViewport(sourceViewport.viewportId);
-    const srcDelta = sViewport.getPan();
-    const zoom = sViewport.getZoom();
+    const srcPan = sViewport.getPan();
+    const srcZoom = sViewport.getZoom();
 
     // Do the zoom first, as the pan is relative to the zoom level
-    tViewport.setZoom(zoom);
-    tViewport.setPan(srcDelta);
+    tViewport.setZoom(srcZoom);
+    tViewport.setPan(srcPan);
   } else {
     tViewport.setCamera(camera);
   }

--- a/packages/tools/src/synchronizers/callbacks/cameraSyncCallback.ts
+++ b/packages/tools/src/synchronizers/callbacks/cameraSyncCallback.ts
@@ -1,15 +1,18 @@
 import { getRenderingEngine, Types } from '@cornerstonejs/core';
+import { Synchronizer } from '../../store';
 
 /**
  * Synchronizer callback to synchronize the camera. Synchronization
  *
+ * TODO - add options to synchronizer to control which camera sync is used,
+ * and to allow zoom only sync or zoom+pan, and maybe also flip/rotate sync.
  * @param synchronizerInstance - The Instance of the Synchronizer
  * @param sourceViewport - The list of IDs defining the source viewport.
  * @param targetViewport - The list of IDs defining the target viewport.
  * @param cameraModifiedEvent - The CAMERA_MODIFIED event.
  */
 export default function cameraSyncCallback(
-  synchronizerInstance,
+  synchronizerInstance: Synchronizer,
   sourceViewport: Types.IViewportId,
   targetViewport: Types.IViewportId,
   cameraModifiedEvent: CustomEvent
@@ -34,9 +37,15 @@ export default function cameraSyncCallback(
   const tViewport = renderingEngine.getViewport(targetViewport.viewportId);
 
   // TODO: only sync in-plane movements if one viewport is a stack viewport
+  if (camera.parallelProjection) {
+    const sViewport = renderingEngine.getViewport(sourceViewport.viewportId);
+    const srcDelta = sViewport.getPan();
 
-  // Todo: we shouldn't set camera, we should set the focalPoint
-  // to the nearest slice center world position
-  tViewport.setCamera(camera);
+    // Do the zoom first, as the pan is relative to the zoom level
+    tViewport.setZoom(sViewport.getZoom());
+    tViewport.setPan(srcDelta);
+  } else {
+    tViewport.setCamera(camera);
+  }
   tViewport.render();
 }

--- a/packages/tools/src/synchronizers/callbacks/cameraSyncCallback.ts
+++ b/packages/tools/src/synchronizers/callbacks/cameraSyncCallback.ts
@@ -40,9 +40,10 @@ export default function cameraSyncCallback(
   if (camera.parallelProjection) {
     const sViewport = renderingEngine.getViewport(sourceViewport.viewportId);
     const srcDelta = sViewport.getPan();
+    const zoom = sViewport.getZoom();
 
     // Do the zoom first, as the pan is relative to the zoom level
-    tViewport.setZoom(sViewport.getZoom());
+    tViewport.setZoom(zoom);
     tViewport.setPan(srcDelta);
   } else {
     tViewport.setCamera(camera);


### PR DESCRIPTION
The existing camera sync was a camera copy, which broke display of
images in different frame of reference uids/with different initial
viewing conditions, in a way that completely prevented viewing them.
This version preserves pan and zoom relative
to the initial viewing conditions.  As well, it takes input parameters
to set the initial pan/zoom conditions.