### PR TITLE
fix(Length):Throws NPE because length is set to null (race condition)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "api-check": "lerna run api-check --stream",
     "build": "lerna run build --stream",
+    "build:umd": "lerna run build:umd --stream",
     "build:update-api": "lerna run build:update-api --stream",
     "example": "node ./utils/ExampleRunner/example-runner-cli.js",
     "all-examples": "node ./utils/ExampleRunner/build-all-examples-cli.js --fromRoot",

--- a/packages/tools/src/drawingSvg/drawTextBox.ts
+++ b/packages/tools/src/drawingSvg/drawTextBox.ts
@@ -50,7 +50,7 @@ function _drawTextGroup(
   svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
   textUID: string,
-  textLines: Array<string>,
+  textLines: Array<string> = [''],
   position: Types.Point2,
   options: any
 ): SVGRect {

--- a/packages/tools/src/tools/annotation/LengthTool.ts
+++ b/packages/tools/src/tools/annotation/LengthTool.ts
@@ -734,7 +734,8 @@ class LengthTool extends AnnotationTool {
     const cachedVolumeStats = data.cachedStats[targetId];
     const { length, unit } = cachedVolumeStats;
 
-    if (length === undefined) {
+    // Can be null on load
+    if (length === undefined || length === null || isNaN(length)) {
       return;
     }
 


### PR DESCRIPTION
On loading a DICOM SR, the length can be null, which causes a render issue.
There is still another issue on loading, which seems to render the image partially, and then doesn't complete, but this fix at least allows loading.