### PR TITLE
fix(annotation):The wrong annotation was being selected for common frameUID

### DIFF
--- a/packages/tools/src/utilities/getAnnotationNearPoint.ts
+++ b/packages/tools/src/utilities/getAnnotationNearPoint.ts
@@ -106,7 +106,8 @@ function findAnnotationNearPointByTool(
   if (annotations?.length) {
     const { element } = enabledElement.viewport;
     for (const annotation of annotations) {
-      if (currentId && currentId !== annotation.metadata?.referencedImageId) {
+      const referencedImageId = annotation.metadata?.referencedImageId;
+      if (currentId && referencedImageId && currentId !== referencedImageId) {
         continue;
       }
 

--- a/packages/tools/src/utilities/getAnnotationNearPoint.ts
+++ b/packages/tools/src/utilities/getAnnotationNearPoint.ts
@@ -102,9 +102,14 @@ function findAnnotationNearPointByTool(
     enabledElement.viewport.element,
     (tool.constructor as typeof BaseTool).toolName
   );
+  const currentId = enabledElement.viewport?.getCurrentImageId();
   if (annotations?.length) {
     const { element } = enabledElement.viewport;
     for (const annotation of annotations) {
+      if (currentId && currentId !== annotation.metadata?.referencedImageId) {
+        continue;
+      }
+
       if (
         tool.isPointNearTool(element, annotation, point, proximity, '') ||
         tool.getHandleNearImagePoint(element, annotation, point, proximity)

--- a/packages/tools/src/utilities/getAnnotationNearPoint.ts
+++ b/packages/tools/src/utilities/getAnnotationNearPoint.ts
@@ -102,7 +102,7 @@ function findAnnotationNearPointByTool(
     enabledElement.viewport.element,
     (tool.constructor as typeof BaseTool).toolName
   );
-  const currentId = enabledElement.viewport?.getCurrentImageId();
+  const currentId = enabledElement.viewport?.getCurrentImageId?.();
   if (annotations?.length) {
     const { element } = enabledElement.viewport;
     for (const annotation of annotations) {


### PR DESCRIPTION
When the frame of reference UID is common between series, and two markups happen to coincide on different images, the first one found will be select for nearby tool data, thus updating and setting values for the wrong annotation.