### PR TITLE
fix: Use queryselector instead of firstChild to get svg-layer

### DIFF
--- a/packages/tools/src/drawingSvg/getSvgDrawingHelper.ts
+++ b/packages/tools/src/drawingSvg/getSvgDrawingHelper.ts
@@ -2,6 +2,8 @@ import { state } from '../store';
 import { getEnabledElement } from '@cornerstonejs/core';
 import { SVGDrawingHelper } from '../types';
 
+const VIEWPORT_ELEMENT = 'viewport-element';
+
 /**
  * Returns the SVG drawing helper for the given HTML element.
  * @param element - The HTML element to get the SVG drawing helper for.
@@ -34,7 +36,8 @@ function getSvgDrawingHelper(element: HTMLDivElement): SVGDrawingHelper {
  * @private
  */
 function _getSvgLayer(element) {
-  const internalDivElement = element.firstChild;
+  const viewportElement = `.${VIEWPORT_ELEMENT}`;
+  const internalDivElement = element.querySelector(viewportElement);
   const svgLayer = internalDivElement.querySelector('.svg-layer');
 
   return svgLayer;


### PR DESCRIPTION
Related issue : https://github.com/cornerstonejs/cornerstone3D-beta/issues/252#issue-1416549311

if getSvgDrawingHelper is not a generic and will not be used for any other purpose, this code will solve the problem.