### PR TITLE
fix: revert the stack viewport setting of targetImageIndex

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1808,9 +1808,6 @@ class StackViewport extends Viewport implements IStackViewport {
       imageIdIndex
     );
 
-    // update the target imageIdIndex for it to not interfere
-    // with the scroll event
-    this.targetImageIdIndex = imageIdIndex;
     return imageId;
   }
 


### PR DESCRIPTION
This should not be set 