### PR TITLE
feat: reset to center option for reset camera

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -595,9 +595,6 @@ function getVolumeActorCorners(volumeActor: any): Array<Point3>;
 function getVolumeViewportsContainingSameVolumes(targetViewport: IVolumeViewport, renderingEngineId?: string): Array<IVolumeViewport>;
 
 // @public (undocumented)
-function hasNaNValues(input: number[] | number): boolean;
-
-// @public (undocumented)
 interface ICache {
     // (undocumented)
     getCacheSize: () => number;
@@ -665,10 +662,6 @@ interface ICamera {
     parallelProjection?: boolean;
     // (undocumented)
     parallelScale?: number;
-    // (undocumented)
-    physicalScale?: number;
-    // (undocumented)
-    physicalTranslation?: Point3;
     // (undocumented)
     position?: Point3;
     // (undocumented)
@@ -1946,8 +1939,7 @@ declare namespace utilities {
         snapFocalPointToSlice,
         getImageSliceDataForVolumeViewport,
         isImageActor,
-        getViewportsWithImageURI,
-        hasNaNValues
+        getViewportsWithImageURI
     }
 }
 export { utilities }

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -595,6 +595,9 @@ function getVolumeActorCorners(volumeActor: any): Array<Point3>;
 function getVolumeViewportsContainingSameVolumes(targetViewport: IVolumeViewport, renderingEngineId?: string): Array<IVolumeViewport>;
 
 // @public (undocumented)
+function hasNaNValues(input: number[] | number): boolean;
+
+// @public (undocumented)
 interface ICache {
     // (undocumented)
     getCacheSize: () => number;
@@ -651,6 +654,8 @@ interface ICachedVolume {
 // @public (undocumented)
 interface ICamera {
     // (undocumented)
+    clippingRange?: Point2;
+    // (undocumented)
     flipHorizontal?: boolean;
     // (undocumented)
     flipVertical?: boolean;
@@ -660,6 +665,10 @@ interface ICamera {
     parallelProjection?: boolean;
     // (undocumented)
     parallelScale?: number;
+    // (undocumented)
+    physicalScale?: number;
+    // (undocumented)
+    physicalTranslation?: Point3;
     // (undocumented)
     position?: Point3;
     // (undocumented)
@@ -1396,7 +1405,7 @@ interface IVolumeViewport extends IViewport {
     // (undocumented)
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
     // (undocumented)
-    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
+    resetCamera(resetPan?: boolean, resetZoom?: boolean, resetToCenter?: boolean): boolean;
     // (undocumented)
     setBlendMode(blendMode: BlendModes, filterActorUIDs?: Array<string>, immediate?: boolean): void;
     // (undocumented)
@@ -1937,7 +1946,8 @@ declare namespace utilities {
         snapFocalPointToSlice,
         getImageSliceDataForVolumeViewport,
         isImageActor,
-        getViewportsWithImageURI
+        getViewportsWithImageURI,
+        hasNaNValues
     }
 }
 export { utilities }
@@ -1991,6 +2001,11 @@ export class Viewport implements IViewport {
     // (undocumented)
     _getEdges(bounds: Array<number>): Array<[number[], number[]]>;
     // (undocumented)
+    _getFocalPointForResetCamera(centeredFocalPoint: Point3, previousCamera: ICamera, { resetPan, resetToCenter }: {
+        resetPan: boolean;
+        resetToCenter: boolean;
+    }): Point3;
+    // (undocumented)
     getFrameOfReferenceUID: () => string;
     // (undocumented)
     getPan(): Point2;
@@ -2027,7 +2042,7 @@ export class Viewport implements IViewport {
     // (undocumented)
     reset(immediate?: boolean): void;
     // (undocumented)
-    protected resetCamera(resetPan?: boolean, resetZoom?: boolean, storeAsInitialCamera?: boolean): boolean;
+    protected resetCamera(resetPan?: boolean, resetZoom?: boolean, resetToCenter?: boolean, storeAsInitialCamera?: boolean): boolean;
     // (undocumented)
     protected resetCameraNoEvent(): void;
     // (undocumented)
@@ -2213,7 +2228,7 @@ export class VolumeViewport extends Viewport implements IVolumeViewport {
     // (undocumented)
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
     // (undocumented)
-    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
+    resetCamera(resetPan?: boolean, resetZoom?: boolean, resetToCenter?: boolean): boolean;
     // (undocumented)
     setBlendMode(blendMode: BlendModes, filterActorUIDs?: any[], immediate?: boolean): void;
     // (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -502,11 +502,14 @@ interface ICachedVolume {
 
 // @public
 interface ICamera {
+    clippingRange?: Point2;
     flipHorizontal?: boolean;
     flipVertical?: boolean;
     focalPoint?: Point3;
     parallelProjection?: boolean;
     parallelScale?: number;
+    physicalScale?: number;
+    physicalTranslation?: Point3;
     position?: Point3;
     scale?: number;
     viewAngle?: number;
@@ -1001,7 +1004,11 @@ interface IVolumeViewport extends IViewport {
     hasImageURI: (imageURI: string) => boolean;
     hasVolumeId: (volumeId: string) => boolean;
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
-    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
+    resetCamera(
+    resetPan?: boolean,
+    resetZoom?: boolean,
+    resetToCenter?: boolean
+    ): boolean;
     setBlendMode(
     blendMode: BlendModes,
     filterActorUIDs?: Array<string>,

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -508,8 +508,6 @@ interface ICamera {
     focalPoint?: Point3;
     parallelProjection?: boolean;
     parallelScale?: number;
-    physicalScale?: number;
-    physicalTranslation?: Point3;
     position?: Point3;
     scale?: number;
     viewAngle?: number;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1898,11 +1898,14 @@ interface ICachedVolume {
 
 // @public
 interface ICamera {
+    clippingRange?: Point2;
     flipHorizontal?: boolean;
     flipVertical?: boolean;
     focalPoint?: Point3;
     parallelProjection?: boolean;
     parallelScale?: number;
+    physicalScale?: number;
+    physicalTranslation?: Point3;
     position?: Point3;
     scale?: number;
     viewAngle?: number;
@@ -2522,7 +2525,11 @@ interface IVolumeViewport extends IViewport {
     hasImageURI: (imageURI: string) => boolean;
     hasVolumeId: (volumeId: string) => boolean;
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
-    resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
+    resetCamera(
+    resetPan?: boolean,
+    resetZoom?: boolean,
+    resetToCenter?: boolean
+    ): boolean;
     setBlendMode(
     blendMode: BlendModes,
     filterActorUIDs?: Array<string>,

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1904,8 +1904,6 @@ interface ICamera {
     focalPoint?: Point3;
     parallelProjection?: boolean;
     parallelScale?: number;
-    physicalScale?: number;
-    physicalTranslation?: Point3;
     position?: Point3;
     scale?: number;
     viewAngle?: number;

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1875,8 +1875,10 @@ class StackViewport extends Viewport implements IStackViewport {
     // without this
     this.getVtkActiveCamera().roll(this.rotationCache);
 
-    // reset other properties
-    return super.resetCamera(resetPan, resetZoom);
+    // For stack Viewport we since we have only one slice
+    // it should be enough to reset the camera to the center of the image
+    const resetToCenter = true;
+    return super.resetCamera(resetPan, resetZoom, resetToCenter);
   }
 
   /**

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -1132,30 +1132,27 @@ class Viewport implements IViewport {
       const oldFocalPoint = oldCamera.focalPoint;
       const oldViewPlaneNormal = oldCamera.viewPlaneNormal;
 
-      const vectorFromOldFocalPointToCenteredFocalPoint = <Point3>[
-        centeredFocalPoint[0] - oldFocalPoint[0],
-        centeredFocalPoint[1] - oldFocalPoint[1],
-        centeredFocalPoint[2] - oldFocalPoint[2],
-      ];
+      const vectorFromOldFocalPointToCenteredFocalPoint = vec3.create();
+      vec3.subtract(
+        vectorFromOldFocalPointToCenteredFocalPoint,
+        centeredFocalPoint,
+        oldFocalPoint
+      );
 
-      const distanceAlongViewPlaneNormal = vtkMath.dot(
+      const distanceFromOldFocalPointToCenteredFocalPoint = vec3.dot(
         vectorFromOldFocalPointToCenteredFocalPoint,
         oldViewPlaneNormal
       );
 
-      const scaledViewPlaneNormal = <Point3>[
-        oldViewPlaneNormal[0] * distanceAlongViewPlaneNormal,
-        oldViewPlaneNormal[1] * distanceAlongViewPlaneNormal,
-        oldViewPlaneNormal[2] * distanceAlongViewPlaneNormal,
-      ];
+      const newFocalPoint = vec3.create();
+      vec3.scaleAndAdd(
+        newFocalPoint,
+        centeredFocalPoint,
+        oldViewPlaneNormal,
+        -1 * distanceFromOldFocalPointToCenteredFocalPoint
+      );
 
-      const newFocalPoint = <Point3>[
-        centeredFocalPoint[0] - scaledViewPlaneNormal[0],
-        centeredFocalPoint[1] - scaledViewPlaneNormal[1],
-        centeredFocalPoint[2] - scaledViewPlaneNormal[2],
-      ];
-
-      return newFocalPoint;
+      return [newFocalPoint[0], newFocalPoint[1], newFocalPoint[2]];
     }
 
     if (!resetPan && !resetToCenter) {

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -636,10 +636,6 @@ class Viewport implements IViewport {
       { resetPan, resetToCenter }
     );
 
-    if (this.type === 'stack') {
-      console.debug(focalPointToSet);
-    }
-
     const positionToSet: Point3 = [
       focalPointToSet[0] + distance * viewPlaneNormal[0],
       focalPointToSet[1] + distance * viewPlaneNormal[1],
@@ -1117,11 +1113,17 @@ class Viewport implements IViewport {
     previousCamera: ICamera,
     { resetPan, resetToCenter }: { resetPan: boolean; resetToCenter: boolean }
   ): Point3 {
-    if (resetToCenter) {
+    if (resetToCenter && resetPan) {
       return centeredFocalPoint;
     }
 
-    if (resetPan) {
+    if (resetToCenter && !resetPan) {
+      return hasNaNValues(previousCamera.focalPoint)
+        ? centeredFocalPoint
+        : previousCamera.focalPoint;
+    }
+
+    if (!resetToCenter && resetPan) {
       // this is an interesting case that means the reset camera should not
       // change the slice (default behavior is to go to the center of the
       // image), and rather just reset the pan on the slice that is currently
@@ -1156,20 +1158,13 @@ class Viewport implements IViewport {
       return newFocalPoint;
     }
 
-    if (!resetPan) {
+    if (!resetPan && !resetToCenter) {
       // this means the reset camera should not change the slice and should not
       // touch the pan either.
       return hasNaNValues(previousCamera.focalPoint)
         ? centeredFocalPoint
         : previousCamera.focalPoint;
     }
-
-    // the last option is a very uncommon use case to reset the camera to
-    // the center of the image, but keep the pan? This is not supported
-    // yet
-    return hasNaNValues(previousCamera.focalPoint)
-      ? centeredFocalPoint
-      : previousCamera.focalPoint;
   }
 
   /**

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -656,7 +656,7 @@ class Viewport implements IViewport {
       viewAngle: 90,
       viewUp: viewUpToSet,
       physicalScale: radius,
-      physicalTranslation: focalPointToSet.map((v) => -v),
+      physicalTranslation: focalPointToSet.map((v) => -v) as Point3,
       clippingRange: clippingRangeToUse,
       flipHorizontal: this.flipHorizontal ? false : undefined,
       flipVertical: this.flipVertical ? false : undefined,

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -9,7 +9,8 @@ import _cloneDeep from 'lodash.clonedeep';
 import Events from '../enums/Events';
 import ViewportType from '../enums/ViewportType';
 import renderingEngineCache from './renderingEngineCache';
-import { triggerEvent, planar, isImageActor, hasNaNValues } from '../utilities';
+import { triggerEvent, planar, isImageActor } from '../utilities';
+import hasNaNValues from '../utilities/hasNaNValues';
 import { RENDERING_DEFAULTS } from '../constants';
 import type {
   ICamera,
@@ -649,14 +650,19 @@ class Viewport implements IViewport {
       RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE,
     ];
 
+    activeCamera.setPhysicalScale(radius);
+    activeCamera.setPhysicalTranslation(
+      -focalPointToSet[0],
+      -focalPointToSet[1],
+      -focalPointToSet[2]
+    );
+
     this.setCamera({
       parallelScale: resetZoom ? parallelScale : previousCamera.parallelScale,
       focalPoint: focalPointToSet,
       position: positionToSet,
       viewAngle: 90,
       viewUp: viewUpToSet,
-      physicalScale: radius,
-      physicalTranslation: focalPointToSet.map((v) => -v) as Point3,
       clippingRange: clippingRangeToUse,
       flipHorizontal: this.flipHorizontal ? false : undefined,
       flipVertical: this.flipVertical ? false : undefined,
@@ -883,8 +889,6 @@ class Viewport implements IViewport {
       viewAngle,
       flipHorizontal,
       flipVertical,
-      physicalScale,
-      physicalTranslation,
       clippingRange,
     } = cameraInterface;
 
@@ -918,15 +922,6 @@ class Viewport implements IViewport {
 
     if (viewAngle !== undefined) {
       vtkCamera.setViewAngle(viewAngle);
-    }
-
-    if (physicalScale !== undefined) {
-      vtkCamera.setPhysicalScale(physicalScale);
-    }
-
-    if (physicalTranslation !== undefined) {
-      // TODO: The PhysicalXXX stuff are used for VR only, do we need this?
-      vtkCamera.setPhysicalTranslation(...physicalTranslation);
     }
 
     if (clippingRange !== undefined) {

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -566,8 +566,12 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
   /**
    * Reset the camera for the volume viewport
    */
-  public resetCamera(resetPan = true, resetZoom = true): boolean {
-    super.resetCamera(resetPan, resetZoom);
+  public resetCamera(
+    resetPan = true,
+    resetZoom = true,
+    resetToCenter = true
+  ): boolean {
+    super.resetCamera(resetPan, resetZoom, resetToCenter);
     const activeCamera = this.getVtkActiveCamera();
     // Set large numbers to ensure everything is always rendered
     if (activeCamera.getParallelProjection()) {

--- a/packages/core/src/types/ICamera.ts
+++ b/packages/core/src/types/ICamera.ts
@@ -1,4 +1,5 @@
 import Point3 from './Point3';
+import Point2 from './Point2';
 
 /**
  * Camera Interface. See {@link https://kitware.github.io/vtk-examples/site/VTKBook/03Chapter3/#35-cameras} if you
@@ -28,6 +29,12 @@ interface ICamera {
   flipHorizontal?: boolean;
   /** flip Vertical */
   flipVertical?: boolean;
+  /** physical scale */
+  physicalScale?: number;
+  /** physical translation */
+  physicalTranslation?: Point3;
+  /** clipping range */
+  clippingRange?: Point2;
 }
 
 export default ICamera;

--- a/packages/core/src/types/ICamera.ts
+++ b/packages/core/src/types/ICamera.ts
@@ -29,10 +29,6 @@ interface ICamera {
   flipHorizontal?: boolean;
   /** flip Vertical */
   flipVertical?: boolean;
-  /** physical scale */
-  physicalScale?: number;
-  /** physical translation */
-  physicalTranslation?: Point3;
   /** clipping range */
   clippingRange?: Point2;
 }

--- a/packages/core/src/types/IVolumeViewport.ts
+++ b/packages/core/src/types/IVolumeViewport.ts
@@ -99,7 +99,11 @@ export default interface IVolumeViewport extends IViewport {
   /**
    * Reset the camera for the volume viewport
    */
-  resetCamera(resetPan?: boolean, resetZoom?: boolean): boolean;
+  resetCamera(
+    resetPan?: boolean,
+    resetZoom?: boolean,
+    resetToCenter?: boolean
+  ): boolean;
   /**
    * Sets the blendMode for actors of the viewport.
    */

--- a/packages/core/src/utilities/hasNaNValues.ts
+++ b/packages/core/src/utilities/hasNaNValues.ts
@@ -1,0 +1,12 @@
+/**
+ * A function that checks if there is a value in the array that is NaN.
+ * or if the input is a number it just checks if it is NaN.
+ * @param input - The input to check if it is NaN.
+ * @returns - True if the input is NaN, false otherwise.
+ */
+export default function hasNaNValues(input: number[] | number): boolean {
+  if (Array.isArray(input)) {
+    return input.some((value) => Number.isNaN(value));
+  }
+  return Number.isNaN(input);
+}

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -27,6 +27,7 @@ import snapFocalPointToSlice from './snapFocalPointToSlice';
 import getImageSliceDataForVolumeViewport from './getImageSliceDataForVolumeViewport';
 import isImageActor from './isImageActor';
 import getViewportsWithImageURI from './getViewportsWithImageURI';
+import hasNaNValues from './hasNaNValues';
 
 // name spaces
 import * as planar from './planar';
@@ -64,4 +65,5 @@ export {
   getImageSliceDataForVolumeViewport,
   isImageActor,
   getViewportsWithImageURI,
+  hasNaNValues,
 };

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -27,7 +27,6 @@ import snapFocalPointToSlice from './snapFocalPointToSlice';
 import getImageSliceDataForVolumeViewport from './getImageSliceDataForVolumeViewport';
 import isImageActor from './isImageActor';
 import getViewportsWithImageURI from './getViewportsWithImageURI';
-import hasNaNValues from './hasNaNValues';
 
 // name spaces
 import * as planar from './planar';
@@ -65,5 +64,4 @@ export {
   getImageSliceDataForVolumeViewport,
   isImageActor,
   getViewportsWithImageURI,
-  hasNaNValues,
 };

--- a/packages/tools/examples/resetCamera/index.ts
+++ b/packages/tools/examples/resetCamera/index.ts
@@ -227,8 +227,6 @@ async function run() {
   const volumeViewport = <Types.IVolumeViewport>(
     renderingEngine.getViewport(viewportIdVolume)
   );
-  window.stackViewport = stackViewport;
-  window.volumeViewport = volumeViewport;
 
   // Define a volume in memory
   const volume = await volumeLoader.createAndCacheVolume(volumeId, {

--- a/packages/tools/examples/resetCamera/index.ts
+++ b/packages/tools/examples/resetCamera/index.ts
@@ -227,7 +227,8 @@ async function run() {
   const volumeViewport = <Types.IVolumeViewport>(
     renderingEngine.getViewport(viewportIdVolume)
   );
-  window.viewport = volumeViewport;
+  window.stackViewport = stackViewport;
+  window.volumeViewport = volumeViewport;
 
   // Define a volume in memory
   const volume = await volumeLoader.createAndCacheVolume(volumeId, {

--- a/packages/tools/examples/resetCamera/index.ts
+++ b/packages/tools/examples/resetCamera/index.ts
@@ -1,0 +1,252 @@
+import {
+  RenderingEngine,
+  Types,
+  Enums,
+  volumeLoader,
+  getRenderingEngine,
+} from '@cornerstonejs/core';
+import * as cornerstoneTools from '@cornerstonejs/tools';
+
+import {
+  initDemo,
+  createImageIdsAndCacheMetaData,
+  setTitleAndDescription,
+  addButtonToToolbar,
+  addDropdownToToolbar,
+  addSliderToToolbar,
+  camera as cameraHelpers,
+  setCtTransferFunctionForVolumeActor,
+  addToggleButtonToToolbar,
+} from '../../../../utils/demo/helpers';
+
+const {
+  PanTool,
+  WindowLevelTool,
+  StackScrollMouseWheelTool,
+  ZoomTool,
+  ToolGroupManager,
+  Enums: csToolsEnums,
+} = cornerstoneTools;
+
+const { ViewportType } = Enums;
+const { MouseBindings } = csToolsEnums;
+
+// This is for debugging purposes
+console.warn(
+  'Click on index.ts to open source code for this example --------->'
+);
+
+const renderingEngineId = 'myRenderingEngine';
+const viewportIdStack = 'CT_STACK';
+const viewportIdVolume = 'CT_VOLUME';
+
+// Define a unique id for the volume
+const volumeName = 'CT_VOLUME_ID'; // Id of the volume less loader prefix
+const volumeLoaderScheme = 'cornerstoneStreamingImageVolume'; // Loader id which defines which volume loader to use
+const volumeId = `${volumeLoaderScheme}:${volumeName}`; // VolumeId with loader id + volume id
+
+// ======== Set up page ======== //
+setTitleAndDescription(
+  'Reset Camera API',
+  'Demonstrates Different options for resetting the camera'
+);
+
+const content = document.getElementById('content');
+const element1 = document.createElement('div');
+element1.id = 'cornerstone-element1';
+element1.style.width = '500px';
+element1.style.height = '500px';
+
+const element2 = document.createElement('div');
+element2.id = 'cornerstone-element2';
+element2.style.width = '500px';
+element2.style.height = '500px';
+
+element1.oncontextmenu = (e) => e.preventDefault();
+element2.oncontextmenu = (e) => e.preventDefault();
+
+content.appendChild(element1);
+content.appendChild(element2);
+// ============================= //
+
+let selectedViewportId = viewportIdStack;
+let resetPan = true;
+let resetZoom = true;
+let resetToCenter;
+
+addDropdownToToolbar({
+  options: {
+    values: [viewportIdStack, viewportIdVolume],
+    defaultValue: viewportIdStack,
+  },
+  onSelectedValueChange: (value) => {
+    selectedViewportId = value as string;
+  },
+});
+// Buttons
+addButtonToToolbar({
+  title: 'Reset Camera',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IVolumeViewport>(
+      renderingEngine.getViewport(selectedViewportId)
+    );
+
+    viewport.resetCamera(resetPan, resetZoom, resetToCenter);
+
+    renderingEngine.render();
+  },
+});
+
+addToggleButtonToToolbar({
+  title: 'toggle reset zoom',
+  onClick: (toggle) => {
+    resetZoom = toggle;
+  },
+  defaultToggle: true,
+});
+
+addToggleButtonToToolbar({
+  title: 'toggle reset pan',
+  onClick: (toggle) => {
+    resetPan = toggle;
+  },
+  defaultToggle: true,
+});
+
+addToggleButtonToToolbar({
+  title: 'toggle reset to center',
+  onClick: (toggle) => {
+    resetToCenter = toggle;
+  },
+  defaultToggle: true,
+});
+
+/**
+ * Runs the demo
+ */
+async function run() {
+  // Init Cornerstone and related libraries
+  await initDemo();
+
+  cornerstoneTools.addTool(PanTool);
+  cornerstoneTools.addTool(WindowLevelTool);
+  cornerstoneTools.addTool(StackScrollMouseWheelTool);
+  cornerstoneTools.addTool(ZoomTool);
+
+  const toolGroup = ToolGroupManager.createToolGroup('toolGroupId');
+
+  // Add tools to the tool group
+  toolGroup.addTool(WindowLevelTool.toolName);
+  toolGroup.addTool(PanTool.toolName);
+  toolGroup.addTool(ZoomTool.toolName);
+  toolGroup.addTool(StackScrollMouseWheelTool.toolName);
+
+  // Set the initial state of the tools, here all tools are active and bound to
+  // Different mouse inputs
+  toolGroup.setToolActive(WindowLevelTool.toolName, {
+    bindings: [
+      {
+        mouseButton: MouseBindings.Primary, // Left Click
+      },
+    ],
+  });
+  toolGroup.setToolActive(PanTool.toolName, {
+    bindings: [
+      {
+        mouseButton: MouseBindings.Auxiliary, // Middle Click
+      },
+    ],
+  });
+  toolGroup.setToolActive(ZoomTool.toolName, {
+    bindings: [
+      {
+        mouseButton: MouseBindings.Secondary, // Right Click
+      },
+    ],
+  });
+  // As the Stack Scroll mouse wheel is a tool using the `mouseWheelCallback`
+  // hook instead of mouse buttons, it does not need to assign any mouse button.
+  toolGroup.setToolActive(StackScrollMouseWheelTool.toolName);
+
+  // Get Cornerstone imageIds and fetch metadata into RAM
+  const imageIds = await createImageIdsAndCacheMetaData({
+    StudyInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463',
+    SeriesInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561',
+    wadoRsRoot: 'https://d3t6nz73ql33tx.cloudfront.net/dicomweb',
+    type: 'VOLUME',
+  });
+
+  const stackImageIds = await createImageIdsAndCacheMetaData({
+    StudyInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463',
+    SeriesInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561',
+    wadoRsRoot: 'https://d3t6nz73ql33tx.cloudfront.net/dicomweb',
+    type: 'STACK',
+  });
+
+  // Instantiate a rendering engine
+  const renderingEngine = new RenderingEngine(renderingEngineId);
+
+  // Create a stack viewport
+  const viewportInputs = [
+    {
+      viewportId: viewportIdStack,
+      type: ViewportType.STACK,
+      element: element1,
+      defaultOptions: {
+        background: <Types.Point3>[1, 0.5, 0.2],
+      },
+    },
+    {
+      viewportId: viewportIdVolume,
+      type: ViewportType.ORTHOGRAPHIC,
+      element: element2,
+      defaultOptions: {
+        orientation: Enums.OrientationAxis.SAGITTAL,
+        background: <Types.Point3>[0.2, 0, 0.2],
+      },
+    },
+  ];
+
+  renderingEngine.setViewports(viewportInputs);
+
+  // Get the stack viewport that was created
+  const stackViewport = <Types.IStackViewport>(
+    renderingEngine.getViewport(viewportIdStack)
+  );
+
+  stackViewport.setStack(stackImageIds, 10);
+
+  const volumeViewport = <Types.IVolumeViewport>(
+    renderingEngine.getViewport(viewportIdVolume)
+  );
+  window.viewport = volumeViewport;
+
+  // Define a volume in memory
+  const volume = await volumeLoader.createAndCacheVolume(volumeId, {
+    imageIds,
+  });
+
+  // Set the volume to load
+  volume.load();
+
+  // Set the volume on the viewport
+  volumeViewport.setVolumes([
+    { volumeId, callback: setCtTransferFunctionForVolumeActor },
+  ]);
+
+  toolGroup.addViewport(viewportIdVolume, renderingEngineId);
+  toolGroup.addViewport(viewportIdStack, renderingEngineId);
+
+  // Render the image
+  renderingEngine.render();
+}
+
+run();

--- a/packages/tools/test/segmentationState_test.js
+++ b/packages/tools/test/segmentationState_test.js
@@ -235,12 +235,10 @@ describe('Segmentation State -- ', () => {
         );
       });
 
-      eventTarget.addEventListener(
-        Events.SEGMENTATION_REPRESENTATION_MODIFIED,
-        (evt) => {
-          done();
-        }
-      );
+      // wait for segmentation rendered event
+      eventTarget.addEventListener(Events.SEGMENTATION_RENDERED, (evt) => {
+        done();
+      });
 
       this.segToolGroup.addViewport(vp.id, this.renderingEngine.id);
 

--- a/utils/ExampleRunner/example-info.json
+++ b/utils/ExampleRunner/example-info.json
@@ -102,6 +102,10 @@
         "name": "Annotation Selection and Locking",
         "description": "Demonstrates how to toggle the Locked and Selected states for Annotations"
       },
+      "resetCamera": {
+        "name": "Viewports Reset Camera",
+        "description": "Demonstrates various options that are available for resetting camera on viewports"
+      },
       "annotationVisibility": {
         "name": "Annotation changing visibility",
         "description": "Demonstrates how to toggle the Visibility state for Annotations"


### PR DESCRIPTION
- Refactored reset camera to use the setCamera (previous bug where resetting volumes where not updating camera because of clipping planes)
- Added resetToCenter parameter to enable optional keeping the slice and just reseting the slice for volumes in any planes

Try example: https://deploy-preview-269--cornerstone-3d-docs.netlify.app/live-examples/resetcamera