### PR TITLE
feat: flip viewports via camera api instead of actor

### DIFF
--- a/packages/core/test/stackViewport_gpu_render_test.js
+++ b/packages/core/test/stackViewport_gpu_render_test.js
@@ -946,7 +946,7 @@ describe('renderingCore -- Stack', () => {
       }
     });
 
-    it('Should be able to flip a stack viewport horizontally and rotate it', function (done) {
+    it('Should be able to flip a stack viewport vertically and rotate it', function (done) {
       const element = createViewport(this.renderingEngine, AXIAL, 256, 256);
       this.DOMElements.push(element);
 
@@ -971,9 +971,9 @@ describe('renderingCore -- Stack', () => {
             rotation: 90,
           });
 
-          vp.setCamera({ flipHorizontal: true });
-
           vp.render();
+
+          vp.setCamera({ flipVertical: true });
         });
       } catch (e) {
         done.fail(e);


### PR DESCRIPTION
This PR fixes the flipping of the volumes by implementing it through camera api instead of actor

Try it out, it works on oblique too 🎉  https://deploy-preview-271--cornerstone-3d-docs.netlify.app/live-examples/volumeapi