### PR TITLE
Issue : Cine infinite rendering loop

### DIFF
--- a/packages/tools/src/utilities/cine/playClip.ts
+++ b/packages/tools/src/utilities/cine/playClip.ts
@@ -99,13 +99,12 @@ function playClip(
   // This function encapsulates the frame rendering logic...
   const playClipAction = () => {
     // Hoisting of context variables
-    let newImageIdIndex = stackData.targetImageIdIndex;
-    
     const stackData = {
       targetImageIdIndex: viewport.getTargetImageIdIndex(),
       imageIds: viewport.getImageIds(),
     };
-
+    
+    let newImageIdIndex = stackData.targetImageIdIndex;
     const imageCount = stackData.imageIds.length;
 
     if (playClipData.reverse) {

--- a/packages/tools/src/utilities/cine/playClip.ts
+++ b/packages/tools/src/utilities/cine/playClip.ts
@@ -123,10 +123,6 @@ function playClip(
       return;
     }
 
-    // Loop around if we go outside the stack
-    if (newImageIdIndex >= imageCount) {
-      newImageIdIndex = 0;
-    }
 
     if (newImageIdIndex < 0) {
       newImageIdIndex = imageCount - 1;

--- a/packages/tools/src/utilities/cine/playClip.ts
+++ b/packages/tools/src/utilities/cine/playClip.ts
@@ -99,6 +99,10 @@ function playClip(
   // This function encapsulates the frame rendering logic...
   const playClipAction = () => {
     // Hoisting of context variables
+   const stackData = {
+            targetImageIdIndex: viewport.getTargetImageIdIndex(),
+            imageIds: viewport.getImageIds(),
+        };
     let newImageIdIndex = stackData.targetImageIdIndex;
 
     const imageCount = stackData.imageIds.length;
@@ -123,6 +127,10 @@ function playClip(
       return;
     }
 
+    // Loop around if we go outside the stack
+    if (newImageIdIndex >= imageCount) {
+      newImageIdIndex = 0;
+    }
 
     if (newImageIdIndex < 0) {
       newImageIdIndex = imageCount - 1;

--- a/packages/tools/src/utilities/cine/playClip.ts
+++ b/packages/tools/src/utilities/cine/playClip.ts
@@ -2,10 +2,10 @@ import {
   utilities,
   getEnabledElement,
   StackViewport,
-} from "@cornerstonejs/core";
-import CINE_EVENTS from "./events";
-import { addToolState, getToolState } from "./state";
-import { CINETypes } from "../../types";
+} from '@cornerstonejs/core';
+import CINE_EVENTS from './events';
+import { addToolState, getToolState } from './state';
+import { CINETypes } from '../../types';
 
 const { triggerEvent } = utilities;
 
@@ -26,14 +26,14 @@ function playClip(
   let playClipIsTimeVarying;
 
   if (element === undefined) {
-    throw new Error("playClip: element must not be undefined");
+    throw new Error('playClip: element must not be undefined');
   }
 
   const enabledElement = getEnabledElement(element);
 
   if (!enabledElement) {
     throw new Error(
-      "playClip: element must be a valid Cornerstone enabled element"
+      'playClip: element must be a valid Cornerstone enabled element'
     );
   }
 
@@ -41,7 +41,7 @@ function playClip(
 
   if (!(viewport instanceof StackViewport)) {
     throw new Error(
-      "playClip: element must be a stack viewport, volume viewport playClip not yet implemented"
+      'playClip: element must be a stack viewport, volume viewport playClip not yet implemented'
     );
   }
 
@@ -99,11 +99,12 @@ function playClip(
   // This function encapsulates the frame rendering logic...
   const playClipAction = () => {
     // Hoisting of context variables
+    let newImageIdIndex = stackData.targetImageIdIndex;
+    
     const stackData = {
       targetImageIdIndex: viewport.getTargetImageIdIndex(),
       imageIds: viewport.getImageIds(),
     };
-    let newImageIdIndex = stackData.targetImageIdIndex;
 
     const imageCount = stackData.imageIds.length;
 
@@ -211,7 +212,7 @@ function _getPlayClipTimeouts(vector: number[], speed: number) {
   // Initialize time varying to false
   let isTimeVarying = false;
 
-  if (typeof speed !== "number" || speed <= 0) {
+  if (typeof speed !== 'number' || speed <= 0) {
     speed = 1;
   }
 
@@ -252,7 +253,7 @@ function _getPlayClipTimeouts(vector: number[], speed: number) {
 function _stopClipWithData(playClipData) {
   const id = playClipData.intervalId;
 
-  if (typeof id !== "undefined") {
+  if (typeof id !== 'undefined') {
     playClipData.intervalId = undefined;
     if (playClipData.usingFrameTimeVector) {
       clearTimeout(id);

--- a/packages/tools/src/utilities/cine/playClip.ts
+++ b/packages/tools/src/utilities/cine/playClip.ts
@@ -2,10 +2,10 @@ import {
   utilities,
   getEnabledElement,
   StackViewport,
-} from '@cornerstonejs/core';
-import CINE_EVENTS from './events';
-import { addToolState, getToolState } from './state';
-import { CINETypes } from '../../types';
+} from "@cornerstonejs/core";
+import CINE_EVENTS from "./events";
+import { addToolState, getToolState } from "./state";
+import { CINETypes } from "../../types";
 
 const { triggerEvent } = utilities;
 
@@ -26,14 +26,14 @@ function playClip(
   let playClipIsTimeVarying;
 
   if (element === undefined) {
-    throw new Error('playClip: element must not be undefined');
+    throw new Error("playClip: element must not be undefined");
   }
 
   const enabledElement = getEnabledElement(element);
 
   if (!enabledElement) {
     throw new Error(
-      'playClip: element must be a valid Cornerstone enabled element'
+      "playClip: element must be a valid Cornerstone enabled element"
     );
   }
 
@@ -41,7 +41,7 @@ function playClip(
 
   if (!(viewport instanceof StackViewport)) {
     throw new Error(
-      'playClip: element must be a stack viewport, volume viewport playClip not yet implemented'
+      "playClip: element must be a stack viewport, volume viewport playClip not yet implemented"
     );
   }
 
@@ -99,10 +99,10 @@ function playClip(
   // This function encapsulates the frame rendering logic...
   const playClipAction = () => {
     // Hoisting of context variables
-   const stackData = {
-            targetImageIdIndex: viewport.getTargetImageIdIndex(),
-            imageIds: viewport.getImageIds(),
-        };
+    const stackData = {
+      targetImageIdIndex: viewport.getTargetImageIdIndex(),
+      imageIds: viewport.getImageIds(),
+    };
     let newImageIdIndex = stackData.targetImageIdIndex;
 
     const imageCount = stackData.imageIds.length;
@@ -211,7 +211,7 @@ function _getPlayClipTimeouts(vector: number[], speed: number) {
   // Initialize time varying to false
   let isTimeVarying = false;
 
-  if (typeof speed !== 'number' || speed <= 0) {
+  if (typeof speed !== "number" || speed <= 0) {
     speed = 1;
   }
 
@@ -252,7 +252,7 @@ function _getPlayClipTimeouts(vector: number[], speed: number) {
 function _stopClipWithData(playClipData) {
   const id = playClipData.intervalId;
 
-  if (typeof id !== 'undefined') {
+  if (typeof id !== "undefined") {
     playClipData.intervalId = undefined;
     if (playClipData.usingFrameTimeVector) {
       clearTimeout(id);


### PR DESCRIPTION
This line in the code causes CINE to be in an infinite loop and render the same frame over and over. It happens when you activate the CINE tool and you are on the last image of a series.

```
    if (newImageIdIndex >= imageCount) {
      newImageIdIndex = 0;
    }
```

and since delta is ``` const delta = newImageIdIndex - stackData.targetImageIdIndex; ``` It causes it to go in the negative when it should always be 1 from my understanding.

```
        if (newImageIdIndex !== stackData.targetImageIdIndex) {
            const delta = newImageIdIndex - stackData.targetImageIdIndex;
            viewport.scroll(delta, debounced, loop);
        }
    };
```

If you would like to replicate the issue, visit this study

https://v3-demo.ohif.org/viewer?StudyInstanceUIDs=1.3.6.1.4.1.25403.345050719074.3824.20170126083429.2

load any series and go to the last image in it by scrolling, so 53/53 for example, and trigger the CINE tool, you will notice it freezes, and it's frozen not because it's stopped but it's just really rendering the same frame over and over.

You can check by recording the performance and looking at the call stack, or you will just notice the CPU usage rising up.

After removing those lines the issue doesn't happen anymore since the calculation for delta comes out with 1 instead of negative values, so 53- 52 = 1, with the previous code it would've been 0-52 = -52 which makes it get stuck.




The way I fixed it could be wrong, so feel free to fix it some other way, but it's an issue to lookout for anyway. 