### PR TITLE
fix: Add storeAsInitialCamera parameter to StackViewport setCamera

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1764,7 +1764,7 @@ export class StackViewport extends Viewport implements IStackViewport {
     // (undocumented)
     setActors(actors: Array<ActorEntry>): void;
     // (undocumented)
-    setCamera(cameraInterface: ICamera): void;
+    setCamera(cameraInterface: ICamera, storeAsInitialCamera?: boolean): void;
     // (undocumented)
     setColormap(colormap: CPUFallbackColormapData): void;
     // (undocumented)

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -620,11 +620,14 @@ class StackViewport extends Viewport implements IStackViewport {
    * @param cameraInterface - The camera interface that will be used to
    * render the scene.
    */
-  public setCamera(cameraInterface: ICamera): void {
+  public setCamera(
+    cameraInterface: ICamera,
+    storeAsInitialCamera = false
+  ): void {
     if (this.useCPURendering) {
       this.setCameraCPU(cameraInterface);
     } else {
-      super.setCamera(cameraInterface);
+      super.setCamera(cameraInterface, storeAsInitialCamera);
     }
   }
 


### PR DESCRIPTION
While reading the API documentation on [`StackViewport.setZoom`](https://www.cornerstonejs.org/api/core/class/StackViewport#setZoom) I wanted to try out the `storeAsInitialCamera` parameter, but I noticed it wasn't working. Upon further inspection I realized it was due to the fact that, even though `Viewport.setCamera` has said parameter, `StackViewport` doesn't, so the the value is never passed down to the super class.

Please note that I purposely omitted the parameter from the call to `this.setCameraCPU` given that I believe it is not used anywhere. Not sure if this is the correct take though, so let me know if this requires further work.