### PR TITLE
fix: unify handling of annotation units and remove 'MO'

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1361,7 +1361,7 @@ export class EllipticalROITool extends AnnotationTool {
         hasMoved?: boolean;
     } | null;
     // (undocumented)
-    _getTextLines: (data: any, targetId: any) => any[];
+    _getTextLines: (data: any, targetId: string, isPreScaled: boolean) => string[];
     // (undocumented)
     handleSelectedCallback: (evt: EventTypes_2.MouseDownEventType, annotation: EllipticalROIAnnotation, handle: ToolHandle, interactionType?: string) => void;
     // (undocumented)
@@ -3074,7 +3074,7 @@ export class ProbeTool extends AnnotationTool {
     // (undocumented)
     getHandleNearImagePoint(element: HTMLDivElement, annotation: ProbeAnnotation, canvasCoords: Types_2.Point2, proximity: number): ToolHandle | undefined;
     // (undocumented)
-    _getTextLines(data: any, targetId: any): any[];
+    _getTextLines(data: any, targetId: string, isPreScaled: boolean): string[] | undefined;
     // (undocumented)
     _getValueForModality(value: any, imageVolume: any, modality: any): {};
     // (undocumented)
@@ -3359,7 +3359,7 @@ export class RectangleROITool extends AnnotationTool {
         height: number;
     };
     // (undocumented)
-    _getTextLines: (data: any, targetId: string) => any[];
+    _getTextLines: (data: any, targetId: string, isPreScaled: boolean) => string[] | undefined;
     // (undocumented)
     handleSelectedCallback: (evt: EventTypes_2.MouseDownEventType, annotation: RectangleROIAnnotation, handle: ToolHandle, interactionType?: string) => void;
     // (undocumented)

--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -737,7 +737,7 @@ class AngleTool extends AnnotationTool {
     return renderStatus;
   };
 
-  // text line for the current active length annotation
+  // text line for the current active angle annotation
   _getTextLines(data, targetId) {
     const cachedVolumeStats = data.cachedStats[targetId];
     const { angle } = cachedVolumeStats;

--- a/packages/tools/src/tools/annotation/DragProbeTool.ts
+++ b/packages/tools/src/tools/annotation/DragProbeTool.ts
@@ -18,6 +18,7 @@ import triggerAnnotationRenderForViewportIds from '../../utilities/triggerAnnota
 import ProbeTool from './ProbeTool';
 import { ProbeAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
+import { isViewportPreScaled } from '../../utilities/viewport/isViewportPreScaled';
 
 export default class DragProbeTool extends ProbeTool {
   static toolName = 'DragProbe';
@@ -168,7 +169,9 @@ export default class DragProbeTool extends ProbeTool {
 
     renderStatus = true;
 
-    const textLines = this._getTextLines(data, targetId);
+    const isPreScaled = isViewportPreScaled(viewport, targetId);
+
+    const textLines = this._getTextLines(data, targetId, isPreScaled);
     if (textLines) {
       const textCanvasCoordinates = [
         canvasCoordinates[0] + 6,

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -55,6 +55,7 @@ import {
 import triggerAnnotationRenderForViewportIds from '../../utilities/triggerAnnotationRenderForViewportIds';
 import { pointInShapeCallback } from '../../utilities/';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
+import { getModalityUnit } from '../../utilities/getModalityUnit';
 
 const { transformWorldToIndex } = csUtils;
 
@@ -918,49 +919,25 @@ export default class EllipticalROITool extends AnnotationTool {
       cachedVolumeStats;
 
     const textLines = [];
-    let areaLine, meanLine, stdDevLine, maxLine;
+    const unit = getModalityUnit(Modality);
 
     if (area) {
-      areaLine = isEmptyArea
+      const areaLine = isEmptyArea
         ? `Area: Oblique not supported`
         : `Area: ${area.toFixed(2)} ${areaUnit}\xb2`;
-    }
-
-    if (mean) {
-      meanLine = `Mean: ${mean.toFixed(2)}`;
-    }
-
-    if (max) {
-      maxLine = `Max: ${max.toFixed(2)}`;
-    }
-
-    if (stdDev) {
-      stdDevLine = `StdDev: ${stdDev.toFixed(2)}`;
-    }
-
-    let unit;
-    if (Modality === 'PT') {
-      unit = 'SUV';
-    } else if (Modality === 'CT') {
-      unit = 'HU';
-    } else {
-      unit = 'MO';
-    }
-
-    if (areaLine) {
       textLines.push(areaLine);
     }
 
-    if (meanLine) {
-      textLines.push(meanLine + ' ' + unit);
+    if (mean) {
+      textLines.push(`Mean: ${mean.toFixed(2)} ${unit}`);
     }
 
-    if (maxLine) {
-      textLines.push(maxLine + ' ' + unit);
+    if (max) {
+      textLines.push(`Max: ${max.toFixed(2)} ${unit}`);
     }
 
-    if (stdDevLine) {
-      textLines.push(stdDevLine + ' ' + unit);
+    if (stdDev) {
+      textLines.push(`Std Dev: ${stdDev.toFixed(2)} ${unit}`);
     }
 
     return textLines;

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -56,6 +56,7 @@ import triggerAnnotationRenderForViewportIds from '../../utilities/triggerAnnota
 import { pointInShapeCallback } from '../../utilities/';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
 import { getModalityUnit } from '../../utilities/getModalityUnit';
+import { isViewportPreScaled } from '../../utilities/viewport/isViewportPreScaled';
 
 const { transformWorldToIndex } = csUtils;
 
@@ -869,7 +870,9 @@ export default class EllipticalROITool extends AnnotationTool {
 
       renderStatus = true;
 
-      const textLines = this._getTextLines(data, targetId);
+      const isPreScaled = isViewportPreScaled(viewport, targetId);
+
+      const textLines = this._getTextLines(data, targetId, isPreScaled);
       if (!textLines || textLines.length === 0) {
         continue;
       }
@@ -913,13 +916,13 @@ export default class EllipticalROITool extends AnnotationTool {
     return renderStatus;
   };
 
-  _getTextLines = (data, targetId) => {
+  _getTextLines = (data, targetId: string, isPreScaled: boolean): string[] => {
     const cachedVolumeStats = data.cachedStats[targetId];
     const { area, mean, stdDev, max, isEmptyArea, Modality, areaUnit } =
       cachedVolumeStats;
 
-    const textLines = [];
-    const unit = getModalityUnit(Modality);
+    const textLines: string[] = [];
+    const unit = getModalityUnit(Modality, isPreScaled);
 
     if (area) {
       const areaLine = isEmptyArea

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -44,6 +44,7 @@ import {
 } from '../../types';
 import { ProbeAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
+import { getModalityUnit } from '../../utilities/getModalityUnit';
 
 const { transformWorldToIndex } = csUtils;
 
@@ -533,6 +534,7 @@ export default class ProbeTool extends AnnotationTool {
     }
 
     const textLines = [];
+    const unit = getModalityUnit(Modality);
 
     textLines.push(`(${index[0]}, ${index[1]}, ${index[2]})`);
 
@@ -551,10 +553,8 @@ export default class ProbeTool extends AnnotationTool {
           textLines.push(`${SUVBsa.toFixed(2)} SUV bsa`);
         }
       }
-    } else if (Modality === 'CT') {
-      textLines.push(`${value.toFixed(2)} HU`);
     } else {
-      textLines.push(`${value.toFixed(2)} MO`);
+      textLines.push(`${value.toFixed(2)} ${unit}`);
     }
 
     return textLines;

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -49,6 +49,7 @@ import {
   AnnotationModifiedEventDetail,
 } from '../../types/EventTypes';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
+import { getModalityUnit } from '../../utilities/getModalityUnit';
 
 const { transformWorldToIndex } = csUtils;
 
@@ -841,31 +842,12 @@ export default class RectangleROITool extends AnnotationTool {
     }
 
     const textLines = [];
+    const unit = getModalityUnit(Modality);
 
-    const areaLine = `Area: ${area.toFixed(2)} ${areaUnit}\xb2`;
-    let meanLine = `Mean: ${mean.toFixed(2)}`;
-    let maxLine = `Max: ${max.toFixed(2)}`;
-    let stdDevLine = `Std Dev: ${stdDev.toFixed(2)}`;
-
-    // Give appropriate units for the modality.
-    if (Modality === 'PT') {
-      meanLine += ' SUV';
-      maxLine += ' SUV';
-      stdDevLine += ' SUV';
-    } else if (Modality === 'CT') {
-      meanLine += ' HU';
-      maxLine += ' HU';
-      stdDevLine += ' HU';
-    } else {
-      meanLine += ' MO';
-      maxLine += ' MO';
-      stdDevLine += ' MO';
-    }
-
-    textLines.push(areaLine);
-    textLines.push(maxLine);
-    textLines.push(meanLine);
-    textLines.push(stdDevLine);
+    textLines.push(`Area: ${area.toFixed(2)} ${areaUnit}\xb2`);
+    textLines.push(`Mean: ${mean.toFixed(2)} ${unit}`);
+    textLines.push(`Max: ${max.toFixed(2)} ${unit}`);
+    textLines.push(`Std Dev: ${stdDev.toFixed(2)} ${unit}`);
 
     return textLines;
   };

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -50,6 +50,7 @@ import {
 } from '../../types/EventTypes';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
 import { getModalityUnit } from '../../utilities/getModalityUnit';
+import { isViewportPreScaled } from '../../utilities/viewport/isViewportPreScaled';
 
 const { transformWorldToIndex } = csUtils;
 
@@ -767,7 +768,9 @@ export default class RectangleROITool extends AnnotationTool {
 
       renderStatus = true;
 
-      const textLines = this._getTextLines(data, targetId);
+      const isPreScaled = isViewportPreScaled(viewport, targetId);
+
+      const textLines = this._getTextLines(data, targetId, isPreScaled);
       if (!textLines || textLines.length === 0) {
         continue;
       }
@@ -832,8 +835,13 @@ export default class RectangleROITool extends AnnotationTool {
    *
    * @param data - The annotation tool-specific data.
    * @param targetId - The volumeId of the volume to display the stats for.
+   * @param isPreScaled - Whether the viewport is pre-scaled or not.
    */
-  _getTextLines = (data, targetId: string) => {
+  _getTextLines = (
+    data,
+    targetId: string,
+    isPreScaled: boolean
+  ): string[] | undefined => {
     const cachedVolumeStats = data.cachedStats[targetId];
     const { area, mean, max, stdDev, Modality, areaUnit } = cachedVolumeStats;
 
@@ -841,8 +849,8 @@ export default class RectangleROITool extends AnnotationTool {
       return;
     }
 
-    const textLines = [];
-    const unit = getModalityUnit(Modality);
+    const textLines: string[] = [];
+    const unit = getModalityUnit(Modality, isPreScaled);
 
     textLines.push(`Area: ${area.toFixed(2)} ${areaUnit}\xb2`);
     textLines.push(`Mean: ${mean.toFixed(2)} ${unit}`);

--- a/packages/tools/src/utilities/getModalityUnit.ts
+++ b/packages/tools/src/utilities/getModalityUnit.ts
@@ -1,0 +1,11 @@
+function getModalityUnit(modality: string): string {
+  if (modality === 'CT') {
+    return 'HU';
+  } else if (modality === 'PT') {
+    return 'SUV';
+  } else {
+    return '';
+  }
+}
+
+export { getModalityUnit };

--- a/packages/tools/src/utilities/getModalityUnit.ts
+++ b/packages/tools/src/utilities/getModalityUnit.ts
@@ -1,7 +1,7 @@
-function getModalityUnit(modality: string): string {
+function getModalityUnit(modality: string, isPreScaled: boolean): string {
   if (modality === 'CT') {
     return 'HU';
-  } else if (modality === 'PT') {
+  } else if (modality === 'PT' && isPreScaled === true) {
     return 'SUV';
   } else {
     return '';

--- a/packages/tools/src/utilities/viewport/isViewportPreScaled.ts
+++ b/packages/tools/src/utilities/viewport/isViewportPreScaled.ts
@@ -1,0 +1,24 @@
+import {
+  cache,
+  StackViewport,
+  Types,
+  VolumeViewport,
+} from '@cornerstonejs/core';
+
+function isViewportPreScaled(
+  viewport: Types.IStackViewport | Types.IVolumeViewport,
+  targetId: string
+): boolean {
+  if (viewport instanceof VolumeViewport) {
+    const volumeId = targetId.split('volumeId:')[1];
+    const volume = cache.getVolume(volumeId);
+    return volume.scaling && Object.keys(volume.scaling).length > 0;
+  } else if (viewport instanceof StackViewport) {
+    const { preScale } = viewport.getImageData();
+    return preScale.scaled;
+  } else {
+    throw new Error('Viewport is not a valid type');
+  }
+}
+
+export { isViewportPreScaled };


### PR DESCRIPTION
This pull request addresses two points:
1) Unify handling of annotation units.

So far, each annotation (elliptical, rectangle, probe) was handling units on its own (and in a slightly different way). This is unified and the actual function is taken from https://github.com/OHIF/Viewers/blob/ae897c47e08611014ad1918b567df36444764329/extensions/cornerstone/src/utils/measurementServiceMappings/utils/getModalityUnit.js

2) By taking the function linked above, `MO` is not shown anymore. 

Before, for every modality that is not PT and not CT, `MO` was shown as unit for the annotations. I find this confusing, as `MO` doesn't have a physical meaning. I only recently learned that it stands for "modality unit" (as opposed to stored pixel value). See https://groups.google.com/g/cornerstone-platform/c/oCuC7_TIizY/m/fCyGBIEaBAAJ
