### PR TITLE
Fix issue when getting an index that equals 0.

### DIFF
--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -951,7 +951,7 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
   public getCurrentImageId = (): string | undefined => {
     const index = this._getImageIdIndex();
 
-    if (isNan(index)) {
+    if (isNaN(index)) {
       return;
     }
 

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -951,7 +951,7 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
   public getCurrentImageId = (): string | undefined => {
     const index = this._getImageIdIndex();
 
-    if (!index) {
+    if (isNan(index)) {
       return;
     }
 


### PR DESCRIPTION
When using this method while being on the first image, the index returns 0, and this method would return `undefined`. This is unwanted since the first image obviously has a 0 index which is usable. My fix simply consists of ensuring the returned value is a number (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN).