### PR TITLE
feat: add data-id to some svg elements for e2e tests - need to add more

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -40,7 +40,7 @@ type ActorSliceRange = {
 };
 
 // @public (undocumented)
-function addAnnotation(element: HTMLDivElement, annotation: Annotation): void;
+function addAnnotation(element: HTMLDivElement, annotation: Annotation): string;
 
 // @public (undocumented)
 const addCanvasPointsToArray: (element: HTMLDivElement, canvasPoints: Types_2.Point2[], newCanvasPoint: Types_2.Point2, commonData: PlanarFreehandROICommonData) => number;
@@ -1298,7 +1298,7 @@ declare namespace drawing_2 {
 }
 
 // @public (undocumented)
-function drawLine(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, lineUID: string, start: Types_2.Point2, end: Types_2.Point2, options?: {}): void;
+function drawLine(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, lineUID: string, start: Types_2.Point2, end: Types_2.Point2, options?: {}, dataId?: string): void;
 
 // @public (undocumented)
 function drawLinkedTextBox(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, textBoxUID: string, textLines: Array<string>, textBoxPosition: Types_2.Point2, annotationAnchorPoints: Array<Types_2.Point2>, textBox: unknown, options?: {}): SVGRect;
@@ -1313,7 +1313,7 @@ function drawPolyline(svgDrawingHelper: SVGDrawingHelper, annotationUID: string,
 }): void;
 
 // @public (undocumented)
-function drawRect(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, rectangleUID: string, start: Types_2.Point2, end: Types_2.Point2, options?: {}): void;
+function drawRect(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, rectangleUID: string, start: Types_2.Point2, end: Types_2.Point2, options?: {}, dataId?: string): void;
 
 // @public (undocumented)
 function drawTextBox(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, textUID: string, textLines: Array<string>, position: Types_2.Point2, options?: {}): SVGRect;
@@ -1660,6 +1660,10 @@ class FrameOfReferenceSpecificAnnotationManager {
     // (undocumented)
     getFramesOfReference: () => Array<string>;
     // (undocumented)
+    getNumberOfAnnotations: (toolName: string, frameOfReferenceUID?: string) => number;
+    // (undocumented)
+    getNumberOfAnnotationsInFrameOfReference: (toolName: string, frameOfReferenceUID: string) => number;
+    // (undocumented)
     _imageVolumeModifiedHandler: (evt: Types_2.EventTypes.ImageVolumeModifiedEvent) => void;
     // (undocumented)
     removeAllAnnotations: () => void;
@@ -1770,6 +1774,9 @@ function getGlobalRepresentationConfig(representationType: SegmentationRepresent
 
 // @public (undocumented)
 function getLockedSegments(segmentationId: string): number[] | [];
+
+// @public (undocumented)
+function getNumberOfAnnotations(toolName: string, frameOfReferenceUID?: string): number;
 
 // @public (undocumented)
 function getOrientationStringLPS(vector: Types_2.Point3): string;
@@ -3955,6 +3962,7 @@ type StackViewportScrollEventDetail = {
 declare namespace state {
     export {
         getAnnotations,
+        getNumberOfAnnotations,
         addAnnotation,
         getAnnotation,
         removeAnnotation,

--- a/packages/tools/src/drawingSvg/drawLine.ts
+++ b/packages/tools/src/drawingSvg/drawLine.ts
@@ -11,7 +11,8 @@ export default function drawLine(
   lineUID: string,
   start: Types.Point2,
   end: Types.Point2,
-  options = {}
+  options = {},
+  dataId = ''
 ): void {
   // if length is NaN return
   if (isNaN(start[0]) || isNaN(start[1]) || isNaN(end[0]) || isNaN(end[1])) {
@@ -55,6 +56,10 @@ export default function drawLine(
     svgDrawingHelper.setNodeTouched(svgNodeHash);
   } else {
     const newLine = document.createElementNS(svgns, 'line');
+
+    if (dataId !== '') {
+      newLine.setAttribute('data-id', dataId);
+    }
 
     _setNewAttributesIfValid(attributes, newLine);
 

--- a/packages/tools/src/drawingSvg/drawRect.ts
+++ b/packages/tools/src/drawingSvg/drawRect.ts
@@ -12,7 +12,8 @@ export default function drawRect(
   rectangleUID: string,
   start: Types.Point2,
   end: Types.Point2,
-  options = {}
+  options = {},
+  dataId = ''
 ): void {
   const {
     color,
@@ -57,6 +58,10 @@ export default function drawRect(
     svgDrawingHelper.setNodeTouched(svgNodeHash);
   } else {
     const svgRectElement = document.createElementNS(svgns, 'rect');
+
+    if (dataId !== '') {
+      svgRectElement.setAttribute('data-id', dataId);
+    }
 
     _setNewAttributesIfValid(attributes, svgRectElement);
 

--- a/packages/tools/src/stateManagement/annotation/FrameOfReferenceSpecificAnnotationManager.ts
+++ b/packages/tools/src/stateManagement/annotation/FrameOfReferenceSpecificAnnotationManager.ts
@@ -151,6 +151,59 @@ export default class FrameOfReferenceSpecificAnnotationManager {
     return toolSpecificAnnotations[index];
   };
 
+  getNumberOfAnnotationsInFrameOfReference = (
+    toolName: string,
+    frameOfReferenceUID: string
+  ): number => {
+    const annotations =
+      this.getFrameOfReferenceAnnotations(frameOfReferenceUID);
+
+    if (!annotations) {
+      return 0;
+    }
+
+    const toolSpecificAnnotations = annotations[toolName];
+
+    if (!toolSpecificAnnotations) {
+      return 0;
+    }
+
+    return toolSpecificAnnotations.length;
+  };
+
+  /**
+   * A function that returns the number of annotations for a given tool in the
+   * specific frame of reference. IF no frame of reference is provided, it will
+   * return the number of annotations for the tool in all frames of references
+   *
+   * @param toolName - The name of the tool to retrieve data for.
+   * @param frameOfReferenceUID - The UID of the FrameOfReference to retrieve data for.
+   *
+   * @returns The number of annotations for a given tool in the state
+   */
+  getNumberOfAnnotations = (
+    toolName: string,
+    frameOfReferenceUID?: string
+  ): number => {
+    if (frameOfReferenceUID) {
+      return this.getNumberOfAnnotationsInFrameOfReference(
+        toolName,
+        frameOfReferenceUID
+      );
+    }
+
+    const framesOfReference = this.getFramesOfReference();
+
+    return framesOfReference.reduce((acc, frameOfReferenceUID) => {
+      const numberOfAnnotations = this.getNumberOfAnnotationsInFrameOfReference(
+        toolName,
+        frameOfReferenceUID
+      );
+
+      return acc + numberOfAnnotations;
+    }, 0);
+  };
+
   /**
    * Adds an instance of `Annotation` to the `annotations`.
    *

--- a/packages/tools/src/stateManagement/annotation/annotationState.ts
+++ b/packages/tools/src/stateManagement/annotation/annotationState.ts
@@ -67,7 +67,10 @@ function getAnnotations(
  * @param element - HTMLDivElement
  * @param annotation - The annotation that is being added to the annotations manager.
  */
-function addAnnotation(element: HTMLDivElement, annotation: Annotation): void {
+function addAnnotation(
+  element: HTMLDivElement,
+  annotation: Annotation
+): string {
   const annotationManager = getViewportSpecificAnnotationManager(element);
 
   if (annotation.annotationUID === undefined) {
@@ -89,6 +92,29 @@ function addAnnotation(element: HTMLDivElement, annotation: Annotation): void {
   };
 
   triggerEvent(eventTarget, eventType, eventDetail);
+
+  return annotation.annotationUID;
+}
+
+/**
+ * Get the number of annotations for a given tool in the specified frame of reference.
+ * If no frame of reference is specified, it will return the number of annotations
+ * for all frames of reference.
+ *
+ * @param toolName - The name of the tool
+ * @param frameOfReferenceUID - The frame of reference UID
+ *
+ * @returns The number of annotations for a given frame of reference and tool name.
+ */
+function getNumberOfAnnotations(
+  toolName: string,
+  frameOfReferenceUID?: string
+): number {
+  const annotationManager = getDefaultAnnotationManager();
+  return annotationManager.getNumberOfAnnotations(
+    toolName,
+    frameOfReferenceUID
+  );
 }
 
 /**
@@ -157,6 +183,7 @@ function removeAllAnnotations(element?: HTMLDivElement): void {
 
 export {
   getAnnotations,
+  getNumberOfAnnotations,
   addAnnotation,
   getAnnotation,
   removeAnnotation,

--- a/packages/tools/src/stateManagement/index.js
+++ b/packages/tools/src/stateManagement/index.js
@@ -11,6 +11,7 @@ import {
   getDefaultAnnotationManager,
   getViewportSpecificAnnotationManager,
   getAnnotation,
+  getNumberOfAnnotations,
 } from './annotation/annotationState';
 
 import {
@@ -26,6 +27,7 @@ export {
   annotationSelection,
   getAnnotations,
   addAnnotation,
+  getNumberOfAnnotations,
   removeAnnotation,
   getDefaultAnnotationManager,
   getViewportSpecificAnnotationManager,

--- a/packages/tools/src/tools/annotation/BidirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/BidirectionalTool.ts
@@ -1050,6 +1050,9 @@ class BidirectionalTool extends AnnotationTool {
         );
       }
 
+      const dataId1 = `${annotationUID}-line-1`;
+      const dataId2 = `${annotationUID}-line-2`;
+
       const lineUID = '0';
       drawLineSvg(
         svgDrawingHelper,
@@ -1062,7 +1065,8 @@ class BidirectionalTool extends AnnotationTool {
           lineDash,
           lineWidth,
           shadow,
-        }
+        },
+        dataId1
       );
 
       const secondLineUID = '1';
@@ -1077,7 +1081,8 @@ class BidirectionalTool extends AnnotationTool {
           lineDash,
           lineWidth,
           shadow,
-        }
+        },
+        dataId2
       );
 
       renderStatus = true;

--- a/packages/tools/src/tools/annotation/LengthTool.ts
+++ b/packages/tools/src/tools/annotation/LengthTool.ts
@@ -667,6 +667,7 @@ class LengthTool extends AnnotationTool {
         );
       }
 
+      const dataId = `${annotationUID}-line`;
       const lineUID = '1';
       drawLineSvg(
         svgDrawingHelper,
@@ -679,7 +680,8 @@ class LengthTool extends AnnotationTool {
           width: lineWidth,
           lineDash,
           shadow,
-        }
+        },
+        dataId
       );
 
       renderStatus = true;

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -752,6 +752,7 @@ class RectangleROITool extends AnnotationTool {
         );
       }
 
+      const dataId = `${annotationUID}-rect`;
       const rectangleUID = '0';
       drawRectSvg(
         svgDrawingHelper,
@@ -763,7 +764,8 @@ class RectangleROITool extends AnnotationTool {
           color,
           lineDash,
           lineWidth,
-        }
+        },
+        dataId
       );
 
       renderStatus = true;


### PR DESCRIPTION
adding data-id attribute to svg elements for e2e frameworks to be able to select and tests annotations