### PR TITLE
fix: annotations throwing error when stack and volume viewports are converted

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1156,8 +1156,6 @@ interface IStackViewport extends IViewport {
     // (undocumented)
     getImageIds: () => string[];
     // (undocumented)
-    getImageURIIndex: (imageURI: string) => number;
-    // (undocumented)
     getProperties: () => StackViewportProperties;
     // (undocumented)
     getRenderer(): any;
@@ -1715,8 +1713,6 @@ export class StackViewport extends Viewport implements IStackViewport {
     getImageData(): IImageData | CPUIImageData;
     // (undocumented)
     getImageIds: () => Array<string>;
-    // (undocumented)
-    getImageURIIndex: (imageURI: string) => number;
     // (undocumented)
     getProperties: () => StackViewportProperties;
     // (undocumented)

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -583,13 +583,16 @@ function getTargetVolumeAndSpacingInNormalDir(viewport: IVolumeViewport, camera:
 };
 
 // @public (undocumented)
+function getViewportsWithImageURI(imageURI: string, renderingEngineId?: string): Array<Viewport_2>;
+
+// @public (undocumented)
+function getViewportsWithVolumeId(volumeId: string, renderingEngineId?: string): Array<IVolumeViewport>;
+
+// @public (undocumented)
 function getVolumeActorCorners(volumeActor: any): Array<Point3>;
 
 // @public (undocumented)
 function getVolumeViewportsContainingSameVolumes(targetViewport: IVolumeViewport, renderingEngineId?: string): Array<IVolumeViewport>;
-
-// @public (undocumented)
-function getVolumeViewportsContainingVolumeId(volumeId: string, renderingEngineId?: string): Array<IVolumeViewport>;
 
 // @public (undocumented)
 interface ICache {
@@ -1153,6 +1156,8 @@ interface IStackViewport extends IViewport {
     // (undocumented)
     getImageIds: () => string[];
     // (undocumented)
+    getImageURIIndex: (imageURI: string) => number;
+    // (undocumented)
     getProperties: () => StackViewportProperties;
     // (undocumented)
     getRenderer(): any;
@@ -1375,13 +1380,17 @@ interface IVolumeViewport extends IViewport {
     // (undocumented)
     getFrameOfReferenceUID: () => string;
     // (undocumented)
-    getImageData(): IImageData | undefined;
+    getImageData(volumeId?: string): IImageData | undefined;
     // (undocumented)
     getIntensityFromWorld(point: Point3): number;
     // (undocumented)
     getProperties: () => any;
     // (undocumented)
     getSlabThickness(): number;
+    // (undocumented)
+    hasImageURI: (imageURI: string) => boolean;
+    // (undocumented)
+    hasVolumeId: (volumeId: string) => boolean;
     // (undocumented)
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
     // (undocumented)
@@ -1707,6 +1716,8 @@ export class StackViewport extends Viewport implements IStackViewport {
     // (undocumented)
     getImageIds: () => Array<string>;
     // (undocumented)
+    getImageURIIndex: (imageURI: string) => number;
+    // (undocumented)
     getProperties: () => StackViewportProperties;
     // (undocumented)
     getRenderer(): any;
@@ -1894,7 +1905,7 @@ declare namespace utilities {
         getVolumeActorCorners,
         indexWithinDimensions,
         getVolumeViewportsContainingSameVolumes,
-        getVolumeViewportsContainingVolumeId,
+        getViewportsWithVolumeId,
         transformWorldToIndex,
         loadImageToCanvas,
         renderToCanvas,
@@ -1903,7 +1914,8 @@ declare namespace utilities {
         getSliceRange,
         snapFocalPointToSlice,
         getImageSliceDataForVolumeViewport,
-        isImageActor
+        isImageActor,
+        getViewportsWithImageURI
     }
 }
 export { utilities }
@@ -2167,11 +2179,15 @@ export class VolumeViewport extends Viewport implements IVolumeViewport {
     // (undocumented)
     getFrameOfReferenceUID: () => string;
     // (undocumented)
-    getImageData(): IImageData | undefined;
+    getImageData(volumeId?: string): IImageData | undefined;
     // (undocumented)
     getIntensityFromWorld(point: Point3): number;
     // (undocumented)
     getSlabThickness(): number;
+    // (undocumented)
+    hasImageURI: (imageURI: string) => boolean;
+    // (undocumented)
+    hasVolumeId(volumeId: string): boolean;
     // (undocumented)
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
     // (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -830,6 +830,7 @@ interface IStackViewport extends IViewport {
     getFrameOfReferenceUID: () => string;
     getImageData(): IImageData | CPUIImageData;
     getImageIds: () => string[];
+    getImageURIIndex: (imageURI: string) => number;
     getProperties: () => StackViewportProperties;
     getRenderer(): any;
     hasImageId: (imageId: string) => boolean;
@@ -991,11 +992,13 @@ interface IVolumeViewport extends IViewport {
     getCurrentImageIdIndex: () => number;
     // (undocumented)
     getFrameOfReferenceUID: () => string;
-    getImageData(): IImageData | undefined;
+    getImageData(volumeId?: string): IImageData | undefined;
     getIntensityFromWorld(point: Point3): number;
     // (undocumented)
     getProperties: () => any;
     getSlabThickness(): number;
+    hasImageURI: (imageURI: string) => boolean;
+    hasVolumeId: (volumeId: string) => boolean;
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
     resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
     setBlendMode(

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -830,7 +830,6 @@ interface IStackViewport extends IViewport {
     getFrameOfReferenceUID: () => string;
     getImageData(): IImageData | CPUIImageData;
     getImageIds: () => string[];
-    getImageURIIndex: (imageURI: string) => number;
     getProperties: () => StackViewportProperties;
     getRenderer(): any;
     hasImageId: (imageId: string) => boolean;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2266,6 +2266,7 @@ interface IStackViewport extends IViewport {
     getFrameOfReferenceUID: () => string;
     getImageData(): IImageData | CPUIImageData;
     getImageIds: () => string[];
+    getImageURIIndex: (imageURI: string) => number;
     getProperties: () => StackViewportProperties;
     getRenderer(): any;
     hasImageId: (imageId: string) => boolean;
@@ -2510,11 +2511,13 @@ interface IVolumeViewport extends IViewport {
     getCurrentImageIdIndex: () => number;
     // (undocumented)
     getFrameOfReferenceUID: () => string;
-    getImageData(): IImageData | undefined;
+    getImageData(volumeId?: string): IImageData | undefined;
     getIntensityFromWorld(point: Point3): number;
     // (undocumented)
     getProperties: () => any;
     getSlabThickness(): number;
+    hasImageURI: (imageURI: string) => boolean;
+    hasVolumeId: (volumeId: string) => boolean;
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
     resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
     setBlendMode(

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2266,7 +2266,6 @@ interface IStackViewport extends IViewport {
     getFrameOfReferenceUID: () => string;
     getImageData(): IImageData | CPUIImageData;
     getImageIds: () => string[];
-    getImageURIIndex: (imageURI: string) => number;
     getProperties: () => StackViewportProperties;
     getRenderer(): any;
     hasImageId: (imageId: string) => boolean;

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -2217,15 +2217,6 @@ class StackViewport extends Viewport implements IStackViewport {
     return this.targetImageIdIndex;
   };
 
-  /* A function that takes an imageURI as an argument and returns
-   *  the index of that imageURI in the imageIds array.
-   * @param imageURI - the imageURI to search for
-   */
-  public getImageURIIndex = (imageURI: string): number => {
-    const imageURIs = this.imageIds.map(imageIdToURI);
-    return imageURIs.indexOf(imageURI);
-  };
-
   /**
    * Returns the list of image Ids for the current viewport
    * @returns list of strings for image Ids

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -2217,6 +2217,15 @@ class StackViewport extends Viewport implements IStackViewport {
     return this.targetImageIdIndex;
   };
 
+  /* A function that takes an imageURI as an argument and returns
+   *  the index of that imageURI in the imageIds array.
+   * @param imageURI - the imageURI to search for
+   */
+  public getImageURIIndex = (imageURI: string): number => {
+    const imageURIs = this.imageIds.map(imageIdToURI);
+    return imageURIs.indexOf(imageURI);
+  };
+
   /**
    * Returns the list of image Ids for the current viewport
    * @returns list of strings for image Ids

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -753,6 +753,16 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
     return this._getImageIdIndex();
   };
 
+  /*
+   * Checking if the imageURI is in the volumes that are being
+   * rendered by the viewport. imageURI is the imageId without the schema
+   * for instance for the imageId of streaming-wadors:http://..., the http://... is the imageURI.
+   * Why we don't check the imageId is because the same image can be shown in
+   * another viewport (StackViewport) with a different schema
+   *
+   * @param imageURI - The imageURI to check
+   * @returns True if the imageURI is in the volumes that are being rendered by the viewport
+   */
   public hasImageURI = (imageURI: string): boolean => {
     const volumeActors = this.getActors().filter(({ actor }) =>
       actor.isA('vtkVolume')

--- a/packages/core/src/types/IStackViewport.ts
+++ b/packages/core/src/types/IStackViewport.ts
@@ -67,6 +67,11 @@ export default interface IStackViewport extends IViewport {
    * Returns the currently rendered imageId
    */
   getCurrentImageId: () => string;
+
+  /**
+   * returns the index of the imageURI in the imageIds array
+   */
+  getImageURIIndex: (imageURI: string) => number;
   /**
    * Custom rendering pipeline for the rendering for the CPU fallback
    */

--- a/packages/core/src/types/IStackViewport.ts
+++ b/packages/core/src/types/IStackViewport.ts
@@ -69,10 +69,6 @@ export default interface IStackViewport extends IViewport {
   getCurrentImageId: () => string;
 
   /**
-   * returns the index of the imageURI in the imageIds array
-   */
-  getImageURIIndex: (imageURI: string) => number;
-  /**
    * Custom rendering pipeline for the rendering for the CPU fallback
    */
   customRenderViewportToCanvas: () => {

--- a/packages/core/src/types/IVolumeViewport.ts
+++ b/packages/core/src/types/IVolumeViewport.ts
@@ -31,6 +31,20 @@ export default interface IVolumeViewport extends IViewport {
    * If so, it uses the origin and focalPoint to calculate the slice index.
    */
   getCurrentImageIdIndex: () => number;
+
+  /**
+   * Checks if the viewport has a volume actor with the given volumeId
+   * @param volumeId - the volumeId to look for
+   * @returns Boolean indicating if the volume is present in the viewport
+   */
+  hasVolumeId: (volumeId: string) => boolean;
+
+  /**
+   * if the volume viewport has imageURI (no loader schema)
+   * in one of its volume actors
+   */
+  hasImageURI: (imageURI: string) => boolean;
+
   /**
    * Uses viewport camera and volume actor to decide if the viewport
    * is looking at the volume in the direction of acquisition (imageIds).
@@ -111,6 +125,12 @@ export default interface IVolumeViewport extends IViewport {
    * Returns the image and its properties that is being shown inside the
    * stack viewport. It returns, the image dimensions, image direction,
    * image scalar data, vtkImageData object, metadata, and scaling (e.g., PET suvbw)
+   * Note: since the volume viewport supports fusion, to get the
+   * image data for a specific volume, use the optional volumeId
+   * argument.
+   *
+   * @param volumeId - The volumeId of the volume to get the image for.
+   * @returns IImageData: {dimensions, direction, scalarData, vtkImageData, metadata, scaling}
    */
-  getImageData(): IImageData | undefined;
+  getImageData(volumeId?: string): IImageData | undefined;
 }

--- a/packages/core/src/types/IVolumeViewport.ts
+++ b/packages/core/src/types/IVolumeViewport.ts
@@ -34,8 +34,6 @@ export default interface IVolumeViewport extends IViewport {
 
   /**
    * Checks if the viewport has a volume actor with the given volumeId
-   * @param volumeId - the volumeId to look for
-   * @returns Boolean indicating if the volume is present in the viewport
    */
   hasVolumeId: (volumeId: string) => boolean;
 
@@ -128,9 +126,6 @@ export default interface IVolumeViewport extends IViewport {
    * Note: since the volume viewport supports fusion, to get the
    * image data for a specific volume, use the optional volumeId
    * argument.
-   *
-   * @param volumeId - The volumeId of the volume to get the image for.
-   * @returns IImageData: {dimensions, direction, scalarData, vtkImageData, metadata, scaling}
    */
   getImageData(volumeId?: string): IImageData | undefined;
 }

--- a/packages/core/src/utilities/getViewportsWithImageURI.ts
+++ b/packages/core/src/utilities/getViewportsWithImageURI.ts
@@ -1,0 +1,46 @@
+import { getRenderingEngine } from '../RenderingEngine';
+import { getRenderingEngines } from '../RenderingEngine/getRenderingEngine';
+import { IStackViewport, IVolumeViewport } from '../types';
+
+type Viewport = IStackViewport | IVolumeViewport;
+
+/**
+ * Get the viewport that is rendering the image with the given imageURI (imageId without
+ * the loader schema), this can be a stackViewport or a volumeViewport.
+ *
+ * @param renderingEngine - The rendering engine that is rendering the viewports
+ * @param imageURI - The imageURI of the image that is requested
+ * @returns A Viewport
+ */
+export default function getViewportsWithImageURI(
+  imageURI: string,
+  renderingEngineId?: string
+): Array<Viewport> {
+  // If rendering engine is not provided, use all rendering engines
+  let renderingEngines;
+  if (renderingEngineId) {
+    renderingEngines = [getRenderingEngine(renderingEngineId)];
+  } else {
+    renderingEngines = getRenderingEngines();
+  }
+
+  const viewports = [];
+  renderingEngines.forEach((renderingEngine) => {
+    const stackViewports = renderingEngine.getStackViewports();
+
+    const filteredStackViewports = stackViewports.filter((viewport) =>
+      viewport.hasImageURI(imageURI)
+    );
+
+    // If no stack viewport found but a volumeViewport is rendering the same data
+    const volumeViewports = renderingEngine.getVolumeViewports();
+
+    const filteredVolumeViewports = volumeViewports.filter((viewport) =>
+      viewport.hasImageURI(imageURI)
+    );
+
+    viewports.push(...filteredStackViewports, ...filteredVolumeViewports);
+  });
+
+  return viewports;
+}

--- a/packages/core/src/utilities/getViewportsWithVolumeId.ts
+++ b/packages/core/src/utilities/getViewportsWithVolumeId.ts
@@ -10,7 +10,7 @@ import {
  *
  * @returns VolumeViewport viewports array
  */
-function getVolumeViewportsContainingVolumeId(
+function getViewportsWithVolumeId(
   volumeId: string,
   renderingEngineId?: string
 ): Array<IVolumeViewport> {
@@ -22,20 +22,17 @@ function getVolumeViewportsContainingVolumeId(
     renderingEngines = getRenderingEngines();
   }
 
-  const sameVolumeViewports = [];
+  const targetViewports = [];
 
   renderingEngines.forEach((renderingEngine) => {
     const viewports = renderingEngine.getVolumeViewports();
-    const filteredViewports = viewports.filter((vp) => {
-      const actorEntries = vp.getActors();
-      return actorEntries.some(
-        (actorEntry) => actorEntry.actor && actorEntry.uid === volumeId
-      );
-    });
-    sameVolumeViewports.push(...filteredViewports);
+    const filteredViewports = viewports.filter((vp) =>
+      vp.hasVolumeId(volumeId)
+    );
+    targetViewports.push(...filteredViewports);
   });
 
-  return sameVolumeViewports;
+  return targetViewports;
 }
 
-export default getVolumeViewportsContainingVolumeId;
+export default getViewportsWithVolumeId;

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -16,7 +16,7 @@ import getTargetVolumeAndSpacingInNormalDir from './getTargetVolumeAndSpacingInN
 import getVolumeActorCorners from './getVolumeActorCorners';
 import indexWithinDimensions from './indexWithinDimensions';
 import getVolumeViewportsContainingSameVolumes from './getVolumeViewportsContainingSameVolumes';
-import getVolumeViewportsContainingVolumeId from './getVolumeViewportsContainingVolumeId';
+import getViewportsWithVolumeId from './getViewportsWithVolumeId';
 import transformWorldToIndex from './transformWorldToIndex';
 import loadImageToCanvas from './loadImageToCanvas';
 import renderToCanvas from './renderToCanvas';
@@ -26,6 +26,7 @@ import getSliceRange from './getSliceRange';
 import snapFocalPointToSlice from './snapFocalPointToSlice';
 import getImageSliceDataForVolumeViewport from './getImageSliceDataForVolumeViewport';
 import isImageActor from './isImageActor';
+import getViewportsWithImageURI from './getViewportsWithImageURI';
 
 // name spaces
 import * as planar from './planar';
@@ -52,7 +53,7 @@ export {
   getVolumeActorCorners,
   indexWithinDimensions,
   getVolumeViewportsContainingSameVolumes,
-  getVolumeViewportsContainingVolumeId,
+  getViewportsWithVolumeId,
   transformWorldToIndex,
   loadImageToCanvas,
   renderToCanvas,
@@ -62,4 +63,5 @@ export {
   snapFocalPointToSlice,
   getImageSliceDataForVolumeViewport,
   isImageActor,
+  getViewportsWithImageURI,
 };

--- a/packages/core/test/volumeViewport_gpu_render_test.js
+++ b/packages/core/test/volumeViewport_gpu_render_test.js
@@ -496,7 +496,7 @@ describe('Volume Viewport GPU -- ', () => {
 
       element.addEventListener(Events.IMAGE_RENDERED, () => {
         const viewport = this.renderingEngine.getViewport(viewportId);
-        const viewports = utilities.getVolumeViewportsContainingVolumeId(
+        const viewports = utilities.getViewportsWithVolumeId(
           volumeId,
           this.renderingEngine.id
         );

--- a/packages/streaming-image-volume-loader/src/helpers/autoLoad.ts
+++ b/packages/streaming-image-volume-loader/src/helpers/autoLoad.ts
@@ -38,7 +38,7 @@ function getRenderingEngineAndViewportsContainingVolume(
 
   for (let i = 0; i < renderingEnginesArray.length; i++) {
     const renderingEngine = renderingEnginesArray[i];
-    const viewports = utilities.getVolumeViewportsContainingVolumeId(
+    const viewports = utilities.getViewportsWithVolumeId(
       volumeId,
       renderingEngine.id
     );

--- a/packages/tools/examples/stackToVolumeWithAnnotations/_setViewports.ts
+++ b/packages/tools/examples/stackToVolumeWithAnnotations/_setViewports.ts
@@ -1,0 +1,114 @@
+import {
+  Types,
+  Enums,
+  volumeLoader,
+  setVolumesForViewports,
+  CONSTANTS,
+  utilities,
+  cache,
+} from '@cornerstonejs/core';
+import { StreamingImageVolume } from '@cornerstonejs/streaming-image-volume-loader';
+import { Types as cstTypes } from '@cornerstonejs/tools';
+
+const { ViewportType } = Enums;
+const { ORIENTATION } = CONSTANTS;
+const VOLUME_LOADER_SCHEME = 'streaming-wadors';
+
+function _convertVolumeToStackViewport(
+  renderingEngine: Types.IRenderingEngine,
+  viewport: Types.IVolumeViewport,
+  toolGroup: cstTypes.IToolGroup
+): void {
+  const { id, element } = viewport;
+
+  // Create a stack viewport
+  const viewportInput = {
+    viewportId: id,
+    type: ViewportType.STACK,
+    element,
+    defaultOptions: {
+      background: <Types.Point3>[0.4, 0, 0.4],
+    },
+  };
+
+  renderingEngine.enableElement(viewportInput);
+
+  // Set the tool group on the viewport
+  toolGroup.addViewport(id, renderingEngine.id);
+
+  // Get the stack viewport that was created
+  const stackViewport = <Types.IStackViewport>renderingEngine.getViewport(id);
+
+  const actorEntry = viewport.getDefaultActor();
+  const { uid: volumeId } = actorEntry;
+  const volume = cache.getVolume(volumeId) as StreamingImageVolume;
+
+  const imageIds = volume.imageIds;
+
+  // if this is the first time decaching do it
+  if (!cache.getImageLoadObject(imageIds[0])) {
+    volume.decache();
+  }
+
+  const stack = volume.imageIds;
+
+  // Set the stack on the viewport
+  const currentIndex = Math.floor(stack.length / 2);
+  stackViewport.setStack(stack, currentIndex);
+
+  // Render the image
+  viewport.render();
+}
+
+async function _convertStackToVolumeViewport(
+  renderingEngine: Types.IRenderingEngine,
+  viewport: Types.IStackViewport,
+  toolGroup: cstTypes.IToolGroup
+): Promise<void> {
+  // Define a unique id for the volume
+  const volumeName = 'CT_VOLUME_ID'; // Id of the volume less loader prefix
+  const volumeLoaderScheme = 'cornerstoneStreamingImageVolume'; // Loader id which defines which volume loader to use
+  const volumeId = `${volumeLoaderScheme}:${volumeName}`; // VolumeId with loader id + volume id
+
+  const { id, element } = viewport;
+
+  let imageIds = viewport.getImageIds();
+  imageIds = imageIds.map((imageId) => {
+    const imageURI = utilities.imageIdToURI(imageId);
+    return `${VOLUME_LOADER_SCHEME}:${imageURI}`;
+  });
+
+  const viewportInputArray = [
+    {
+      viewportId: id,
+      type: ViewportType.ORTHOGRAPHIC,
+      element,
+      defaultOptions: {
+        orientation: ORIENTATION.AXIAL,
+        background: <Types.Point3>[0.2, 0.4, 0.2],
+      },
+    },
+  ];
+
+  renderingEngine.setViewports(viewportInputArray);
+
+  // we need to add back the viewport to the toolGroup since volume viewport
+  // is replacing the stack viewport, and on stackViewport destroy, the toolGroup
+  // will remove the viewport from the toolGroup
+  toolGroup.addViewport(id, renderingEngine.id);
+
+  // Define a volume in memory
+  const volume = await volumeLoader.createAndCacheVolume(volumeId, {
+    imageIds,
+  });
+
+  // Set the volume to load
+  volume.load();
+
+  setVolumesForViewports(renderingEngine, [{ volumeId }], [id]);
+
+  // Render the image
+  renderingEngine.renderViewports([id]);
+}
+
+export { _convertStackToVolumeViewport, _convertVolumeToStackViewport };

--- a/packages/tools/examples/stackToVolumeWithAnnotations/index.ts
+++ b/packages/tools/examples/stackToVolumeWithAnnotations/index.ts
@@ -1,0 +1,222 @@
+import {
+  RenderingEngine,
+  Types,
+  Enums,
+  getRenderingEngine,
+} from '@cornerstonejs/core';
+import {
+  initDemo,
+  createImageIdsAndCacheMetaData,
+  setTitleAndDescription,
+  addDropdownToToolbar,
+  addButtonToToolbar,
+} from '../../../../utils/demo/helpers';
+import * as cornerstoneTools from '@cornerstonejs/tools';
+import {
+  _convertVolumeToStackViewport,
+  _convertStackToVolumeViewport,
+} from './_setViewports';
+
+// This is for debugging purposes
+console.warn(
+  'Click on index.ts to open source code for this example --------->'
+);
+
+const {
+  LengthTool,
+  ProbeTool,
+  RectangleROITool,
+  EllipticalROITool,
+  BidirectionalTool,
+  AngleTool,
+  ToolGroupManager,
+  ArrowAnnotateTool,
+  StackScrollMouseWheelTool,
+  Enums: csToolsEnums,
+} = cornerstoneTools;
+
+const { ViewportType } = Enums;
+const { MouseBindings } = csToolsEnums;
+
+// ======== Set up page ======== //
+setTitleAndDescription(
+  'Stack and VolumeViewport conversions',
+  'In this demo, you see how the stack and volume viewport conversions work. The purple background represents a StackViewport while the green background represents a VolumeViewport. You can start annotating the images and annotations will be rendered correctly regardless of the viewport they were drawn on.'
+);
+
+const content = document.getElementById('content');
+const element = document.createElement('div');
+
+// Disable right click context menu so we can have right click tools
+element.oncontextmenu = (e) => e.preventDefault();
+
+element.id = 'cornerstone-element';
+element.style.width = '500px';
+element.style.height = '500px';
+
+content.appendChild(element);
+
+const instructions = document.createElement('p');
+instructions.innerText = 'Left Click to use selected tool';
+
+content.append(instructions);
+// ============================= //
+
+const toolGroupId = 'STACK_TOOL_GROUP_ID';
+
+const toolsNames = [
+  LengthTool.toolName,
+  ProbeTool.toolName,
+  RectangleROITool.toolName,
+  EllipticalROITool.toolName,
+  BidirectionalTool.toolName,
+  AngleTool.toolName,
+  ArrowAnnotateTool.toolName,
+];
+let selectedToolName = toolsNames[0];
+const renderingEngineId = 'myRenderingEngine';
+const viewportId = 'CT_VIEWPORT';
+let toolGroup;
+
+addDropdownToToolbar({
+  options: { values: toolsNames, defaultValue: selectedToolName },
+  onSelectedValueChange: (newSelectedToolNameAsStringOrNumber) => {
+    const newSelectedToolName = String(newSelectedToolNameAsStringOrNumber);
+
+    // Set the new tool active
+    toolGroup.setToolActive(newSelectedToolName, {
+      bindings: [
+        {
+          mouseButton: MouseBindings.Primary, // Left Click
+        },
+      ],
+    });
+
+    // Set the old tool passive
+    toolGroup.setToolPassive(selectedToolName);
+
+    selectedToolName = <string>newSelectedToolName;
+  },
+});
+
+addButtonToToolbar({
+  title: 'Switch StackViewport to VolumeViewport, and vice versa',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    const viewport = renderingEngine.getViewport(viewportId);
+
+    if (viewport.type === ViewportType.STACK) {
+      _convertStackToVolumeViewport(
+        renderingEngine,
+        viewport as Types.IStackViewport,
+        toolGroup
+      );
+      return;
+    }
+
+    // convert to stack
+    _convertVolumeToStackViewport(
+      renderingEngine,
+      viewport as Types.IVolumeViewport,
+      toolGroup
+    );
+  },
+});
+
+/**
+ * Runs the demo
+ */
+async function run() {
+  // Init Cornerstone and related libraries
+  await initDemo();
+
+  // Add tools to Cornerstone3D
+  cornerstoneTools.addTool(LengthTool);
+  cornerstoneTools.addTool(ProbeTool);
+  cornerstoneTools.addTool(RectangleROITool);
+  cornerstoneTools.addTool(EllipticalROITool);
+  cornerstoneTools.addTool(BidirectionalTool);
+  cornerstoneTools.addTool(AngleTool);
+  cornerstoneTools.addTool(ArrowAnnotateTool);
+  cornerstoneTools.addTool(StackScrollMouseWheelTool);
+
+  // Define a tool group, which defines how mouse events map to tool commands for
+  // Any viewport using the group
+  toolGroup = ToolGroupManager.createToolGroup(toolGroupId);
+
+  // Add the tools to the tool group
+  toolGroup.addTool(LengthTool.toolName);
+  toolGroup.addTool(ProbeTool.toolName);
+  toolGroup.addTool(RectangleROITool.toolName);
+  toolGroup.addTool(EllipticalROITool.toolName);
+  toolGroup.addTool(BidirectionalTool.toolName);
+  toolGroup.addTool(AngleTool.toolName);
+  toolGroup.addTool(ArrowAnnotateTool.toolName);
+  toolGroup.addTool(StackScrollMouseWheelTool.toolName);
+
+  // Set the initial state of the tools, here we set one tool active on left click.
+  // This means left click will draw that tool.
+  toolGroup.setToolActive(LengthTool.toolName, {
+    bindings: [
+      {
+        mouseButton: MouseBindings.Primary, // Left Click
+      },
+    ],
+  });
+  // We set all the other tools passive here, this means that any state is rendered, and editable
+  // But aren't actively being drawn (see the toolModes example for information)
+  toolGroup.setToolActive(StackScrollMouseWheelTool.toolName);
+  toolGroup.setToolPassive(ProbeTool.toolName);
+  toolGroup.setToolPassive(RectangleROITool.toolName);
+  toolGroup.setToolPassive(EllipticalROITool.toolName);
+  toolGroup.setToolPassive(BidirectionalTool.toolName);
+  toolGroup.setToolPassive(AngleTool.toolName);
+  toolGroup.setToolPassive(ArrowAnnotateTool.toolName);
+
+  // Get Cornerstone imageIds and fetch metadata into RAM
+  const imageIds = await createImageIdsAndCacheMetaData({
+    StudyInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463',
+    SeriesInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561',
+    wadoRsRoot: 'https://d3t6nz73ql33tx.cloudfront.net/dicomweb',
+    type: 'STACK',
+  });
+
+  // Instantiate a rendering engine
+  const renderingEngine = new RenderingEngine(renderingEngineId);
+
+  // Create a stack viewport
+  const viewportInput = {
+    viewportId,
+    type: ViewportType.STACK,
+    element,
+    defaultOptions: {
+      background: <Types.Point3>[0.4, 0, 0.4],
+    },
+  };
+
+  renderingEngine.enableElement(viewportInput);
+
+  // Set the tool group on the viewport
+  toolGroup.addViewport(viewportId, renderingEngineId);
+
+  // Get the stack viewport that was created
+  const viewport = <Types.IStackViewport>(
+    renderingEngine.getViewport(viewportId)
+  );
+
+  // Define a stack containing a single image
+  const stack = imageIds;
+
+  // Set the stack on the viewport
+  const currentIndex = Math.floor(stack.length / 2);
+  viewport.setStack(stack, currentIndex);
+
+  // Render the image
+  viewport.render();
+}
+
+run();

--- a/packages/tools/src/tools/WindowLevelTool.ts
+++ b/packages/tools/src/tools/WindowLevelTool.ts
@@ -60,11 +60,10 @@ class WindowLevelTool extends BaseTool {
       const actorEntry = viewport.getActor(volumeId);
       volumeActor = actorEntry.actor as Types.VolumeActor;
       rgbTransferFunction = volumeActor.getProperty().getRGBTransferFunction(0);
-      viewportsContainingVolumeUID =
-        utilities.getVolumeViewportsContainingVolumeId(
-          volumeId,
-          renderingEngine.id
-        );
+      viewportsContainingVolumeUID = utilities.getViewportsWithVolumeId(
+        volumeId,
+        renderingEngine.id
+      );
       [lower, upper] = rgbTransferFunction.getRange();
       const volume = cache.getVolume(volumeId);
       modality = volume.metadata.Modality;

--- a/packages/tools/src/tools/annotation/BidirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/BidirectionalTool.ts
@@ -1211,6 +1211,13 @@ class BidirectionalTool extends AnnotationTool {
 
       const image = this.getTargetIdImage(targetId, renderingEngine);
 
+      // If image does not exists for the targetId, skip. This can be due
+      // to various reasons such as if the target was a volumeViewport, and
+      // the volumeViewport has been decached in the meantime.
+      if (!image) {
+        continue;
+      }
+
       const { imageData, dimensions, hasPixelSpacing } = image;
 
       const dist1 = this._calculateLength(worldPos1, worldPos2);

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -977,6 +977,13 @@ class EllipticalROITool extends AnnotationTool {
 
       const image = this.getTargetIdImage(targetId, renderingEngine);
 
+      // If image does not exists for the targetId, skip. This can be due
+      // to various reasons such as if the target was a volumeViewport, and
+      // the volumeViewport has been decached in the meantime.
+      if (!image) {
+        continue;
+      }
+
       const { dimensions, imageData, metadata, hasPixelSpacing } = image;
 
       const worldPos1Index = transformWorldToIndex(imageData, worldPos1);

--- a/packages/tools/src/tools/annotation/LengthTool.ts
+++ b/packages/tools/src/tools/annotation/LengthTool.ts
@@ -767,6 +767,13 @@ class LengthTool extends AnnotationTool {
 
       const image = this.getTargetIdImage(targetId, renderingEngine);
 
+      // If image does not exists for the targetId, skip. This can be due
+      // to various reasons such as if the target was a volumeViewport, and
+      // the volumeViewport has been decached in the meantime.
+      if (!image) {
+        continue;
+      }
+
       const { imageData, dimensions, hasPixelSpacing } = image;
 
       const length = this._calculateLength(worldPos1, worldPos2);

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -7,7 +7,7 @@ import {
   triggerEvent,
   eventTarget,
   utilities as csUtils,
-  getRenderingEngine,
+  utilities,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -605,6 +605,13 @@ class ProbeTool extends AnnotationTool {
 
       const image = this.getTargetIdImage(targetId, renderingEngine);
 
+      // If image does not exists for the targetId, skip. This can be due
+      // to various reasons such as if the target was a volumeViewport, and
+      // the volumeViewport has been decached in the meantime.
+      if (!image) {
+        continue;
+      }
+
       const { dimensions, scalarData, imageData, metadata } = image;
 
       const modality = metadata.Modality;
@@ -625,10 +632,15 @@ class ProbeTool extends AnnotationTool {
         // Index[2] for stackViewport is always 0, but for visualization
         // we reset it to be imageId index
         if (targetId.startsWith('imageId:')) {
-          const renderingEngine = getRenderingEngine(renderingEngineId);
-          const viewports = renderingEngine.getStackViewports();
           const imageId = targetId.split('imageId:')[1];
-          const viewport = viewports.find((vp) => vp.hasImageId(imageId));
+          const imageURI = csUtils.imageIdToURI(imageId);
+          const viewports = utilities.getViewportsWithImageURI(
+            imageURI,
+            renderingEngineId
+          );
+
+          const viewport = viewports[0];
+
           index[2] = viewport.getCurrentImageIdIndex();
         }
 

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -892,6 +892,13 @@ class RectangleROITool extends AnnotationTool {
 
       const image = this.getTargetIdImage(targetId, renderingEngine);
 
+      // If image does not exists for the targetId, skip. This can be due
+      // to various reasons such as if the target was a volumeViewport, and
+      // the volumeViewport has been decached in the meantime.
+      if (!image) {
+        continue;
+      }
+
       const { dimensions, scalarData, imageData, metadata, hasPixelSpacing } =
         image;
 

--- a/utils/ExampleRunner/example-info.json
+++ b/utils/ExampleRunner/example-info.json
@@ -168,6 +168,10 @@
         "name": "Shared Tool State",
         "description": "Demonstrates that annotations are stored on frame of reference, and can therefore be shared between Stack and Volume Viewports."
       },
+      "stackToVolumeWithAnnotations": {
+        "name": "StackViewport <--> VolumeViewport ",
+        "description": "Demonstrates how annotations are preserved and rendered correctly even when a stack viewport is converted to a volume viewport and vice versa. This is an advanced usage for MPR"
+      },
       "volumeViewportSynchronization": {
         "name": "Volume Viewport Synchronization",
         "description": "Demonstrates how to set up synchronization between viewports for viewport-level (e.g. camera) and actor-level (e.g. VOI) properties."


### PR DESCRIPTION
This fixes the problem where stack viewport is converted to a volume viewport, but annotations cannot render and throws error. 

- New Demo https://deploy-preview-195--cornerstone-3d-docs.netlify.app/live-examples/stacktovolumewithannotations