### PR TITLE
fix: resetCamera and annotations for flipped viewports

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -85,7 +85,8 @@ const colormapsData: CPUFallbackColormapsData;
 declare namespace CONSTANTS {
     export {
         colormapsData as CPU_COLORMAPS,
-        RENDERING_DEFAULTS
+        RENDERING_DEFAULTS,
+        EPSILON
     }
 }
 export { CONSTANTS }
@@ -424,6 +425,9 @@ declare namespace Enums {
     }
 }
 export { Enums }
+
+// @public (undocumented)
+const EPSILON = 0.001;
 
 // @public (undocumented)
 export enum EVENTS {
@@ -1956,8 +1960,6 @@ export class Viewport implements IViewport {
     addActor(actorEntry: ActorEntry): void;
     // (undocumented)
     addActors(actors: Array<ActorEntry>, resetCameraPanAndZoom?: boolean): void;
-    // (undocumented)
-    protected applyFlipTx: (worldPos: Point3) => Point3;
     // (undocumented)
     readonly canvas: HTMLCanvasElement;
     // (undocumented)

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1635,6 +1635,9 @@ function filterAnnotationsWithinSlice(annotations: Annotations, camera: Types_2.
 function filterViewportsWithFrameOfReferenceUID(viewports: Array<Types_2.IStackViewport | Types_2.IVolumeViewport>, FrameOfReferenceUID: string): Array<Types_2.IStackViewport | Types_2.IVolumeViewport>;
 
 // @public (undocumented)
+function filterViewportsWithParallelNormals(viewports: any, camera: any, EPS?: number): any;
+
+// @public (undocumented)
 function filterViewportsWithToolEnabled(viewports: Array<Types_2.IStackViewport | Types_2.IVolumeViewport>, toolName: string): Array<Types_2.IStackViewport | Types_2.IVolumeViewport>;
 
 // @public (undocumented)
@@ -1837,7 +1840,7 @@ function getToolGroupsWithSegmentation(segmentationId: string): string[];
 function getToolState(element: HTMLDivElement): CINETypes.ToolData | undefined;
 
 // @public (undocumented)
-function getViewportIdsWithToolToRender(element: HTMLDivElement, toolName: string, requireSameOrientation?: boolean): string[];
+function getViewportIdsWithToolToRender(element: HTMLDivElement, toolName: string, requireParallelNormals?: boolean): string[];
 
 // @public (undocumented)
 function getViewportSpecificAnnotationManager(element?: Types_2.IEnabledElement | HTMLDivElement): FrameOfReferenceSpecificAnnotationManager;
@@ -4394,7 +4397,8 @@ declare namespace viewportFilters {
     export {
         filterViewportsWithToolEnabled,
         filterViewportsWithFrameOfReferenceUID,
-        getViewportIdsWithToolToRender
+        getViewportIdsWithToolToRender,
+        filterViewportsWithParallelNormals
     }
 }
 

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -2175,7 +2175,7 @@ class StackViewport extends Viewport implements IStackViewport {
     // set clipping range back to original to be able
     vtkCamera.setClippingRange(crange[0], crange[1]);
 
-    return worldCoord;
+    return [worldCoord[0], worldCoord[1], worldCoord[2]];
   };
 
   private worldToCanvasGPU = (worldPos: Point3) => {

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -2165,7 +2165,7 @@ class StackViewport extends Viewport implements IStackViewport {
     // The y axis display coordinates are inverted with respect to canvas coords
     displayCoord[1] = size[1] - displayCoord[1];
 
-    let worldCoord = openGLRenderWindow.displayToWorld(
+    const worldCoord = openGLRenderWindow.displayToWorld(
       displayCoord[0],
       displayCoord[1],
       0,
@@ -2174,8 +2174,6 @@ class StackViewport extends Viewport implements IStackViewport {
 
     // set clipping range back to original to be able
     vtkCamera.setClippingRange(crange[0], crange[1]);
-
-    worldCoord = this.applyFlipTx(worldCoord);
 
     return worldCoord;
   };
@@ -2199,7 +2197,7 @@ class StackViewport extends Viewport implements IStackViewport {
       offscreenMultiRenderWindow.getOpenGLRenderWindow();
     const size = openGLRenderWindow.getSize();
     const displayCoord = openGLRenderWindow.worldToDisplay(
-      ...this.applyFlipTx(worldPos),
+      ...worldPos,
       renderer
     );
 

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -542,6 +542,15 @@ class Viewport implements IViewport {
     storeAsInitialCamera = true
   ): boolean {
     const renderer = this.getRenderer();
+
+    // fix the flip right away, since we rely on the viewPlaneNormal and
+    // viewUp for later. Basically, we need to flip back if flipHorizontal
+    // is true or flipVertical is true
+    this.setCamera({
+      flipHorizontal: false,
+      flipVertical: false,
+    });
+
     const previousCamera = _cloneDeep(this.getCamera());
 
     const bounds = renderer.computeVisiblePropBounds();
@@ -559,14 +568,6 @@ class Viewport implements IViewport {
       bounds[4] = bounds[4] + spc[2] / 2;
       bounds[5] = bounds[5] - spc[2] / 2;
     }
-
-    // fix the flip right away, since we rely on the viewPlaneNormal and
-    // viewUp for later. Basically, we need to flip back if flipHorizontal
-    // is true or flipVertical is true
-    this.setCamera({
-      flipHorizontal: false,
-      flipVertical: false,
-    });
 
     const activeCamera = this.getVtkActiveCamera();
     const viewPlaneNormal = <Point3>activeCamera.getViewPlaneNormal();

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -26,15 +26,13 @@ import type {
 } from '../types';
 import type { ViewportInput } from '../types/IViewport';
 import type IVolumeViewport from '../types/IVolumeViewport';
-import { RENDERING_DEFAULTS } from '../constants';
+import { RENDERING_DEFAULTS, EPSILON } from '../constants';
 import { Events, BlendModes, OrientationAxis } from '../enums';
 import eventTarget from '../eventTarget';
 import type { vtkSlabCamera as vtkSlabCameraType } from './vtkClasses/vtkSlabCamera';
 import { imageIdToURI, triggerEvent } from '../utilities';
 import { VoiModifiedEventDetail } from '../types/EventTypes';
 import deepFreeze from '../utilities/deepFreeze';
-
-const EPSILON = 1e-3;
 
 const ORIENTATION = {
   axial: {

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -833,7 +833,7 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
 
     vtkCamera.setIsPerformingCoordinateTransformation(false);
 
-    return worldCoord;
+    return [worldCoord[0], worldCoord[1], worldCoord[2]];
   };
 
   /**

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -784,7 +784,7 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
     const vtkCamera = this.getVtkActiveCamera() as vtkSlabCameraType;
 
     /**
-     * NOTE: this is necessary because we want the coordinate trasformation
+     * NOTE: this is necessary because we want the coordinate transformation
      * respect to the view plane (plane orthogonal to the camera and passing to
      * the focal point).
      *
@@ -826,7 +826,7 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
     // The y axis display coordinates are inverted with respect to canvas coords
     displayCoord[1] = size[1] - displayCoord[1];
 
-    let worldCoord = openGLRenderWindow.displayToWorld(
+    const worldCoord = openGLRenderWindow.displayToWorld(
       displayCoord[0],
       displayCoord[1],
       0,
@@ -835,7 +835,6 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
 
     vtkCamera.setIsPerformingCoordinateTransformation(false);
 
-    worldCoord = this.applyFlipTx(worldCoord);
     return worldCoord;
   };
 
@@ -881,7 +880,7 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
       offscreenMultiRenderWindow.getOpenGLRenderWindow();
     const size = openGLRenderWindow.getSize();
     const displayCoord = openGLRenderWindow.worldToDisplay(
-      ...this.applyFlipTx(worldPos),
+      ...worldPos,
       renderer
     );
 

--- a/packages/core/src/constants/epsilon.ts
+++ b/packages/core/src/constants/epsilon.ts
@@ -1,0 +1,3 @@
+const EPSILON = 1e-3;
+
+export default EPSILON;

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -1,4 +1,5 @@
 import CPU_COLORMAPS from './cpuColormaps';
 import RENDERING_DEFAULTS from './rendering';
+import EPSILON from './epsilon';
 
-export { CPU_COLORMAPS, RENDERING_DEFAULTS };
+export { CPU_COLORMAPS, RENDERING_DEFAULTS, EPSILON };

--- a/packages/tools/examples/crossHairs/index.ts
+++ b/packages/tools/examples/crossHairs/index.ts
@@ -268,8 +268,6 @@ async function run() {
     [viewportId1, viewportId2, viewportId3]
   );
 
-  window.viewport = renderingEngine.getViewport(viewportId1);
-
   // Define tool groups to add the segmentation display tool to
   const toolGroup = ToolGroupManager.createToolGroup(toolGroupId);
 

--- a/packages/tools/examples/crossHairs/index.ts
+++ b/packages/tools/examples/crossHairs/index.ts
@@ -39,7 +39,7 @@ const toolGroupId = 'MY_TOOLGROUP_ID';
 // ======== Set up page ======== //
 setTitleAndDescription(
   'Crosshairs',
-  'Here we demonstrate crosshairs linking three orthogonal views of the same data'
+  'Here we demonstrate crosshairs linking three orthogonal views of the same data. You can select the blend mode that will be used if you modify the slab thickness of the crosshairs by dragging the control points.'
 );
 
 const size = '500px';
@@ -267,6 +267,8 @@ async function run() {
     ],
     [viewportId1, viewportId2, viewportId3]
   );
+
+  window.viewport = renderingEngine.getViewport(viewportId1);
 
   // Define tool groups to add the segmentation display tool to
   const toolGroup = ToolGroupManager.createToolGroup(toolGroupId);

--- a/packages/tools/src/utilities/viewportFilters/filterViewportsWithParallelNormals.ts
+++ b/packages/tools/src/utilities/viewportFilters/filterViewportsWithParallelNormals.ts
@@ -1,0 +1,26 @@
+import { vec3 } from 'gl-matrix';
+
+/**
+ * It filters the viewports that are looking in the same view as the camera
+ * It basically checks if the viewPlaneNormal is parallel to the camera viewPlaneNormal
+ * @param viewports - Array of viewports to filter
+ * @param camera - Camera to compare against
+ * @returns - Array of viewports with the same view
+ */
+export function filterViewportsWithParallelNormals(
+  viewports,
+  camera,
+  EPS = 0.999
+) {
+  return viewports.filter((viewport) => {
+    const vpCamera = viewport.getCamera();
+
+    const isParallel =
+      Math.abs(vec3.dot(vpCamera.viewPlaneNormal, camera.viewPlaneNormal)) >
+      EPS;
+
+    return isParallel;
+  });
+}
+
+export default filterViewportsWithParallelNormals;

--- a/packages/tools/src/utilities/viewportFilters/getViewportIdsWithToolToRender.ts
+++ b/packages/tools/src/utilities/viewportFilters/getViewportIdsWithToolToRender.ts
@@ -1,7 +1,7 @@
 import { getEnabledElement } from '@cornerstonejs/core';
 import filterViewportsWithFrameOfReferenceUID from './filterViewportsWithFrameOfReferenceUID';
 import filterViewportsWithToolEnabled from './filterViewportsWithToolEnabled';
-import filterViewportsWithSameOrientation from './filterViewportsWithSameOrientation';
+import filterViewportsWithParallelNormals from './filterViewportsWithParallelNormals';
 
 /**
  * Given a cornerstone3D enabled `element`, and a `toolName`, find all viewportIds
@@ -10,14 +10,14 @@ import filterViewportsWithSameOrientation from './filterViewportsWithSameOrienta
  *
  * @param element - The target cornerstone3D enabled element.
  * @param toolName - The string toolName.
- * @param requireSameOrientation - If true, only return viewports matching the orientation of the original viewport
+ * @param requireParallelNormals - If true, only return viewports that have parallel normals.
  *
  * @returns An array of viewportIds.
  */
 export default function getViewportIdsWithToolToRender(
   element: HTMLDivElement,
   toolName: string,
-  requireSameOrientation = true
+  requireParallelNormals = true
 ): string[] {
   const enabledElement = getEnabledElement(element);
   const { renderingEngine, FrameOfReferenceUID } = enabledElement;
@@ -32,8 +32,8 @@ export default function getViewportIdsWithToolToRender(
 
   const viewport = renderingEngine.getViewport(enabledElement.viewportId);
 
-  if (requireSameOrientation) {
-    viewports = filterViewportsWithSameOrientation(
+  if (requireParallelNormals) {
+    viewports = filterViewportsWithParallelNormals(
       viewports,
       viewport.getCamera()
     );

--- a/packages/tools/src/utilities/viewportFilters/index.ts
+++ b/packages/tools/src/utilities/viewportFilters/index.ts
@@ -1,9 +1,11 @@
 import filterViewportsWithFrameOfReferenceUID from './filterViewportsWithFrameOfReferenceUID';
 import filterViewportsWithToolEnabled from './filterViewportsWithToolEnabled';
 import getViewportIdsWithToolToRender from './getViewportIdsWithToolToRender';
+import filterViewportsWithParallelNormals from './filterViewportsWithParallelNormals';
 
 export {
   filterViewportsWithToolEnabled,
   filterViewportsWithFrameOfReferenceUID,
   getViewportIdsWithToolToRender,
+  filterViewportsWithParallelNormals,
 };

--- a/packages/tools/test/segmentationState_test.js
+++ b/packages/tools/test/segmentationState_test.js
@@ -158,10 +158,15 @@ describe('Segmentation State -- ', () => {
           expect(segRepresentation.segmentationId).toBe(segVolumeId);
           expect(segRepresentation.type).toBe(LABELMAP);
           expect(segRepresentation.config).toBeDefined();
-
-          done();
         }
       );
+
+      // wait for segmentation render to call done to ensure
+      // all events have been fired and we don't get errors for rendering while
+      // the data is decached
+      eventTarget.addEventListener(Events.SEGMENTATION_RENDERED, (evt) => {
+        done();
+      });
 
       this.segToolGroup.addViewport(vp.id, this.renderingEngine.id);
 


### PR DESCRIPTION
- resetViewport was broken after the new flip implementation
- tool rendering were broken since we were filtering based on the orientation which is not logical with the new flip via camera API
