### PR TITLE
GPU rendering : wrong voiRange for some multi-frame instances or multi-instance series rendered on the same viewport

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1765,6 +1765,15 @@ class StackViewport extends Viewport implements IStackViewport {
     }
 
     this.initialVOIRange = voiRange;
+
+    if (this.voiApplied && typeof voiRange === 'undefined') {
+      // There are some cases when different frames within the same multi-frame
+      // file are not hitting the actor cache because above
+      // this.__checkVTKImageDataMatchesCornerstoneImage() call results in
+      // "false".
+      // In that case we want to keep the applied VOI range.
+      voiRange = this.voiRange;
+    }
     this.setProperties({ voiRange });
 
     // At the moment it appears that vtkImageSlice actors do not automatically


### PR DESCRIPTION
On GPU Rendering mode:
When we try to render a new image on the reused viewport, but this line: https://github.com/cornerstonejs/cornerstone3D-beta/blob/6ffaee7e817843c3971502d9ec32d85716a1de15/packages/core/src/RenderingEngine/StackViewport.ts#L1648 results in false value, it will create a new rendering actor. and when it does this, and if the newly rendered image doesn't have specific VOI Range values are set, the voiRange correction won't happen, resulting in bad window level and center - on UI side it will appear as white noises.

This will possibly fix the #225

