### PR TITLE
Fix toolName typo for Crosshairs tool

### DIFF
--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -2584,5 +2584,5 @@ class CrosshairsTool extends AnnotationTool {
   }
 }
 
-CrosshairsTool.toolName = 'Crosshairs;';
+CrosshairsTool.toolName = 'Crosshairs';
 export default CrosshairsTool;


### PR DESCRIPTION
```CrosshairsTool.toolName = 'Crosshairs;';```
to
```CrosshairsTool.toolName = 'Crosshairs';```