### PR TITLE
fix(rgba): Handle rgba to rgb conversion based on length

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -64,6 +64,7 @@ import {
 import cache from '../cache';
 import correctShift from './helpers/cpuFallback/rendering/correctShift';
 import { ImageActor } from '../types/IActor';
+import isRgbaSourceRgbDest from './helpers/isRgbaSourceRgbDest';
 
 const EPSILON = 1; // Slice Thickness
 
@@ -1341,7 +1342,7 @@ class StackViewport extends Viewport implements IStackViewport {
     const scalars = this._imageData.getPointData().getScalars();
     const scalarData = scalars.getData() as Uint8Array | Float32Array;
 
-    if (image.rgba || pixelData.length * 3 == scalarData.byteLength * 4) {
+    if (image.rgba || isRgbaSourceRgbDest(pixelData, scalarData.byteLength)) {
       if (!image.rgba) {
         console.warn('rgba not specified but data looks rgba ish', image);
       }

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1341,7 +1341,10 @@ class StackViewport extends Viewport implements IStackViewport {
     const scalars = this._imageData.getPointData().getScalars();
     const scalarData = scalars.getData() as Uint8Array | Float32Array;
 
-    if (image.rgba) {
+    if (image.rgba || pixelData.length * 3 == scalarData.byteLength * 4) {
+      if (!image.rgba) {
+        console.warn('rgba not specified but data looks rgba ish', image);
+      }
       // if image is already cached with rgba for any reason (cpu fallback),
       // we need to convert it to rgb for the pixel data set
       // RGB case

--- a/packages/core/src/RenderingEngine/helpers/isRgbaSourceRgbDest.ts
+++ b/packages/core/src/RenderingEngine/helpers/isRgbaSourceRgbDest.ts
@@ -1,0 +1,1 @@
+export default (src, dest) => src.length * 3 === dest.byteLength * 4;


### PR DESCRIPTION
This is a work around for the rgba flag not being set correctly and when we have rgba data but need rgb.