### PR TITLE
fix: fixes the memory leak for volumes

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -828,6 +828,8 @@ interface IImageLoadObject {
 // @public (undocumented)
 interface IImageVolume {
     // (undocumented)
+    cancelLoading?: () => void;
+    // (undocumented)
     convertToCornerstoneImage?: (imageId: string, imageIdIndex: number) => IImageLoadObject;
     // (undocumented)
     dimensions: Point3;
@@ -999,6 +1001,8 @@ function imageToWorldCoords(imageId: string, imageCoords: Point2): Point3 | unde
 // @public (undocumented)
 export class ImageVolume implements IImageVolume {
     constructor(props: IVolume);
+    // (undocumented)
+    cancelLoading: () => void;
     // (undocumented)
     dimensions: Point3;
     // (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -626,6 +626,8 @@ interface IImageLoadObject {
 
 // @public
 interface IImageVolume {
+    // (undocumented)
+    cancelLoading?: () => void;
     convertToCornerstoneImage?: (
     imageId: string,
     imageIdIndex: number
@@ -1187,7 +1189,7 @@ type StackViewportScrollEventDetail = {
 export class StreamingImageVolume extends ImageVolume {
     constructor(imageVolumeProperties: Types.IVolume, streamingProperties: Types.IStreamingVolumeProperties);
     // (undocumented)
-    cancelLoading(): void;
+    cancelLoading: () => void;
     // (undocumented)
     clearLoadCallbacks(): void;
     // (undocumented)

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2022,6 +2022,8 @@ interface IImageLoadObject {
 
 // @public
 interface IImageVolume {
+    // (undocumented)
+    cancelLoading?: () => void;
     convertToCornerstoneImage?: (
     imageId: string,
     imageIdIndex: number

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -451,16 +451,22 @@ class RenderingEngine implements IRenderingEngine {
       return;
     }
 
-    this._reset();
-    renderingEngineCache.delete(this.id);
-
+    // remove vtk rendered first before resetting the viewport
     if (!this.useCPURendering) {
+      const viewports = this._getViewportsAsArray();
+      viewports.forEach((vp) => {
+        this.offscreenMultiRenderWindow.removeRenderer(vp.id);
+      });
+
       // Free up WebGL resources
       this.offscreenMultiRenderWindow.delete();
 
       // Make sure all references go stale and are garbage collected.
       delete this.offscreenMultiRenderWindow;
     }
+
+    this._reset();
+    renderingEngineCache.delete(this.id);
 
     this.hasBeenDestroyed = true;
   }
@@ -1225,7 +1231,7 @@ class RenderingEngine implements IRenderingEngine {
    *
    * @param viewport - The `Viewport` to render.
    */
-  private _resetViewport(viewport) {
+  private _resetViewport(viewport: IStackViewport | IVolumeViewport) {
     const renderingEngineId = this.id;
 
     const { element, canvas, id: viewportId } = viewport;

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -176,7 +176,7 @@ class Viewport implements IViewport {
   protected applyFlipTx = (worldPos: Point3): Point3 => {
     const actorEntry = this.getDefaultActor();
 
-    if (!actorEntry) {
+    if (!actorEntry || !actorEntry.actor) {
       return worldPos;
     }
 

--- a/packages/core/src/RenderingEngine/vtkClasses/vtkOffscreenMultiRenderWindow.js
+++ b/packages/core/src/RenderingEngine/vtkClasses/vtkOffscreenMultiRenderWindow.js
@@ -54,9 +54,15 @@ function vtkOffscreenMultiRenderWindow(publicAPI, model) {
     model.rendererMap[id] = renderer;
   };
 
+  publicAPI.destroy = () => {
+    const rwi = model.renderWindow.getInteractor();
+    rwi.delete();
+  };
+
   publicAPI.removeRenderer = (id) => {
     const renderer = publicAPI.getRenderer(id);
     model.renderWindow.removeRenderer(renderer);
+    renderer.delete();
     delete model.rendererMap[id];
   };
 
@@ -98,6 +104,7 @@ function vtkOffscreenMultiRenderWindow(publicAPI, model) {
   // Properly release GL context
   publicAPI.delete = macro.chain(
     publicAPI.setContainer,
+    publicAPI.destroy,
     model.openGLRenderWindow.delete,
     publicAPI.delete
   );

--- a/packages/core/src/RenderingEngine/vtkClasses/vtkSharedVolumeMapper.js
+++ b/packages/core/src/RenderingEngine/vtkClasses/vtkSharedVolumeMapper.js
@@ -14,6 +14,12 @@ import vtkVolumeMapper from '@kitware/vtk.js/Rendering/Core/VolumeMapper';
  */
 function vtkSharedVolumeMapper(publicAPI, model) {
   model.classHierarchy.push('vtkSharedVolumeMapper');
+
+  const superDelete = publicAPI.delete;
+  publicAPI.delete = () => {
+    model.scalarTexture = null;
+    superDelete();
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/packages/core/src/cache/cache.ts
+++ b/packages/core/src/cache/cache.ts
@@ -117,23 +117,20 @@ class Cache implements ICache {
    */
   private _decacheVolume = (volumeId: string) => {
     const cachedVolume = this._volumeCache.get(volumeId);
-    const { volumeLoadObject } = cachedVolume;
+    const { volumeLoadObject, volume } = cachedVolume;
 
-    // Cancel any in-progress loading
+    if (volume.cancelLoading) {
+      volume.cancelLoading();
+    }
+
     if (volumeLoadObject.cancelFn) {
+      // Cancel any in-progress loading
       volumeLoadObject.cancelFn();
     }
 
     if (volumeLoadObject.decache) {
       volumeLoadObject.decache();
     }
-
-    // Clear texture memory (it will probably only be released at garbage collection of the DOM element, but might as well try)
-    // TODO We need to actually check if this particular scalar is used.
-    // TODO: Put this in the volume loader's decache function?
-    /*if (volume && volume.vtkOpenGLTexture) {
-      volume.vtkOpenGLTexture.releaseGraphicsResources()
-    }*/
 
     this._volumeCache.delete(volumeId);
   };
@@ -761,5 +758,6 @@ class Cache implements ICache {
  *
  */
 const cache = new Cache();
+window.cache = cache;
 export default cache;
 export { Cache }; // for documentation

--- a/packages/core/src/cache/cache.ts
+++ b/packages/core/src/cache/cache.ts
@@ -758,6 +758,5 @@ class Cache implements ICache {
  *
  */
 const cache = new Cache();
-window.cache = cache;
 export default cache;
 export { Cache }; // for documentation

--- a/packages/core/src/cache/cache.ts
+++ b/packages/core/src/cache/cache.ts
@@ -123,6 +123,10 @@ class Cache implements ICache {
       volume.cancelLoading();
     }
 
+    if (volume.imageData) {
+      volume.imageData = null;
+    }
+
     if (volumeLoadObject.cancelFn) {
       // Cancel any in-progress loading
       volumeLoadObject.cancelFn();

--- a/packages/core/src/cache/classes/ImageVolume.ts
+++ b/packages/core/src/cache/classes/ImageVolume.ts
@@ -71,6 +71,8 @@ export class ImageVolume implements IImageVolume {
       this.referencedVolumeId = props.referencedVolumeId;
     }
   }
+
+  cancelLoading: () => void;
 }
 
 export default ImageVolume;

--- a/packages/core/src/types/IImageVolume.ts
+++ b/packages/core/src/types/IImageVolume.ts
@@ -52,6 +52,9 @@ interface IImageVolume {
     imageId: string,
     imageIdIndex: number
   ) => IImageLoadObject;
+
+  //cancel load
+  cancelLoading?: () => void;
 }
 
 export default IImageVolume;

--- a/packages/core/src/volumeLoader.ts
+++ b/packages/core/src/volumeLoader.ts
@@ -325,7 +325,7 @@ export function createLocalVolume(
   const cachedVolume = cache.getVolume(volumeId);
 
   if (cachedVolume) {
-    return cachedVolume;
+    return cachedVolume as ImageVolume;
   }
 
   const scalarLength = dimensions[0] * dimensions[1] * dimensions[2];

--- a/packages/streaming-image-volume-loader/src/StreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/StreamingImageVolume.ts
@@ -255,6 +255,11 @@ export default class StreamingImageVolume extends ImageVolume {
       // data loader scheme)
       const cachedImage = cache.getCachedImageBasedOnImageURI(imageId);
 
+      // check if we are still loading the volume and we have not canceled loading
+      if (!loadStatus.loading) {
+        return;
+      }
+
       if (!cachedImage || !cachedImage.image) {
         return updateTextureAndTriggerEvents(this, imageIdIndex, imageId);
       }

--- a/packages/streaming-image-volume-loader/src/StreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/StreamingImageVolume.ts
@@ -101,7 +101,7 @@ export default class StreamingImageVolume extends ImageVolume {
    * and filters any imageLoad request in the requestPoolManager that has the same
    * volumeId
    */
-  public cancelLoading(): void {
+  public cancelLoading = () => {
     const { loadStatus } = this;
 
     if (!loadStatus || !loadStatus.loading) {
@@ -124,7 +124,7 @@ export default class StreamingImageVolume extends ImageVolume {
     // requests to ensure requests we no longer need are
     // no longer sent.
     imageLoadPoolManager.filterRequests(filterFunction);
-  }
+  };
 
   /**
    * Clear the load callbacks

--- a/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
+++ b/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
@@ -9,6 +9,7 @@ const { createUint8SharedArray, createFloat32SharedArray } = utilities;
 interface IVolumeLoader {
   promise: Promise<StreamingImageVolume>;
   cancel: () => void;
+  decache: () => void;
 }
 
 /**
@@ -135,7 +136,7 @@ function cornerstoneStreamingImageVolumeLoader(
       break;
   }
 
-  const streamingImageVolume = new StreamingImageVolume(
+  let streamingImageVolume = new StreamingImageVolume(
     // ImageVolume properties
     {
       volumeId,
@@ -164,6 +165,11 @@ function cornerstoneStreamingImageVolumeLoader(
     promise: Promise.resolve(streamingImageVolume),
     cancel: () => {
       streamingImageVolume.cancelLoading();
+    },
+    decache: () => {
+      streamingImageVolume.vtkOpenGLTexture.delete();
+      streamingImageVolume.scalarData = null;
+      streamingImageVolume = null;
     },
   };
 }


### PR DESCRIPTION
This fixes some of the memory issues in which vtk's render window interactor was not unsubscribing from one of its events. 
Right now memory profiling in Chrome does not show any noticeable objects left for decaching but still the demos keep some GPU process. 

We might want to investigate more on this