### PR TITLE
feat: added display area to viewport

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -519,6 +519,27 @@ interface CustomEvent_2<T = any> extends Event {
 const deepMerge: (target?: {}, source?: {}, optionsArgument?: any) => any;
 
 // @public (undocumented)
+type DisplayArea = {
+    imageArea: [number, number];
+    imageCanvasPoint: {
+        imagePoint: [number, number];
+        canvasPoint: [number, number];
+    };
+    storeAsInitialCamera: boolean;
+};
+
+// @public (undocumented)
+type DisplayAreaModifiedEvent = CustomEvent_2<DisplayAreaModifiedEventDetail>;
+
+// @public (undocumented)
+type DisplayAreaModifiedEventDetail = {
+    viewportId: string;
+    displayArea: DisplayArea;
+    volumeId?: string;
+    storeAsInitialCamera?: boolean;
+};
+
+// @public (undocumented)
 enum DynamicOperatorType {
     // (undocumented)
     AVERAGE = "AVERAGE",
@@ -576,6 +597,8 @@ export enum EVENTS {
     CAMERA_MODIFIED = "CORNERSTONE_CAMERA_MODIFIED",
     // (undocumented)
     CAMERA_RESET = "CORNERSTONE_CAMERA_RESET",
+    // (undocumented)
+    DISPLAY_AREA_MODIFIED = "CORNERSTONE_DISPLAY_AREA_MODIFIED",
     // (undocumented)
     ELEMENT_DISABLED = "CORNERSTONE_ELEMENT_DISABLED",
     // (undocumented)
@@ -635,6 +658,8 @@ declare namespace EventTypes {
         CameraModifiedEvent,
         VoiModifiedEvent,
         VoiModifiedEventDetail,
+        DisplayAreaModifiedEvent,
+        DisplayAreaModifiedEventDetail,
         ElementDisabledEvent,
         ElementDisabledEventDetail,
         ElementEnabledEvent,
@@ -1592,6 +1617,8 @@ interface IViewport {
     // (undocumented)
     getDefaultActor(): ActorEntry;
     // (undocumented)
+    getDisplayArea(): DisplayArea | undefined;
+    // (undocumented)
     getFrameOfReferenceUID: () => string;
     // (undocumented)
     getPan(): Point2;
@@ -1623,6 +1650,8 @@ interface IViewport {
     setActors(actors: Array<ActorEntry>): void;
     // (undocumented)
     setCamera(cameraInterface: ICamera, storeAsInitialCamera?: boolean): void;
+    // (undocumented)
+    setDisplayArea(displayArea: DisplayArea, callResetCamera?: boolean, suppressEvents?: boolean): any;
     // (undocumented)
     setOptions(options: ViewportInputOptions, immediate: boolean): void;
     // (undocumented)
@@ -2277,6 +2306,7 @@ declare namespace Types {
         ViewportInputOptions,
         VOIRange,
         VOI,
+        DisplayArea,
         FlipDirection,
         ICachedImage,
         ICachedVolume,
@@ -2408,6 +2438,8 @@ export class Viewport implements IViewport {
     // (undocumented)
     getDefaultActor(): ActorEntry;
     // (undocumented)
+    getDisplayArea(): DisplayArea | undefined;
+    // (undocumented)
     _getEdges(bounds: Array<number>): Array<[number[], number[]]>;
     // (undocumented)
     _getFocalPointForResetCamera(centeredFocalPoint: Point3, previousCamera: ICamera, { resetPan, resetToCenter }: {
@@ -2467,6 +2499,10 @@ export class Viewport implements IViewport {
     // (undocumented)
     protected setCameraNoEvent(camera: ICamera): void;
     // (undocumented)
+    setDisplayArea(displayArea: DisplayArea, suppressEvents?: boolean): void;
+    // (undocumented)
+    protected setFitToCanvasCamera(camera: ICamera): void;
+    // (undocumented)
     protected setInitialCamera(camera: ICamera): void;
     // (undocumented)
     setOptions(options: ViewportInputOptions, immediate?: boolean): void;
@@ -2504,6 +2540,7 @@ export class Viewport implements IViewport {
 type ViewportInputOptions = {
     background?: [number, number, number];
     orientation?: OrientationAxis | OrientationVectors;
+    displayArea?: DisplayArea;
     suppressEvents?: boolean;
     parallelProjection?: boolean;
 };

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -403,6 +403,27 @@ interface CustomEvent_2<T = any> extends Event {
     ): void;
 }
 
+// @public (undocumented)
+type DisplayArea = {
+    imageArea: [number, number]; // areaX, areaY
+    imageCanvasPoint: {
+        imagePoint: [number, number]; // imageX, imageY
+        canvasPoint: [number, number]; // canvasX, canvasY
+    };
+    storeAsInitialCamera: boolean;
+};
+
+// @public
+type DisplayAreaModifiedEvent = CustomEvent_2<DisplayAreaModifiedEventDetail>;
+
+// @public
+type DisplayAreaModifiedEventDetail = {
+    viewportId: string;
+    displayArea: DisplayArea;
+    volumeId?: string;
+    storeAsInitialCamera?: boolean;
+};
+
 // @public
 enum DynamicOperatorType {
     AVERAGE = 'AVERAGE',
@@ -436,6 +457,7 @@ enum Events {
     CAMERA_MODIFIED = 'CORNERSTONE_CAMERA_MODIFIED',
 
     CAMERA_RESET = 'CORNERSTONE_CAMERA_RESET',
+    DISPLAY_AREA_MODIFIED = 'CORNERSTONE_DISPLAY_AREA_MODIFIED',
     ELEMENT_DISABLED = 'CORNERSTONE_ELEMENT_DISABLED',
     ELEMENT_ENABLED = 'CORNERSTONE_ELEMENT_ENABLED',
     GEOMETRY_CACHE_GEOMETRY_ADDED = 'CORNERSTONE_GEOMETRY_CACHE_GEOMETRY_ADDED',
@@ -478,6 +500,8 @@ declare namespace EventTypes {
         CameraModifiedEvent,
         VoiModifiedEvent,
         VoiModifiedEventDetail,
+        DisplayAreaModifiedEvent,
+        DisplayAreaModifiedEventDetail,
         ElementDisabledEvent,
         ElementDisabledEventDetail,
         ElementEnabledEvent,
@@ -1078,6 +1102,7 @@ interface IViewport {
     // (undocumented)
     _getCorners(bounds: Array<number>): Array<number>[];
     getDefaultActor(): ActorEntry;
+    getDisplayArea(): DisplayArea | undefined;
     getFrameOfReferenceUID: () => string;
     getPan(): Point2;
     getRenderer(): void;
@@ -1094,6 +1119,11 @@ interface IViewport {
     reset(immediate: boolean): void;
     setActors(actors: Array<ActorEntry>): void;
     setCamera(cameraInterface: ICamera, storeAsInitialCamera?: boolean): void;
+    setDisplayArea(
+    displayArea: DisplayArea,
+    callResetCamera?: boolean,
+    suppressEvents?: boolean
+    );
     setOptions(options: ViewportInputOptions, immediate: boolean): void;
     setPan(pan: Point2, storeAsInitialCamera?: boolean);
     setZoom(zoom: number, storeAsInitialCamera?: boolean);
@@ -1438,6 +1468,7 @@ type TransformMatrix2D = [number, number, number, number, number, number];
 type ViewportInputOptions = {
     background?: [number, number, number];
     orientation?: OrientationAxis | OrientationVectors;
+    displayArea?: DisplayArea;
     suppressEvents?: boolean;
     parallelProjection?: boolean;
 };

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1458,6 +1458,27 @@ function destroyToolGroup(toolGroupId: string): void;
 function disable(element: any): void;
 
 // @public (undocumented)
+type DisplayArea = {
+    imageArea: [number, number]; // areaX, areaY
+    imageCanvasPoint: {
+        imagePoint: [number, number]; // imageX, imageY
+        canvasPoint: [number, number]; // canvasX, canvasY
+    };
+    storeAsInitialCamera: boolean;
+};
+
+// @public
+type DisplayAreaModifiedEvent = CustomEvent_2<DisplayAreaModifiedEventDetail>;
+
+// @public
+type DisplayAreaModifiedEventDetail = {
+    viewportId: string;
+    displayArea: DisplayArea;
+    volumeId?: string;
+    storeAsInitialCamera?: boolean;
+};
+
+// @public (undocumented)
 function distanceToPoint(lineStart: Types_2.Point2, lineEnd: Types_2.Point2, point: Types_2.Point2): number;
 
 // @public (undocumented)
@@ -1790,6 +1811,8 @@ declare namespace EventTypes {
         CameraModifiedEvent,
         VoiModifiedEvent,
         VoiModifiedEventDetail,
+        DisplayAreaModifiedEvent,
+        DisplayAreaModifiedEventDetail,
         ElementDisabledEvent,
         ElementDisabledEventDetail,
         ElementEnabledEvent,
@@ -2939,6 +2962,7 @@ interface IViewport {
     // (undocumented)
     _getCorners(bounds: Array<number>): Array<number>[];
     getDefaultActor(): ActorEntry;
+    getDisplayArea(): DisplayArea | undefined;
     getFrameOfReferenceUID: () => string;
     getPan(): Point2;
     getRenderer(): void;
@@ -2955,6 +2979,11 @@ interface IViewport {
     reset(immediate: boolean): void;
     setActors(actors: Array<ActorEntry>): void;
     setCamera(cameraInterface: ICamera, storeAsInitialCamera?: boolean): void;
+    setDisplayArea(
+    displayArea: DisplayArea,
+    callResetCamera?: boolean,
+    suppressEvents?: boolean
+    );
     setOptions(options: ViewportInputOptions, immediate: boolean): void;
     setPan(pan: Point2, storeAsInitialCamera?: boolean);
     setZoom(zoom: number, storeAsInitialCamera?: boolean);
@@ -5297,6 +5326,7 @@ declare namespace viewportFilters {
 type ViewportInputOptions = {
     background?: [number, number, number];
     orientation?: OrientationAxis | OrientationVectors;
+    displayArea?: DisplayArea;
     suppressEvents?: boolean;
     parallelProjection?: boolean;
 };

--- a/packages/core/examples/programaticPanZoom/index.ts
+++ b/packages/core/examples/programaticPanZoom/index.ts
@@ -21,6 +21,9 @@ const { ViewportType } = Enums;
 const renderingEngineId = 'myRenderingEngine';
 const viewportId = 'CT_STACK';
 
+function getRand(min, max) {
+  return Math.random() * (max - min) + min;
+}
 // ======== Set up page ======== //
 setTitleAndDescription(
   'Programmatic Pan and Zoom with initial pan and zoom',
@@ -30,6 +33,7 @@ setTitleAndDescription(
 const content = document.getElementById('content');
 const element = document.createElement('div');
 element.id = 'cornerstone-element';
+
 element.style.width = '500px';
 element.style.height = '500px';
 
@@ -65,7 +69,7 @@ addButtonToToolbar({
     );
 
     const zoom = viewport.getZoom();
-    console.log('Current zoom', zoom);
+
     viewport.setZoom(zoom * 1.05);
     viewport.render();
   },
@@ -81,9 +85,7 @@ addButtonToToolbar({
     const viewport = <Types.IVolumeViewport>(
       renderingEngine.getViewport(viewportId)
     );
-    //viewport.resetCamera();
-    viewport.setZoom(1);
-    viewport.setPan([0, 0]);
+    viewport.resetCamera();
     viewport.render();
   },
 });
@@ -101,6 +103,116 @@ addButtonToToolbar({
       renderingEngine.getViewport(viewportId)
     );
     viewport.setZoom(viewport.getZoom(), true);
+  },
+});
+
+addButtonToToolbar({
+  title: 'Set LEFT Display Area',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IVolumeViewport>(
+      renderingEngine.getViewport(viewportId)
+    );
+    viewport.setDisplayArea({
+      imageArea: [1, 1],
+      imageCanvasPoint: {
+        imagePoint: [0, 0.5],
+        canvasPoint: [0, 0.5],
+      },
+      storeAsInitialCamera: true,
+    });
+    viewport.render();
+  },
+});
+
+addButtonToToolbar({
+  title: 'Set RIGHT Display Area',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IVolumeViewport>(
+      renderingEngine.getViewport(viewportId)
+    );
+    viewport.setDisplayArea({
+      imageArea: [1, 1],
+      imageCanvasPoint: {
+        imagePoint: [1, 0.5],
+        canvasPoint: [1, 0.5],
+      },
+      storeAsInitialCamera: true,
+    });
+    viewport.render();
+  },
+});
+
+addButtonToToolbar({
+  title: 'Set TOP Display Area',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IVolumeViewport>(
+      renderingEngine.getViewport(viewportId)
+    );
+    viewport.setDisplayArea({
+      imageArea: [1, 1],
+      imageCanvasPoint: {
+        imagePoint: [0.5, 0],
+        canvasPoint: [0.5, 0],
+      },
+      storeAsInitialCamera: true,
+    });
+    viewport.render();
+  },
+});
+
+addButtonToToolbar({
+  title: 'Set BOTTOM Display Area',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IVolumeViewport>(
+      renderingEngine.getViewport(viewportId)
+    );
+    viewport.setDisplayArea({
+      imageArea: [1, 1],
+      imageCanvasPoint: {
+        imagePoint: [0.5, 1],
+        canvasPoint: [0.5, 1],
+      },
+      storeAsInitialCamera: true,
+    });
+    viewport.render();
+  },
+});
+
+addButtonToToolbar({
+  title: 'Set Random Display Area',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IVolumeViewport>(
+      renderingEngine.getViewport(viewportId)
+    );
+    viewport.setDisplayArea({
+      imageArea: [getRand(0.5, 1.5), getRand(0.5, 1.5)],
+      imageCanvasPoint: {
+        imagePoint: [getRand(0.5, 1.5), getRand(0.5, 1.5)],
+        canvasPoint: [getRand(0.5, 1.5), getRand(0.5, 1.5)],
+      },
+      storeAsInitialCamera: false,
+    });
+    viewport.render();
   },
 });
 
@@ -151,11 +263,6 @@ async function run() {
 
   // Render the image
   viewport.render();
-
-  viewport.setZoom(0.8);
-  viewport.setPan([-128, 0]);
-  // Second one should have no affect
-  viewport.setPan([-128, 0]);
 }
 
 run();

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -502,6 +502,7 @@ class RenderingEngine implements IRenderingEngine {
       options = {
         background: [0, 0, 0],
         orientation: null,
+        displayArea: null,
       };
 
       if (type === ViewportType.ORTHOGRAPHIC) {

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -21,6 +21,7 @@ import type {
   Point3,
   FlipDirection,
   EventTypes,
+  DisplayArea,
 } from '../types';
 import type { ViewportInput, IViewport } from '../types/IViewport';
 import type { vtkSlabCamera } from './vtkClasses/vtkSlabCamera';
@@ -62,7 +63,7 @@ class Viewport implements IViewport {
   _actors: Map<string, any>;
   /** Default options for the viewport which includes orientation, viewPlaneNormal and backgroundColor */
   readonly defaultOptions: any;
-  /** options for the viewport which includes orientation axis and backgroundColor */
+  /** options for the viewport which includes orientation axis, backgroundColor and displayArea */
   options: ViewportInputOptions;
   private _suppressCameraModifiedEvents = false;
   /** A flag representing if viewport methods should fire events or not */
@@ -72,6 +73,10 @@ class Viewport implements IViewport {
    * the relative pan/zoom
    */
   protected initialCamera: ICamera;
+  /** The camera that is defined for resetting displayArea to ensure absolute displayArea
+   * settings
+   */
+  private fitToCanvasCamera: ICamera;
 
   constructor(props: ViewportInput) {
     this.id = props.id;
@@ -155,7 +160,7 @@ class Viewport implements IViewport {
 
     // TODO When this is needed we need to move the camera position.
     // We can steal some logic from the tools we build to do this.
-
+    this.setDisplayArea(this.options.displayArea);
     if (immediate) {
       this.render();
     }
@@ -529,6 +534,80 @@ class Viewport implements IViewport {
   }
 
   /**
+   * Sets the camera to an initial bounds. If
+   * resetPan and resetZoom are true it places the focal point at the center of
+   * the volume (or slice); otherwise, only the camera zoom and camera Pan or Zoom
+   * is reset for the current view.
+   * @param displayArea - The display area of interest.
+   * @param suppressEvents - If true, don't fire displayArea event.
+   */
+  public setDisplayArea(
+    displayArea: DisplayArea,
+    suppressEvents = false
+  ): void {
+    const { storeAsInitialCamera } = displayArea;
+
+    // make calculations relative to the fitToCanvasCamera view
+    this.setCamera(this.fitToCanvasCamera, false);
+
+    const { imageArea, imageCanvasPoint } = displayArea;
+
+    if (imageArea) {
+      const [areaX, areaY] = imageArea;
+      const zoom = Math.min(this.getZoom() / areaX, this.getZoom() / areaY);
+      this.setZoom(zoom, storeAsInitialCamera);
+    }
+
+    // getting the image info
+    const imageData = this.getDefaultImageData();
+    if (imageCanvasPoint && imageData) {
+      const { imagePoint, canvasPoint } = imageCanvasPoint;
+      const [canvasX, canvasY] = canvasPoint;
+      const devicePixelRatio = window?.devicePixelRatio || 1;
+      const validateCanvasPanX = this.sWidth / devicePixelRatio;
+      const validateCanvasPanY = this.sHeight / devicePixelRatio;
+      const canvasPanX = validateCanvasPanX * (canvasX - 0.5);
+      const canvasPanY = validateCanvasPanY * (canvasY - 0.5);
+
+      const dimensions = imageData.getDimensions();
+      const canvasZero = this.worldToCanvas([0, 0, 0]);
+      const canvasEdge = this.worldToCanvas(dimensions);
+      const canvasImage = [
+        canvasEdge[0] - canvasZero[0],
+        canvasEdge[1] - canvasZero[1],
+      ];
+      const [imgWidth, imgHeight] = canvasImage;
+      const [imageX, imageY] = imagePoint;
+      const imagePanX = imgWidth * (0.5 - imageX);
+      const imagePanY = imgHeight * (0.5 - imageY);
+
+      const newPositionX = imagePanX + canvasPanX;
+      const newPositionY = imagePanY + canvasPanY;
+
+      const deltaPoint2: Point2 = [newPositionX, newPositionY];
+      this.setPan(deltaPoint2, storeAsInitialCamera);
+    }
+
+    if (storeAsInitialCamera) {
+      this.options.displayArea = displayArea;
+    }
+
+    if (!suppressEvents) {
+      const eventDetail: EventTypes.DisplayAreaModifiedEventDetail = {
+        viewportId: this.id,
+        displayArea: displayArea,
+        storeAsInitialCamera: storeAsInitialCamera,
+      };
+
+      triggerEvent(this.element, Events.DISPLAY_AREA_MODIFIED, eventDetail);
+    }
+  }
+
+  public getDisplayArea(): DisplayArea | undefined {
+    return this.options.displayArea;
+  }
+
+  /**
    * Resets the camera based on the rendering volume(s) bounds. If
    * resetPan and resetZoom are true it places the focal point at the center of
    * the volume (or slice); otherwise, only the camera zoom and camera Pan or Zoom
@@ -556,7 +635,6 @@ class Viewport implements IViewport {
     });
 
     const previousCamera = _cloneDeep(this.getCamera());
-
     const bounds = renderer.computeVisiblePropBounds();
     const focalPoint = <Point3>[0, 0, 0];
     const imageData = this.getDefaultImageData();
@@ -673,6 +751,8 @@ class Viewport implements IViewport {
 
     const modifiedCamera = _cloneDeep(this.getCamera());
 
+    this.setFitToCanvasCamera(_cloneDeep(this.getCamera()));
+
     if (storeAsInitialCamera) {
       this.setInitialCamera(modifiedCamera);
     }
@@ -688,6 +768,16 @@ class Viewport implements IViewport {
 
     this.triggerCameraModifiedEventIfNecessary(previousCamera, modifiedCamera);
 
+    if (
+      imageData &&
+      this.options.displayArea &&
+      resetZoom &&
+      resetPan &&
+      resetToCenter
+    ) {
+      this.setDisplayArea(this.options.displayArea);
+    }
+
     return true;
   }
 
@@ -699,6 +789,16 @@ class Viewport implements IViewport {
    */
   protected setInitialCamera(camera: ICamera): void {
     this.initialCamera = camera;
+  }
+
+  /**
+   * Sets the provided camera as the displayArea camera.
+   * This allows computing differences applied later as compared to the initial
+   * position, for things like zoom and pan.
+   * @param camera - to store as the initial value.
+   */
+  protected setFitToCanvasCamera(camera: ICamera): void {
+    this.fitToCanvasCamera = camera;
   }
 
   /**

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -160,7 +160,9 @@ class Viewport implements IViewport {
 
     // TODO When this is needed we need to move the camera position.
     // We can steal some logic from the tools we build to do this.
-    this.setDisplayArea(this.options.displayArea);
+    if (this.options?.displayArea) {
+      this.setDisplayArea(this.options?.displayArea);
+    }
     if (immediate) {
       this.render();
     }
@@ -604,7 +606,7 @@ class Viewport implements IViewport {
   }
 
   public getDisplayArea(): DisplayArea | undefined {
-    return this.options.displayArea;
+    return this.options?.displayArea;
   }
 
   /**
@@ -770,12 +772,12 @@ class Viewport implements IViewport {
 
     if (
       imageData &&
-      this.options.displayArea &&
+      this.options?.displayArea &&
       resetZoom &&
       resetPan &&
       resetToCenter
     ) {
-      this.setDisplayArea(this.options.displayArea);
+      this.setDisplayArea(this.options?.displayArea);
     }
 
     return true;

--- a/packages/core/src/enums/Events.ts
+++ b/packages/core/src/enums/Events.ts
@@ -39,6 +39,13 @@ enum Events {
    */
   VOI_MODIFIED = 'CORNERSTONE_VOI_MODIFIED',
   /**
+   * Triggers on the HTML element when viewport modifies its display area
+   *
+   * Make use of {@link EventTypes.DisplayAreaModifiedEvent | DisplayAreaModified Event Type } for typing your event listeners for DISPLAY_AREA_MODIFIED event,
+   * and see what event detail is included in {@link EventTypes.DisplayAreaModifiedEventDetail | DisplayAreaModified Event Detail }
+   */
+  DISPLAY_AREA_MODIFIED = 'CORNERSTONE_DISPLAY_AREA_MODIFIED',
+  /**
    * Triggers on the eventTarget when the element is disabled
    *
    * Make use of {@link EventTypes.ElementDisabledEvent | ElementDisabled Event Type } for typing your event listeners for ELEMENT_DISABLED event,

--- a/packages/core/src/types/EventTypes.ts
+++ b/packages/core/src/types/EventTypes.ts
@@ -8,6 +8,8 @@ import type IImage from './IImage';
 import type IImageVolume from './IImageVolume';
 import type { VOIRange } from './voi';
 import type VOILUTFunctionType from '../enums/VOILUTFunctionType';
+import type DisplayArea from './displayArea';
+
 /**
  * CAMERA_MODIFIED Event's data
  */
@@ -38,6 +40,20 @@ type VoiModifiedEventDetail = {
   volumeId?: string;
   /** VOILUTFunction */
   VOILUTFunction?: VOILUTFunctionType;
+};
+
+/**
+ * DISPLAY_AREA_MODIFIED Event's data
+ */
+type DisplayAreaModifiedEventDetail = {
+  /** Viewport Unique ID in the renderingEngine */
+  viewportId: string;
+  /** new display area */
+  displayArea: DisplayArea;
+  /** Unique ID for the volume in the cache */
+  volumeId?: string;
+  /** Whether displayArea was stored as initial view */
+  storeAsInitialCamera?: boolean;
 };
 
 /**
@@ -260,6 +276,11 @@ type CameraModifiedEvent = CustomEventType<CameraModifiedEventDetail>;
 type VoiModifiedEvent = CustomEventType<VoiModifiedEventDetail>;
 
 /**
+ * DISPLAY_AREA_MODIFIED Event type
+ */
+type DisplayAreaModifiedEvent = CustomEventType<DisplayAreaModifiedEventDetail>;
+
+/**
  * ELEMENT_DISABLED Event type
  */
 type ElementDisabledEvent = CustomEventType<ElementDisabledEventDetail>;
@@ -362,6 +383,8 @@ export type {
   CameraModifiedEvent,
   VoiModifiedEvent,
   VoiModifiedEventDetail,
+  DisplayAreaModifiedEvent,
+  DisplayAreaModifiedEventDetail,
   ElementDisabledEvent,
   ElementDisabledEventDetail,
   ElementEnabledEvent,

--- a/packages/core/src/types/IViewport.ts
+++ b/packages/core/src/types/IViewport.ts
@@ -4,6 +4,7 @@ import Point3 from './Point3';
 import ViewportInputOptions from './ViewportInputOptions';
 import { ActorEntry } from './IActor';
 import ViewportType from '../enums/ViewportType';
+import DisplayArea from './displayArea';
 
 /**
  * Viewport interface for cornerstone viewports
@@ -73,6 +74,14 @@ interface IViewport {
   render(): void;
   /** set options for the viewport */
   setOptions(options: ViewportInputOptions, immediate: boolean): void;
+  /** set displayArea for the viewport */
+  setDisplayArea(
+    displayArea: DisplayArea,
+    callResetCamera?: boolean,
+    suppressEvents?: boolean
+  );
+  /** returns the displayArea */
+  getDisplayArea(): DisplayArea | undefined;
   /** reset camera and options*/
   reset(immediate: boolean): void;
   /** returns the canvas */

--- a/packages/core/src/types/ViewportInputOptions.ts
+++ b/packages/core/src/types/ViewportInputOptions.ts
@@ -1,6 +1,6 @@
 import { OrientationAxis } from '../enums';
 import OrientationVectors from './OrientationVectors';
-
+import DisplayArea from './displayArea';
 /**
  * This type defines the shape of viewport input options, so we can throw when it is incorrect.
  */
@@ -9,6 +9,8 @@ type ViewportInputOptions = {
   background?: [number, number, number];
   /** orientation of the viewport which can be either an Enum for axis Enums.OrientationAxis.[AXIAL|SAGITTAL|CORONAL|DEFAULT] or an object with viewPlaneNormal and viewUp */
   orientation?: OrientationAxis | OrientationVectors;
+  /** displayArea of interest */
+  displayArea?: DisplayArea;
   /** whether the events should be suppressed and not fired*/
   suppressEvents?: boolean;
   /**

--- a/packages/core/src/types/displayArea.ts
+++ b/packages/core/src/types/displayArea.ts
@@ -1,0 +1,10 @@
+type DisplayArea = {
+  imageArea: [number, number]; // areaX, areaY
+  imageCanvasPoint: {
+    imagePoint: [number, number]; // imageX, imageY
+    canvasPoint: [number, number]; // canvasX, canvasY
+  };
+  storeAsInitialCamera: boolean;
+};
+
+export default DisplayArea;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -5,6 +5,7 @@ import type IEnabledElement from './IEnabledElement';
 import type ICache from './ICache';
 import type { IVolume, VolumeScalarData } from './IVolume';
 import type { VOI, VOIRange } from './voi';
+import type DisplayArea from './displayArea';
 import type ImageLoaderFn from './ImageLoaderFn';
 import type IImageVolume from './IImageVolume';
 import type IDynamicImageVolume from './IDynamicImageVolume';
@@ -125,6 +126,7 @@ export type {
   ViewportInputOptions,
   VOIRange,
   VOI,
+  DisplayArea,
   FlipDirection,
   ICachedImage,
   ICachedVolume,

--- a/packages/docs/docs/concepts/cornerstone-core/viewports.md
+++ b/packages/docs/docs/concepts/cornerstone-core/viewports.md
@@ -31,16 +31,52 @@ viewed via 4 viewports in a “4-up” view: Axial MPR, Sagittal MPR, Coronal MP
 - Having a VolumeViewport enables Multi-planar reformation or reconstruction (MPR) by design, in which you can visualize the volume from various different orientations without addition of performance costs.
 - For having image fusion between two series
 
-
-
 ## 3D Viewport
 
 - Sutiable for actual 3D rendering of a volumetric data.
 - For having different types of presets such as Bone, Soft Tissue, Lung, etc.
-
 
 :::note
 
 Both `StackViewport` and `VolumeViewport`, `VolumeViewport3D` are created via the `RenderingEngine` API.
 
 :::
+
+## Initial Display Area
+
+All viewports inherit from the Viewport class which has a `displayArea` field which can be provided.
+This field can be used to programmatically set the initial zoom/pan on an image. By default, the viewport
+will fit the dicom image to the screen. The `displayArea` takes a `DisplayArea` type which has the following
+fields.
+
+```js
+type DisplayArea = {
+  imageArea: [number, number], // areaX, areaY
+  imageCanvasPoint: {
+    imagePoint: [number, number], // imageX, imageY
+    canvasPoint: [number, number], // canvasX, canvasY
+  },
+  storeAsInitialCamera: boolean,
+};
+```
+
+Zoom and pan are all relative to the initial "fit to screen" view.
+
+In order to zoom into the image 200%, we would set the `imageArea` to [0.5, 0.5].
+
+Panning is controlled by a provided `imagePoint` and a provided `canvasPoint`. You can imagine the canvas as a sheet of white paper and the image as another sheet of paper like a chest x-ray. Mark a point in the canvas paper with a pen and then mark another point on your chest x-ray image. Now try to "pan" your image so the point so the `imagePoint` matches the
+`canvasPoint`. This is what the API design of `imageCanvasPoint` represents.
+
+Thus if you wanted to left align you image, you could provide the following value:
+
+```js
+imageCanvasPoint: {
+  imagePoint: [0, 0.5], // imageX, imageY
+  canvasPoint: [0, 0.5], // canvasX, canvasY
+};
+```
+
+This means the left (0) middle (0.5) point on the canvas needs to align with the
+left (0) middle (0.5) point on the image. Values are based on % size of the full image.
+In this example, if we had a 1024 x 1024 x-ray image. The imagePoint would be [0, 512].
+Let's say we were on a mobile iPhone in landscape mode (844 x 390). The canvasPoint would be [0, 195].


### PR DESCRIPTION
Adds initial display area to viewport.

`imageArea` takes a `imageX` and `imageY` which should be a number (0,1]  which determines the % of image to display.
`imageFocalPoint` takes a `focalX` and `focalY` which determines the camera focal point. `focalX=1` and `focalY=1` means the image is in the bottom right corner offscreen.  `focalX=0` and `focalY=0` refers to the upper left corner offscreen and `focalX=0.5` and `focalY=0.5` is the default center image. These numbers represent the XY translation amount as a % of the image width/height

The displayArea will save the stored camera and functions properly for stack viewport. The display area can also be programmatically set with or without saving the stored camera. One use case for programmatic display area setting is to automatically zoom in on a ROI.

Implementation note: setPan is not available despite the existence of imageData and vtkRenderer. It seems the off screen renderer requires some initial imageData render before the `displayToWorld` function is available to the viewer instance. Since the setPan function requires `canvasToWorld` which requires `displayToWorld` we do not use `setPan` in the implementation of setDisplayArea. Instead we use the imageData.indexToWorld function is used instead to calculate the delta vector which the camera should move. This delta vector is doubled so the image can translate completely out of the viewport rather than just 50% (since radius is calculated to fit image).