### PR TITLE
fix: rendering engine should not reset camera on resize

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1616,7 +1616,7 @@ export class RenderingEngine implements IRenderingEngine {
     // (undocumented)
     renderViewports(viewportIds: Array<string>): void;
     // (undocumented)
-    resize(immediate?: boolean, resetPan?: boolean, resetZoom?: boolean): void;
+    resize(immediate?: boolean, keepCamera?: boolean): void;
     // (undocumented)
     setViewports(publicViewportInputEntries: Array<PublicViewportInput>): void;
 }


### PR DESCRIPTION
resize api has changed from 

`reneringEngine.resize(immediate, resetPan, resetZoom)`

to 

`reneringEngine.resize(immediate, keepCamera)` with keep Camera default to true