### PR TITLE
Add new 3D volume viewport

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -2215,7 +2215,9 @@ enum ViewportType {
     // (undocumented)
     PERSPECTIVE = "perspective",
     // (undocumented)
-    STACK = "stack"
+    STACK = "stack",
+    // (undocumented)
+    VOLUME_3D = "volume3d"
 }
 
 // @public (undocumented)

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -42,6 +42,55 @@ function addProvider(provider: (type: string, query: any) => any, priority?: num
 export function addVolumesToViewports(renderingEngine: IRenderingEngine, volumeInputs: Array<IVolumeInput>, viewportIds: Array<string>, immediateRender?: boolean, suppressEvents?: boolean): Promise<void>;
 
 // @public (undocumented)
+export abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
+    constructor(props: ViewportInput);
+    // (undocumented)
+    addVolumes(volumeInputArray: Array<IVolumeInput>, immediate?: boolean, suppressEvents?: boolean): Promise<void>;
+    // (undocumented)
+    canvasToWorld: (canvasPos: Point2) => Point3;
+    // (undocumented)
+    flip(flipDirection: FlipDirection): void;
+    // (undocumented)
+    getBounds(): number[];
+    // (undocumented)
+    getCurrentImageId: () => string;
+    // (undocumented)
+    getCurrentImageIdIndex: () => number;
+    // (undocumented)
+    getFrameOfReferenceUID: () => string;
+    // (undocumented)
+    getImageData(volumeId?: string): IImageData | undefined;
+    // (undocumented)
+    getIntensityFromWorld(point: Point3): number;
+    // (undocumented)
+    getSlabThickness(): number;
+    // (undocumented)
+    hasImageURI: (imageURI: string) => boolean;
+    // (undocumented)
+    hasVolumeId(volumeId: string): boolean;
+    // (undocumented)
+    removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
+    // (undocumented)
+    resetCamera(resetPan?: boolean, resetZoom?: boolean, resetToCenter?: boolean): boolean;
+    // (undocumented)
+    setBlendMode(blendMode: BlendModes, filterActorUIDs?: string[], immediate?: boolean): void;
+    // (undocumented)
+    setOrientation(orientation: OrientationAxis, immediate?: boolean): void;
+    // (undocumented)
+    setProperties({ voiRange }?: VolumeViewportProperties, volumeId?: string, suppressEvents?: boolean): void;
+    // (undocumented)
+    setSlabThickness(slabThickness: number, filterActorUIDs?: string[]): void;
+    // (undocumented)
+    setVolumes(volumeInputArray: Array<IVolumeInput>, immediate?: boolean, suppressEvents?: boolean): Promise<void>;
+    // (undocumented)
+    useCPURendering: boolean;
+    // (undocumented)
+    static get useCustomRenderingPipeline(): boolean;
+    // (undocumented)
+    worldToCanvas: (worldPos: Point3) => Point2;
+}
+
+// @public (undocumented)
 enum BlendModes {
     // (undocumented)
     AVERAGE_INTENSITY_BLEND = 3,
@@ -2231,34 +2280,18 @@ type VolumeNewImageEventDetail = {
 };
 
 // @public (undocumented)
-export class VolumeViewport extends Viewport implements IVolumeViewport {
+export class VolumeViewport extends BaseVolumeViewport {
     constructor(props: ViewportInput);
     // (undocumented)
     addVolumes(volumeInputArray: Array<IVolumeInput>, immediate?: boolean, suppressEvents?: boolean): Promise<void>;
-    // (undocumented)
-    canvasToWorld: (canvasPos: Point2) => Point3;
-    // (undocumented)
-    flip(flipDirection: FlipDirection): void;
-    // (undocumented)
-    getBounds(): number[];
     // (undocumented)
     getCurrentImageId: () => string | undefined;
     // (undocumented)
     getCurrentImageIdIndex: () => number | undefined;
     // (undocumented)
-    getFrameOfReferenceUID: () => string;
-    // (undocumented)
-    getImageData(volumeId?: string): IImageData | undefined;
-    // (undocumented)
     getIntensityFromWorld(point: Point3): number;
     // (undocumented)
     getSlabThickness(): number;
-    // (undocumented)
-    hasImageURI: (imageURI: string) => boolean;
-    // (undocumented)
-    hasVolumeId(volumeId: string): boolean;
-    // (undocumented)
-    removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
     // (undocumented)
     resetCamera(resetPan?: boolean, resetZoom?: boolean, resetToCenter?: boolean): boolean;
     // (undocumented)
@@ -2266,17 +2299,9 @@ export class VolumeViewport extends Viewport implements IVolumeViewport {
     // (undocumented)
     setOrientation(orientation: OrientationAxis, immediate?: boolean): void;
     // (undocumented)
-    setProperties({ voiRange }?: VolumeViewportProperties, volumeId?: string, suppressEvents?: boolean): void;
-    // (undocumented)
     setSlabThickness(slabThickness: number, filterActorUIDs?: any[]): void;
     // (undocumented)
     setVolumes(volumeInputArray: Array<IVolumeInput>, immediate?: boolean, suppressEvents?: boolean): Promise<void>;
-    // (undocumented)
-    useCPURendering: boolean;
-    // (undocumented)
-    static get useCustomRenderingPipeline(): boolean;
-    // (undocumented)
-    worldToCanvas: (worldPos: Point3) => Point2;
 }
 
 // @public (undocumented)

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -138,7 +138,8 @@ declare namespace CONSTANTS {
         colormapsData as CPU_COLORMAPS,
         RENDERING_DEFAULTS,
         mprCameraValues as MPR_CAMERA_VALUES,
-        EPSILON
+        EPSILON,
+        presets as VIEWPORT_PRESETS
     }
 }
 export { CONSTANTS }
@@ -1600,6 +1601,9 @@ type Point3 = [number, number, number];
 type Point4 = [number, number, number, number];
 
 // @public (undocumented)
+const presets: ViewportPreset[];
+
+// @public (undocumented)
 type PreStackNewImageEvent = CustomEvent_2<PreStackNewImageEventDetail>;
 
 // @public (undocumented)
@@ -1957,6 +1961,7 @@ declare namespace Types {
         IVolumeLoadObject,
         IVolumeInput,
         VolumeInputCallback,
+        ViewportPreset,
         Metadata,
         OrientationVectors,
         Point2,
@@ -2174,6 +2179,30 @@ type ViewportInputOptions = {
     orientation?: OrientationAxis | OrientationVectors;
     suppressEvents?: boolean;
 };
+
+// @public (undocumented)
+interface ViewportPreset {
+    // (undocumented)
+    ambient: string;
+    // (undocumented)
+    colorTransfer: string;
+    // (undocumented)
+    diffuse: string;
+    // (undocumented)
+    gradientOpacity: string;
+    // (undocumented)
+    interpolation: string;
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    scalarOpacity: string;
+    // (undocumented)
+    shade: string;
+    // (undocumented)
+    specular: string;
+    // (undocumented)
+    specularPower: string;
+}
 
 // @public (undocumented)
 enum ViewportType {

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -42,6 +42,9 @@ function addProvider(provider: (type: string, query: any) => any, priority?: num
 export function addVolumesToViewports(renderingEngine: IRenderingEngine, volumeInputs: Array<IVolumeInput>, viewportIds: Array<string>, immediateRender?: boolean, suppressEvents?: boolean): Promise<void>;
 
 // @public (undocumented)
+function applyPreset(actor: VolumeActor, preset: ViewportPreset): void;
+
+// @public (undocumented)
 export abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     constructor(props: ViewportInput);
     // (undocumented)
@@ -2033,7 +2036,8 @@ declare namespace utilities {
         calculateViewportsSpatialRegistration,
         spatialRegistrationMetadataProvider,
         getViewportImageCornersInWorld,
-        hasNaNValues
+        hasNaNValues,
+        applyPreset
     }
 }
 export { utilities }

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1250,6 +1250,30 @@ type ViewportInputOptions = {
     suppressEvents?: boolean;
 };
 
+// @public (undocumented)
+interface ViewportPreset {
+    // (undocumented)
+    ambient: string;
+    // (undocumented)
+    colorTransfer: string;
+    // (undocumented)
+    diffuse: string;
+    // (undocumented)
+    gradientOpacity: string;
+    // (undocumented)
+    interpolation: string;
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    scalarOpacity: string;
+    // (undocumented)
+    shade: string;
+    // (undocumented)
+    specular: string;
+    // (undocumented)
+    specularPower: string;
+}
+
 // @public
 enum ViewportType {
     ORTHOGRAPHIC = 'orthographic',

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1279,6 +1279,8 @@ enum ViewportType {
     ORTHOGRAPHIC = 'orthographic',
     PERSPECTIVE = 'perspective',
     STACK = 'stack',
+    // (undocumented)
+    VOLUME_3D = 'volume3d',
 }
 
 // @public (undocumented)

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -4606,6 +4606,30 @@ type ViewportInputOptions = {
     suppressEvents?: boolean;
 };
 
+// @public (undocumented)
+interface ViewportPreset {
+    // (undocumented)
+    ambient: string;
+    // (undocumented)
+    colorTransfer: string;
+    // (undocumented)
+    diffuse: string;
+    // (undocumented)
+    gradientOpacity: string;
+    // (undocumented)
+    interpolation: string;
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    scalarOpacity: string;
+    // (undocumented)
+    shade: string;
+    // (undocumented)
+    specular: string;
+    // (undocumented)
+    specularPower: string;
+}
+
 declare namespace visibility {
     export {
         setAnnotationVisibility,

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -60,6 +60,9 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
       case ViewportType.ORTHOGRAPHIC:
         camera.setParallelProjection(true);
         break;
+      case ViewportType.VOLUME_3D:
+        camera.setParallelProjection(true);
+        break;
       case ViewportType.PERSPECTIVE:
         camera.setParallelProjection(false);
         break;

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -1,0 +1,674 @@
+import vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
+
+import cache from '../cache';
+import ViewportType from '../enums/ViewportType';
+import Viewport from './Viewport';
+import { createVolumeActor } from './helpers';
+import volumeNewImageEventDispatcher, {
+  resetVolumeNewImageState,
+} from './helpers/volumeNewImageEventDispatcher';
+import { loadVolume } from '../volumeLoader';
+import vtkSlabCamera from './vtkClasses/vtkSlabCamera';
+import { getShouldUseCPURendering } from '../init';
+import type {
+  Point2,
+  Point3,
+  IImageData,
+  IVolumeInput,
+  ActorEntry,
+  FlipDirection,
+  VolumeViewportProperties,
+} from '../types';
+import type { ViewportInput } from '../types/IViewport';
+import type IVolumeViewport from '../types/IVolumeViewport';
+import { Events, BlendModes, OrientationAxis } from '../enums';
+import eventTarget from '../eventTarget';
+import { imageIdToURI, triggerEvent } from '../utilities';
+import type { vtkSlabCamera as vtkSlabCameraType } from './vtkClasses/vtkSlabCamera';
+import { VoiModifiedEventDetail } from '../types/EventTypes';
+
+/**
+ * Abstract base class for volume viewports. VolumeViewports are used to render
+ * 3D volumes from which various orientations can be viewed. Since VolumeViewports
+ * use SharedVolumeMappers behind the scene, memory footprint of visualizations
+ * of the same volume in different orientations is very small.
+ *
+ * For setting volumes on viewports you need to use {@link addVolumesToViewports}
+ * which will add volumes to the specified viewports.
+ */
+abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
+  useCPURendering = false;
+  private _FrameOfReferenceUID: string;
+
+  constructor(props: ViewportInput) {
+    super(props);
+
+    this.useCPURendering = getShouldUseCPURendering();
+
+    if (this.useCPURendering) {
+      throw new Error(
+        'VolumeViewports cannot be used whilst CPU Fallback Rendering is enabled.'
+      );
+    }
+
+    const renderer = this.getRenderer();
+
+    const camera = vtkSlabCamera.newInstance();
+    renderer.setActiveCamera(camera);
+
+    switch (this.type) {
+      case ViewportType.ORTHOGRAPHIC:
+        camera.setParallelProjection(true);
+        break;
+      case ViewportType.PERSPECTIVE:
+        camera.setParallelProjection(false);
+        break;
+      default:
+        throw new Error(`Unrecognized viewport type: ${this.type}`);
+    }
+
+    this.initializeVolumeNewImageEventDispatcher();
+  }
+
+  static get useCustomRenderingPipeline(): boolean {
+    return false;
+  }
+
+  private initializeVolumeNewImageEventDispatcher(): void {
+    const volumeNewImageHandlerBound = volumeNewImageHandler.bind(this);
+    const volumeNewImageCleanUpBound = volumeNewImageCleanUp.bind(this);
+
+    function volumeNewImageHandler(cameraEvent) {
+      const { viewportId } = cameraEvent.detail;
+
+      if (viewportId !== this.id || this.isDisabled) {
+        return;
+      }
+
+      const viewportImageData = this.getImageData();
+
+      if (!viewportImageData) {
+        return;
+      }
+
+      volumeNewImageEventDispatcher(cameraEvent);
+    }
+
+    function volumeNewImageCleanUp(evt) {
+      const { viewportId } = evt.detail;
+
+      if (viewportId !== this.id) {
+        return;
+      }
+
+      this.element.removeEventListener(
+        Events.CAMERA_MODIFIED,
+        volumeNewImageHandlerBound
+      );
+
+      eventTarget.removeEventListener(
+        Events.ELEMENT_DISABLED,
+        volumeNewImageCleanUpBound
+      );
+
+      resetVolumeNewImageState(viewportId);
+    }
+
+    this.element.removeEventListener(
+      Events.CAMERA_MODIFIED,
+      volumeNewImageHandlerBound
+    );
+    this.element.addEventListener(
+      Events.CAMERA_MODIFIED,
+      volumeNewImageHandlerBound
+    );
+
+    eventTarget.addEventListener(
+      Events.ELEMENT_DISABLED,
+      volumeNewImageCleanUpBound
+    );
+  }
+
+  /**
+   * Sets the properties for the volume viewport on the volume
+   * (if fusion, it sets it for the first volume in the fusion)
+   *
+   * @param voiRange - Sets the lower and upper voi
+   * @param volumeId - The volume id to set the properties for (if undefined, the first volume)
+   * @param suppressEvents - If true, the viewport will not emit events
+   */
+  public setProperties(
+    { voiRange }: VolumeViewportProperties = {},
+    volumeId?: string,
+    suppressEvents = false
+  ): void {
+    if (volumeId !== undefined && !this.getActor(volumeId)) {
+      return;
+    }
+
+    const actorEntries = this.getActors();
+
+    if (!actorEntries.length) {
+      return;
+    }
+
+    let volumeActor;
+
+    if (volumeId) {
+      const actorEntry = actorEntries.find((entry: ActorEntry) => {
+        return entry.uid === volumeId;
+      });
+
+      volumeActor = actorEntry?.actor as vtkVolume;
+    }
+
+    // // set it for the first volume (if there are more than one - fusion)
+    if (!volumeActor) {
+      volumeActor = actorEntries[0].actor as vtkVolume;
+      volumeId = actorEntries[0].uid;
+    }
+
+    if (!voiRange) {
+      return;
+    }
+
+    // Todo: later when we have more properties, refactor the setVoiRange code below
+    const { lower, upper } = voiRange;
+    volumeActor.getProperty().getRGBTransferFunction(0).setRange(lower, upper);
+
+    if (!suppressEvents) {
+      const eventDetail: VoiModifiedEventDetail = {
+        viewportId: this.id,
+        range: voiRange,
+        volumeId: volumeId,
+      };
+
+      triggerEvent(this.element, Events.VOI_MODIFIED, eventDetail);
+    }
+  }
+
+  /**
+   * Creates volume actors for all volumes defined in the `volumeInputArray`.
+   * For each entry, if a `callback` is supplied, it will be called with the new volume actor as input.
+   * For each entry, if a `blendMode` and/or `slabThickness` is defined, this will be set on the actor's
+   * `VolumeMapper`.
+   *
+   * @param volumeInputArray - The array of `VolumeInput`s which define the volumes to add.
+   * @param immediate - Whether the `Viewport` should be rendered as soon as volumes are added.
+   */
+  public async setVolumes(
+    volumeInputArray: Array<IVolumeInput>,
+    immediate = false,
+    suppressEvents = false
+  ): Promise<void> {
+    const firstImageVolume = cache.getVolume(volumeInputArray[0].volumeId);
+
+    if (!firstImageVolume) {
+      throw new Error(
+        `imageVolume with id: ${firstImageVolume.volumeId} does not exist`
+      );
+    }
+
+    const FrameOfReferenceUID = firstImageVolume.metadata.FrameOfReferenceUID;
+
+    await this._isValidVolumeInputArray(volumeInputArray, FrameOfReferenceUID);
+
+    this._FrameOfReferenceUID = FrameOfReferenceUID;
+
+    const volumeActors = [];
+
+    // One actor per volume
+    for (let i = 0; i < volumeInputArray.length; i++) {
+      const { volumeId, actorUID, slabThickness } = volumeInputArray[i];
+
+      const actor = await createVolumeActor(
+        volumeInputArray[i],
+        this.element,
+        this.id,
+        suppressEvents
+      );
+
+      // We cannot use only volumeId since then we cannot have for instance more
+      // than one representation of the same volume (since actors would have the
+      // same name, and we don't allow that) AND We cannot use only any uid, since
+      // we rely on the volume in the cache for mapper. So we prefer actorUID if
+      // it is defined, otherwise we use volumeId for the actor name.
+      const uid = actorUID || volumeId;
+      volumeActors.push({
+        uid,
+        actor,
+        slabThickness,
+        referenceId: volumeId,
+      });
+    }
+
+    this._setVolumeActors(volumeActors);
+
+    triggerEvent(this.element, Events.VOLUME_VIEWPORT_NEW_VOLUME, {
+      viewportId: this.id,
+      volumeActors,
+    });
+
+    if (immediate) {
+      this.render();
+    }
+  }
+
+  /**
+   * Creates and adds volume actors for all volumes defined in the `volumeInputArray`.
+   * For each entry, if a `callback` is supplied, it will be called with the new volume actor as input.
+   *
+   * @param volumeInputArray - The array of `VolumeInput`s which define the volumes to add.
+   * @param immediate - Whether the `Viewport` should be rendered as soon as volumes are added.
+   */
+  public async addVolumes(
+    volumeInputArray: Array<IVolumeInput>,
+    immediate = false,
+    suppressEvents = false
+  ): Promise<void> {
+    const firstImageVolume = cache.getVolume(volumeInputArray[0].volumeId);
+
+    if (!firstImageVolume) {
+      throw new Error(
+        `imageVolume with id: ${firstImageVolume.volumeId} does not exist`
+      );
+    }
+
+    const volumeActors = [];
+
+    await this._isValidVolumeInputArray(
+      volumeInputArray,
+      this._FrameOfReferenceUID
+    );
+
+    // One actor per volume
+    for (let i = 0; i < volumeInputArray.length; i++) {
+      const { volumeId, visibility, actorUID, slabThickness } =
+        volumeInputArray[i];
+
+      const actor = await createVolumeActor(
+        volumeInputArray[i],
+        this.element,
+        this.id,
+        suppressEvents
+      );
+
+      if (visibility === false) {
+        actor.setVisibility(false);
+      }
+
+      // We cannot use only volumeId since then we cannot have for instance more
+      // than one representation of the same volume (since actors would have the
+      // same name, and we don't allow that) AND We cannot use only any uid, since
+      // we rely on the volume in the cache for mapper. So we prefer actorUID if
+      // it is defined, otherwise we use volumeId for the actor name.
+      const uid = actorUID || volumeId;
+      volumeActors.push({
+        uid,
+        actor,
+        slabThickness,
+        // although the actor UID is defined, we need to use the volumeId for the
+        // referenceId, since the actor UID is used to reference the actor in the
+        // viewport, however, the actor is created from its volumeId
+        // and if later we need to grab the referenced volume from cache,
+        // we can use the referenceId to get the volume from the cache
+        referenceId: volumeId,
+      });
+    }
+
+    this.addActors(volumeActors);
+
+    if (immediate) {
+      // render
+      this.render();
+    }
+  }
+
+  /**
+   * It removes the volume actor from the Viewport. If the volume actor is not in
+   * the viewport, it does nothing.
+   * @param actorUIDs - Array of actor UIDs to remove. In case of simple volume it will
+   * be the volume Id, but in case of Segmentation it will be `{volumeId}-{representationType}`
+   * since the same volume can be rendered in multiple representations.
+   * @param immediate - If true, the Viewport will be rendered immediately
+   */
+  public removeVolumeActors(actorUIDs: Array<string>, immediate = false): void {
+    // Todo: This is actually removeActors
+    this.removeActors(actorUIDs);
+
+    if (immediate) {
+      this.render();
+    }
+  }
+
+  /**
+   * It sets the orientation for the camera, the orientation can be one of the
+   * following: axial, sagittal, coronal, default. Use the Enums.OrientationAxis
+   * to set the orientation. The "default" orientation is the orientation that
+   * the volume was acquired in (scan axis)
+   *
+   * @param orientation - The orientation to set the camera to.
+   * @param immediate - Whether the `Viewport` should be rendered as soon as the camera is set.
+   */
+  public setOrientation(orientation: OrientationAxis, immediate = true): void {
+    console.warn('Method "setOrientation" needs implementation');
+  }
+
+  private async _isValidVolumeInputArray(
+    volumeInputArray: Array<IVolumeInput>,
+    FrameOfReferenceUID: string
+  ): Promise<boolean> {
+    const numVolumes = volumeInputArray.length;
+
+    // Check all other volumes exist and have the same FrameOfReference
+    for (let i = 1; i < numVolumes; i++) {
+      const volumeInput = volumeInputArray[i];
+
+      const imageVolume = await loadVolume(volumeInput.volumeId);
+
+      if (!imageVolume) {
+        throw new Error(
+          `imageVolume with id: ${imageVolume.volumeId} does not exist`
+        );
+      }
+
+      if (FrameOfReferenceUID !== imageVolume.metadata.FrameOfReferenceUID) {
+        throw new Error(
+          `Volumes being added to viewport ${this.id} do not share the same FrameOfReferenceUID. This is not yet supported`
+        );
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * gets the visible bounds of the viewport in the world coordinate system
+   */
+  public getBounds(): number[] {
+    const renderer = this.getRenderer();
+    const bounds = renderer.computeVisiblePropBounds();
+    return bounds;
+  }
+
+  /**
+   * Flip the viewport along the desired axis
+   * @param flipDirection - FlipDirection
+   */
+  public flip(flipDirection: FlipDirection): void {
+    super.flip(flipDirection);
+  }
+
+  public getFrameOfReferenceUID = (): string => {
+    return this._FrameOfReferenceUID;
+  };
+
+  /**
+   * Checks if the viewport has a volume actor with the given volumeId
+   * @param volumeId - the volumeId to look for
+   * @returns Boolean indicating if the volume is present in the viewport
+   */
+  public hasVolumeId(volumeId: string): boolean {
+    // Note: this assumes that the uid of the volume is the same as the volumeId
+    // which is not guaranteed to be the case for SEG.
+    const actorEntries = this.getActors();
+    return actorEntries.some((actorEntry) => {
+      return actorEntry.uid === volumeId;
+    });
+  }
+
+  /**
+   * Returns the image and its properties that is being shown inside the
+   * stack viewport. It returns, the image dimensions, image direction,
+   * image scalar data, vtkImageData object, metadata, and scaling (e.g., PET suvbw)
+   * Note: since the volume viewport supports fusion, to get the
+   * image data for a specific volume, use the optional volumeId
+   * argument.
+   *
+   * @param volumeId - The volumeId of the volume to get the image for.
+   * @returns IImageData: {dimensions, direction, scalarData, vtkImageData, metadata, scaling}
+   */
+  public getImageData(volumeId?: string): IImageData | undefined {
+    const defaultActor = this.getDefaultActor();
+    if (!defaultActor) {
+      return;
+    }
+
+    const { uid: defaultActorUID } = defaultActor;
+    volumeId = volumeId ?? defaultActorUID;
+
+    const { actor } = this.getActor(volumeId);
+
+    if (!actor.isA('vtkVolume')) {
+      return;
+    }
+
+    const volume = cache.getVolume(volumeId);
+
+    const vtkImageData = actor.getMapper().getInputData();
+    return {
+      dimensions: vtkImageData.getDimensions(),
+      spacing: vtkImageData.getSpacing(),
+      origin: vtkImageData.getOrigin(),
+      direction: vtkImageData.getDirection(),
+      scalarData: vtkImageData.getPointData().getScalars().getData(),
+      imageData: actor.getMapper().getInputData(),
+      metadata: {
+        Modality: volume?.metadata?.Modality,
+      },
+      scaling: volume?.scaling,
+      hasPixelSpacing: true,
+    };
+  }
+
+  /**
+   * Attaches the volume actors to the viewport.
+   *
+   * @param volumeActorEntries - The volume actors to add the viewport.
+   *
+   */
+  private _setVolumeActors(volumeActorEntries: Array<ActorEntry>): void {
+    this.setActors(volumeActorEntries);
+  }
+
+  /**
+   * canvasToWorld Returns the world coordinates of the given `canvasPos`
+   * projected onto the plane defined by the `Viewport`'s `vtkCamera`'s focal point
+   * and the direction of projection.
+   *
+   * @param canvasPos - The position in canvas coordinates.
+   * @returns The corresponding world coordinates.
+   * @public
+   */
+  public canvasToWorld = (canvasPos: Point2): Point3 => {
+    const vtkCamera = this.getVtkActiveCamera() as vtkSlabCameraType;
+
+    /**
+     * NOTE: this is necessary because we want the coordinate transformation
+     * respect to the view plane (plane orthogonal to the camera and passing to
+     * the focal point).
+     *
+     * When vtk.js computes the coordinate transformations, it simply uses the
+     * camera matrix (no ray casting).
+     *
+     * However for the volume viewport the clipping range is set to be
+     * (-RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE, RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE).
+     * The clipping range is used in the camera method getProjectionMatrix().
+     * The projection matrix is used then for viewToWorld/worldToView methods of
+     * the renderer. This means that vkt.js will not return the coordinates of
+     * the point on the view plane (i.e. the depth coordinate will correspond
+     * to the focal point).
+     *
+     * Therefore the clipping range has to be set to (distance, distance + 0.01),
+     * where now distance is the distance between the camera position and focal
+     * point. This is done internally, in our camera customization when the flag
+     * isPerformingCoordinateTransformation is set to true.
+     */
+
+    vtkCamera.setIsPerformingCoordinateTransformation(true);
+
+    const renderer = this.getRenderer();
+    const offscreenMultiRenderWindow =
+      this.getRenderingEngine().offscreenMultiRenderWindow;
+    const openGLRenderWindow =
+      offscreenMultiRenderWindow.getOpenGLRenderWindow();
+    const size = openGLRenderWindow.getSize();
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const canvasPosWithDPR = [
+      canvasPos[0] * devicePixelRatio,
+      canvasPos[1] * devicePixelRatio,
+    ];
+    const displayCoord = [
+      canvasPosWithDPR[0] + this.sx,
+      canvasPosWithDPR[1] + this.sy,
+    ];
+
+    // The y axis display coordinates are inverted with respect to canvas coords
+    displayCoord[1] = size[1] - displayCoord[1];
+
+    const worldCoord = openGLRenderWindow.displayToWorld(
+      displayCoord[0],
+      displayCoord[1],
+      0,
+      renderer
+    );
+
+    vtkCamera.setIsPerformingCoordinateTransformation(false);
+
+    return [worldCoord[0], worldCoord[1], worldCoord[2]];
+  };
+
+  /**
+   * Returns the canvas coordinates of the given `worldPos`
+   * projected onto the `Viewport`'s `canvas`.
+   *
+   * @param worldPos - The position in world coordinates.
+   * @returns The corresponding canvas coordinates.
+   * @public
+   */
+  public worldToCanvas = (worldPos: Point3): Point2 => {
+    const vtkCamera = this.getVtkActiveCamera() as vtkSlabCameraType;
+
+    /**
+     * NOTE: this is necessary because we want the coordinate trasformation
+     * respect to the view plane (plane orthogonal to the camera and passing to
+     * the focal point).
+     *
+     * When vtk.js computes the coordinate transformations, it simply uses the
+     * camera matrix (no ray casting).
+     *
+     * However for the volume viewport the clipping range is set to be
+     * (-RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE, RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE).
+     * The clipping range is used in the camera method getProjectionMatrix().
+     * The projection matrix is used then for viewToWorld/worldToView methods of
+     * the renderer. This means that vkt.js will not return the coordinates of
+     * the point on the view plane (i.e. the depth coordinate will corresponded
+     * to the focal point).
+     *
+     * Therefore the clipping range has to be set to (distance, distance + 0.01),
+     * where now distance is the distance between the camera position and focal
+     * point. This is done internally, in our camera customization when the flag
+     * isPerformingCoordinateTransformation is set to true.
+     */
+
+    vtkCamera.setIsPerformingCoordinateTransformation(true);
+
+    const renderer = this.getRenderer();
+    const offscreenMultiRenderWindow =
+      this.getRenderingEngine().offscreenMultiRenderWindow;
+    const openGLRenderWindow =
+      offscreenMultiRenderWindow.getOpenGLRenderWindow();
+    const size = openGLRenderWindow.getSize();
+    const displayCoord = openGLRenderWindow.worldToDisplay(
+      ...worldPos,
+      renderer
+    );
+
+    // The y axis display coordinates are inverted with respect to canvas coords
+    displayCoord[1] = size[1] - displayCoord[1];
+
+    const canvasCoord = <Point2>[
+      displayCoord[0] - this.sx,
+      displayCoord[1] - this.sy,
+    ];
+
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const canvasCoordWithDPR = <Point2>[
+      canvasCoord[0] / devicePixelRatio,
+      canvasCoord[1] / devicePixelRatio,
+    ];
+
+    vtkCamera.setIsPerformingCoordinateTransformation(false);
+
+    return canvasCoordWithDPR;
+  };
+
+  /*
+   * Checking if the imageURI is in the volumes that are being
+   * rendered by the viewport. imageURI is the imageId without the schema
+   * for instance for the imageId of streaming-wadors:http://..., the http://... is the imageURI.
+   * Why we don't check the imageId is because the same image can be shown in
+   * another viewport (StackViewport) with a different schema
+   *
+   * @param imageURI - The imageURI to check
+   * @returns True if the imageURI is in the volumes that are being rendered by the viewport
+   */
+  public hasImageURI = (imageURI: string): boolean => {
+    const volumeActors = this.getActors().filter(({ actor }) =>
+      actor.isA('vtkVolume')
+    );
+
+    return volumeActors.some(({ uid }) => {
+      const volume = cache.getVolume(uid);
+
+      if (!volume || !volume.imageIds) {
+        return false;
+      }
+
+      const volumeImageURIs = volume.imageIds.map(imageIdToURI);
+
+      return volumeImageURIs.includes(imageURI);
+    });
+  };
+
+  /**
+   * Reset the camera for the volume viewport
+   */
+  resetCamera(
+    resetPan?: boolean,
+    resetZoom?: boolean,
+    resetToCenter?: boolean
+  ): boolean {
+    return super.resetCamera(resetPan, resetZoom, resetToCenter);
+  }
+
+  getCurrentImageIdIndex = (): number => {
+    throw new Error('Method not implemented.');
+  };
+
+  getCurrentImageId = (): string => {
+    throw new Error('Method not implemented.');
+  };
+
+  getIntensityFromWorld(point: Point3): number {
+    throw new Error('Method not implemented.');
+  }
+
+  setBlendMode(
+    blendMode: BlendModes,
+    filterActorUIDs?: string[],
+    immediate?: boolean
+  ): void {
+    throw new Error('Method not implemented.');
+  }
+
+  setSlabThickness(slabThickness: number, filterActorUIDs?: string[]): void {
+    throw new Error('Method not implemented.');
+  }
+
+  getSlabThickness(): number {
+    throw new Error('Method not implemented.');
+  }
+}
+
+export default BaseVolumeViewport;

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -21,6 +21,7 @@ import type {
   NormalizedViewportInput,
 } from '../types/IViewport';
 import { OrientationAxis } from '../enums';
+import VolumeViewport3D from './VolumeViewport3D';
 
 type ViewportDisplayCoords = {
   sxStartDisplayCoords: number;
@@ -750,6 +751,8 @@ class RenderingEngine implements IRenderingEngine {
     ) {
       // 4.b Create a volume viewport
       viewport = new VolumeViewport(viewportInput);
+    } else if (type === ViewportType.VOLUME_3D) {
+      viewport = new VolumeViewport3D(viewportInput);
     } else {
       throw new Error(`Viewport Type ${type} is not supported`);
     }

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -5,6 +5,7 @@ import { triggerEvent, uuidv4 } from '../utilities';
 import { vtkOffscreenMultiRenderWindow } from './vtkClasses';
 import ViewportType from '../enums/ViewportType';
 import VolumeViewport from './VolumeViewport';
+import BaseVolumeViewport from './BaseVolumeViewport';
 import StackViewport from './StackViewport';
 import viewportTypeUsesCustomRenderingPipeline from './helpers/viewportTypeUsesCustomRenderingPipeline';
 import getOrCreateCanvas from './helpers/getOrCreateCanvas';
@@ -380,8 +381,8 @@ class RenderingEngine implements IRenderingEngine {
 
     const isVolumeViewport = (
       viewport: IStackViewport | IVolumeViewport
-    ): viewport is VolumeViewport => {
-      return viewport instanceof VolumeViewport;
+    ): viewport is BaseVolumeViewport => {
+      return viewport instanceof BaseVolumeViewport;
     };
 
     return viewports.filter(isVolumeViewport);

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -1,37 +1,19 @@
 import { vec3 } from 'gl-matrix';
 import vtkPlane from '@kitware/vtk.js/Common/DataModel/Plane';
-import vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 
 import cache from '../cache';
-import ViewportType from '../enums/ViewportType';
-import Viewport from './Viewport';
-import { createVolumeActor } from './helpers';
-import volumeNewImageEventDispatcher, {
-  resetVolumeNewImageState,
-} from './helpers/volumeNewImageEventDispatcher';
-import { loadVolume } from '../volumeLoader';
-import vtkSlabCamera from './vtkClasses/vtkSlabCamera';
-import { getShouldUseCPURendering } from '../init';
 import transformWorldToIndex from '../utilities/transformWorldToIndex';
 import type {
-  Point2,
   Point3,
-  IImageData,
   IVolumeInput,
   ActorEntry,
   IImageVolume,
-  FlipDirection,
-  VolumeViewportProperties,
   OrientationVectors,
 } from '../types';
 import type { ViewportInput } from '../types/IViewport';
-import type IVolumeViewport from '../types/IVolumeViewport';
 import { RENDERING_DEFAULTS, MPR_CAMERA_VALUES, EPSILON } from '../constants';
-import { Events, BlendModes, OrientationAxis } from '../enums';
-import eventTarget from '../eventTarget';
-import type { vtkSlabCamera as vtkSlabCameraType } from './vtkClasses/vtkSlabCamera';
-import { imageIdToURI, triggerEvent } from '../utilities';
-import { VoiModifiedEventDetail } from '../types/EventTypes';
+import { BlendModes, OrientationAxis } from '../enums';
+import BaseVolumeViewport from './BaseVolumeViewport';
 
 /**
  * An object representing a VolumeViewport. VolumeViewports are used to render
@@ -42,39 +24,10 @@ import { VoiModifiedEventDetail } from '../types/EventTypes';
  * For setting volumes on viewports you need to use {@link addVolumesToViewports}
  * which will add volumes to the specified viewports.
  */
-class VolumeViewport extends Viewport implements IVolumeViewport {
-  useCPURendering = false;
-  private _FrameOfReferenceUID: string;
+class VolumeViewport extends BaseVolumeViewport {
   private _useAcquisitionPlaneForViewPlane = false;
-
   constructor(props: ViewportInput) {
     super(props);
-
-    this.useCPURendering = getShouldUseCPURendering();
-
-    if (this.useCPURendering) {
-      throw new Error(
-        'VolumeViewports cannot be used whilst CPU Fallback Rendering is enabled.'
-      );
-    }
-
-    const renderer = this.getRenderer();
-
-    const camera = vtkSlabCamera.newInstance();
-    renderer.setActiveCamera(camera);
-
-    switch (this.type) {
-      case ViewportType.ORTHOGRAPHIC:
-        camera.setParallelProjection(true);
-        break;
-      case ViewportType.PERSPECTIVE:
-        camera.setParallelProjection(false);
-        break;
-      default:
-        throw new Error(`Unrecognized viewport type: ${this.type}`);
-    }
-
-    this.initializeVolumeNewImageEventDispatcher();
 
     const { orientation } = this.options;
 
@@ -83,7 +36,7 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
     if (orientation && orientation !== OrientationAxis.ACQUISITION) {
       const { viewPlaneNormal, viewUp } =
         this._getOrientationVectors(orientation);
-
+      const camera = this.getVtkActiveCamera();
       camera.setDirectionOfProjection(
         -viewPlaneNormal[0],
         -viewPlaneNormal[1],
@@ -96,123 +49,6 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
     }
 
     this._useAcquisitionPlaneForViewPlane = true;
-  }
-
-  static get useCustomRenderingPipeline(): boolean {
-    return false;
-  }
-
-  private initializeVolumeNewImageEventDispatcher(): void {
-    const volumeNewImageHandlerBound = volumeNewImageHandler.bind(this);
-    const volumeNewImageCleanUpBound = volumeNewImageCleanUp.bind(this);
-
-    function volumeNewImageHandler(cameraEvent) {
-      const { viewportId } = cameraEvent.detail;
-
-      if (viewportId !== this.id || this.isDisabled) {
-        return;
-      }
-
-      const viewportImageData = this.getImageData();
-
-      if (!viewportImageData) {
-        return;
-      }
-
-      volumeNewImageEventDispatcher(cameraEvent);
-    }
-
-    function volumeNewImageCleanUp(evt) {
-      const { viewportId } = evt.detail;
-
-      if (viewportId !== this.id) {
-        return;
-      }
-
-      this.element.removeEventListener(
-        Events.CAMERA_MODIFIED,
-        volumeNewImageHandlerBound
-      );
-
-      eventTarget.removeEventListener(
-        Events.ELEMENT_DISABLED,
-        volumeNewImageCleanUpBound
-      );
-
-      resetVolumeNewImageState(viewportId);
-    }
-
-    this.element.removeEventListener(
-      Events.CAMERA_MODIFIED,
-      volumeNewImageHandlerBound
-    );
-    this.element.addEventListener(
-      Events.CAMERA_MODIFIED,
-      volumeNewImageHandlerBound
-    );
-
-    eventTarget.addEventListener(
-      Events.ELEMENT_DISABLED,
-      volumeNewImageCleanUpBound
-    );
-  }
-
-  /**
-   * Sets the properties for the volume viewport on the volume
-   * (if fusion, it sets it for the first volume in the fusion)
-   *
-   * @param voiRange - Sets the lower and upper voi
-   * @param volumeId - The volume id to set the properties for (if undefined, the first volume)
-   * @param suppressEvents - If true, the viewport will not emit events
-   */
-  public setProperties(
-    { voiRange }: VolumeViewportProperties = {},
-    volumeId?: string,
-    suppressEvents = false
-  ): void {
-    if (volumeId !== undefined && !this.getActor(volumeId)) {
-      return;
-    }
-
-    const actorEntries = this.getActors();
-
-    if (!actorEntries.length) {
-      return;
-    }
-
-    let volumeActor;
-
-    if (volumeId) {
-      const actorEntry = actorEntries.find((entry: ActorEntry) => {
-        return entry.uid === volumeId;
-      });
-
-      volumeActor = actorEntry?.actor as vtkVolume;
-    }
-
-    // // set it for the first volume (if there are more than one - fusion)
-    if (!volumeActor) {
-      volumeActor = actorEntries[0].actor as vtkVolume;
-      volumeId = actorEntries[0].uid;
-    }
-
-    if (!voiRange) {
-      return;
-    }
-
-    // Todo: later when we have more properties, refactor the setVoiRange code below
-    const { lower, upper } = voiRange;
-    volumeActor.getProperty().getRGBTransferFunction(0).setRange(lower, upper);
-
-    if (!suppressEvents) {
-      const eventDetail: VoiModifiedEventDetail = {
-        viewportId: this.id,
-        range: voiRange,
-        volumeId: volumeId,
-      };
-
-      triggerEvent(this.element, Events.VOI_MODIFIED, eventDetail);
-    }
   }
 
   /**
@@ -242,49 +78,7 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
       this._useAcquisitionPlaneForViewPlane = false;
     }
 
-    const FrameOfReferenceUID = firstImageVolume.metadata.FrameOfReferenceUID;
-
-    await this._isValidVolumeInputArray(volumeInputArray, FrameOfReferenceUID);
-
-    this._FrameOfReferenceUID = FrameOfReferenceUID;
-
-    const volumeActors = [];
-
-    // One actor per volume
-    for (let i = 0; i < volumeInputArray.length; i++) {
-      const { volumeId, actorUID, slabThickness } = volumeInputArray[i];
-
-      const actor = await createVolumeActor(
-        volumeInputArray[i],
-        this.element,
-        this.id,
-        suppressEvents
-      );
-
-      // We cannot use only volumeId since then we cannot have for instance more
-      // than one representation of the same volume (since actors would have the
-      // same name, and we don't allow that) AND We cannot use only any uid, since
-      // we rely on the volume in the cache for mapper. So we prefer actorUID if
-      // it is defined, otherwise we use volumeId for the actor name.
-      const uid = actorUID || volumeId;
-      volumeActors.push({
-        uid,
-        actor,
-        slabThickness,
-        referenceId: volumeId,
-      });
-    }
-
-    this._setVolumeActors(volumeActors);
-
-    triggerEvent(this.element, Events.VOLUME_VIEWPORT_NEW_VOLUME, {
-      viewportId: this.id,
-      volumeActors,
-    });
-
-    if (immediate) {
-      this.render();
-    }
+    return super.setVolumes(volumeInputArray, immediate, suppressEvents);
   }
 
   /**
@@ -312,71 +106,7 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
       this._useAcquisitionPlaneForViewPlane = false;
     }
 
-    const volumeActors = [];
-
-    await this._isValidVolumeInputArray(
-      volumeInputArray,
-      this._FrameOfReferenceUID
-    );
-
-    // One actor per volume
-    for (let i = 0; i < volumeInputArray.length; i++) {
-      const { volumeId, visibility, actorUID, slabThickness } =
-        volumeInputArray[i];
-
-      const actor = await createVolumeActor(
-        volumeInputArray[i],
-        this.element,
-        this.id,
-        suppressEvents
-      );
-
-      if (visibility === false) {
-        actor.setVisibility(false);
-      }
-
-      // We cannot use only volumeId since then we cannot have for instance more
-      // than one representation of the same volume (since actors would have the
-      // same name, and we don't allow that) AND We cannot use only any uid, since
-      // we rely on the volume in the cache for mapper. So we prefer actorUID if
-      // it is defined, otherwise we use volumeId for the actor name.
-      const uid = actorUID || volumeId;
-      volumeActors.push({
-        uid,
-        actor,
-        slabThickness,
-        // although the actor UID is defined, we need to use the volumeId for the
-        // referenceId, since the actor UID is used to reference the actor in the
-        // viewport, however, the actor is created from its volumeId
-        // and if later we need to grab the referenced volume from cache,
-        // we can use the referenceId to get the volume from the cache
-        referenceId: volumeId,
-      });
-    }
-
-    this.addActors(volumeActors);
-
-    if (immediate) {
-      // render
-      this.render();
-    }
-  }
-
-  /**
-   * It removes the volume actor from the Viewport. If the volume actor is not in
-   * the viewport, it does nothing.
-   * @param actorUIDs - Array of actor UIDs to remove. In case of simple volume it will
-   * be the volume Id, but in case of Segmentation it will be `{volumeId}-{representationType}`
-   * since the same volume can be rendered in multiple representations.
-   * @param immediate - If true, the Viewport will be rendered immediately
-   */
-  public removeVolumeActors(actorUIDs: Array<string>, immediate = false): void {
-    // Todo: This is actually removeActors
-    this.removeActors(actorUIDs);
-
-    if (immediate) {
-      this.render();
-    }
+    return super.addVolumes(volumeInputArray, immediate, suppressEvents);
   }
 
   /**
@@ -486,34 +216,6 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
     this.resetCamera();
   }
 
-  private async _isValidVolumeInputArray(
-    volumeInputArray: Array<IVolumeInput>,
-    FrameOfReferenceUID: string
-  ): Promise<boolean> {
-    const numVolumes = volumeInputArray.length;
-
-    // Check all other volumes exist and have the same FrameOfReference
-    for (let i = 1; i < numVolumes; i++) {
-      const volumeInput = volumeInputArray[i];
-
-      const imageVolume = await loadVolume(volumeInput.volumeId);
-
-      if (!imageVolume) {
-        throw new Error(
-          `imageVolume with id: ${imageVolume.volumeId} does not exist`
-        );
-      }
-
-      if (FrameOfReferenceUID !== imageVolume.metadata.FrameOfReferenceUID) {
-        throw new Error(
-          `Volumes being added to viewport ${this.id} do not share the same FrameOfReferenceUID. This is not yet supported`
-        );
-      }
-    }
-
-    return true;
-  }
-
   /**
    * Given a point in world coordinates, return the intensity at that point
    * @param point - The point in world coordinates to get the intensity
@@ -541,21 +243,30 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
     return volume.scalarData[voxelIndex];
   }
 
-  /**
-   * gets the visible bounds of the viewport in the world coordinate system
-   */
-  public getBounds(): number[] {
-    const renderer = this.getRenderer();
-    const bounds = renderer.computeVisiblePropBounds();
-    return bounds;
-  }
+  public setBlendMode(
+    blendMode: BlendModes,
+    filterActorUIDs = [],
+    immediate = false
+  ): void {
+    let actorEntries = this.getActors();
 
-  /**
-   * Flip the viewport along the desired axis
-   * @param flipDirection - FlipDirection
-   */
-  public flip(flipDirection: FlipDirection): void {
-    super.flip(flipDirection);
+    if (filterActorUIDs && filterActorUIDs.length > 0) {
+      actorEntries = actorEntries.filter((actorEntry: ActorEntry) => {
+        return filterActorUIDs.includes(actorEntry.uid);
+      });
+    }
+
+    actorEntries.forEach((actorEntry) => {
+      const { actor } = actorEntry;
+
+      const mapper = actor.getMapper();
+      // @ts-ignore vtk incorrect typing
+      mapper.setBlendMode(blendMode);
+    });
+
+    if (immediate) {
+      this.render();
+    }
   }
 
   /**
@@ -619,36 +330,6 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
     return true;
   }
 
-  public getFrameOfReferenceUID = (): string => {
-    return this._FrameOfReferenceUID;
-  };
-
-  public setBlendMode(
-    blendMode: BlendModes,
-    filterActorUIDs = [],
-    immediate = false
-  ): void {
-    let actorEntries = this.getActors();
-
-    if (filterActorUIDs && filterActorUIDs.length > 0) {
-      actorEntries = actorEntries.filter((actorEntry: ActorEntry) => {
-        return filterActorUIDs.includes(actorEntry.uid);
-      });
-    }
-
-    actorEntries.forEach((actorEntry) => {
-      const { actor } = actorEntry;
-
-      const mapper = actor.getMapper();
-      // @ts-ignore vtk incorrect typing
-      mapper.setBlendMode(blendMode);
-    });
-
-    if (immediate) {
-      this.render();
-    }
-  }
-
   /**
    * It sets the slabThickness of the actors of the viewport. If filterActorUIDs are
    * provided, only the actors with the given UIDs will be affected. If no
@@ -699,206 +380,6 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
   }
 
   /**
-   * Checks if the viewport has a volume actor with the given volumeId
-   * @param volumeId - the volumeId to look for
-   * @returns Boolean indicating if the volume is present in the viewport
-   */
-  public hasVolumeId(volumeId: string): boolean {
-    // Note: this assumes that the uid of the volume is the same as the volumeId
-    // which is not guaranteed to be the case for SEG.
-    const actorEntries = this.getActors();
-    return actorEntries.some((actorEntry) => {
-      return actorEntry.uid === volumeId;
-    });
-  }
-
-  /**
-   * Returns the image and its properties that is being shown inside the
-   * stack viewport. It returns, the image dimensions, image direction,
-   * image scalar data, vtkImageData object, metadata, and scaling (e.g., PET suvbw)
-   * Note: since the volume viewport supports fusion, to get the
-   * image data for a specific volume, use the optional volumeId
-   * argument.
-   *
-   * @param volumeId - The volumeId of the volume to get the image for.
-   * @returns IImageData: {dimensions, direction, scalarData, vtkImageData, metadata, scaling}
-   */
-  public getImageData(volumeId?: string): IImageData | undefined {
-    const defaultActor = this.getDefaultActor();
-    if (!defaultActor) {
-      return;
-    }
-
-    const { uid: defaultActorUID } = defaultActor;
-    volumeId = volumeId ?? defaultActorUID;
-
-    const { actor } = this.getActor(volumeId);
-
-    if (!actor.isA('vtkVolume')) {
-      return;
-    }
-
-    const volume = cache.getVolume(volumeId);
-
-    const vtkImageData = actor.getMapper().getInputData();
-    return {
-      dimensions: vtkImageData.getDimensions(),
-      spacing: vtkImageData.getSpacing(),
-      origin: vtkImageData.getOrigin(),
-      direction: vtkImageData.getDirection(),
-      scalarData: vtkImageData.getPointData().getScalars().getData(),
-      imageData: actor.getMapper().getInputData(),
-      metadata: {
-        Modality: volume?.metadata?.Modality,
-      },
-      scaling: volume?.scaling,
-      hasPixelSpacing: true,
-    };
-  }
-
-  /**
-   * Attaches the volume actors to the viewport.
-   *
-   * @param volumeActorEntries - The volume actors to add the viewport.
-   *
-   */
-  private _setVolumeActors(volumeActorEntries: Array<ActorEntry>): void {
-    this.setActors(volumeActorEntries);
-  }
-
-  /**
-   * canvasToWorld Returns the world coordinates of the given `canvasPos`
-   * projected onto the plane defined by the `Viewport`'s `vtkCamera`'s focal point
-   * and the direction of projection.
-   *
-   * @param canvasPos - The position in canvas coordinates.
-   * @returns The corresponding world coordinates.
-   * @public
-   */
-  public canvasToWorld = (canvasPos: Point2): Point3 => {
-    const vtkCamera = this.getVtkActiveCamera() as vtkSlabCameraType;
-
-    /**
-     * NOTE: this is necessary because we want the coordinate transformation
-     * respect to the view plane (plane orthogonal to the camera and passing to
-     * the focal point).
-     *
-     * When vtk.js computes the coordinate transformations, it simply uses the
-     * camera matrix (no ray casting).
-     *
-     * However for the volume viewport the clipping range is set to be
-     * (-RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE, RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE).
-     * The clipping range is used in the camera method getProjectionMatrix().
-     * The projection matrix is used then for viewToWorld/worldToView methods of
-     * the renderer. This means that vkt.js will not return the coordinates of
-     * the point on the view plane (i.e. the depth coordinate will correspond
-     * to the focal point).
-     *
-     * Therefore the clipping range has to be set to (distance, distance + 0.01),
-     * where now distance is the distance between the camera position and focal
-     * point. This is done internally, in our camera customization when the flag
-     * isPerformingCoordinateTransformation is set to true.
-     */
-
-    vtkCamera.setIsPerformingCoordinateTransformation(true);
-
-    const renderer = this.getRenderer();
-    const offscreenMultiRenderWindow =
-      this.getRenderingEngine().offscreenMultiRenderWindow;
-    const openGLRenderWindow =
-      offscreenMultiRenderWindow.getOpenGLRenderWindow();
-    const size = openGLRenderWindow.getSize();
-    const devicePixelRatio = window.devicePixelRatio || 1;
-    const canvasPosWithDPR = [
-      canvasPos[0] * devicePixelRatio,
-      canvasPos[1] * devicePixelRatio,
-    ];
-    const displayCoord = [
-      canvasPosWithDPR[0] + this.sx,
-      canvasPosWithDPR[1] + this.sy,
-    ];
-
-    // The y axis display coordinates are inverted with respect to canvas coords
-    displayCoord[1] = size[1] - displayCoord[1];
-
-    const worldCoord = openGLRenderWindow.displayToWorld(
-      displayCoord[0],
-      displayCoord[1],
-      0,
-      renderer
-    );
-
-    vtkCamera.setIsPerformingCoordinateTransformation(false);
-
-    return [worldCoord[0], worldCoord[1], worldCoord[2]];
-  };
-
-  /**
-   * Returns the canvas coordinates of the given `worldPos`
-   * projected onto the `Viewport`'s `canvas`.
-   *
-   * @param worldPos - The position in world coordinates.
-   * @returns The corresponding canvas coordinates.
-   * @public
-   */
-  public worldToCanvas = (worldPos: Point3): Point2 => {
-    const vtkCamera = this.getVtkActiveCamera() as vtkSlabCameraType;
-
-    /**
-     * NOTE: this is necessary because we want the coordinate trasformation
-     * respect to the view plane (plane orthogonal to the camera and passing to
-     * the focal point).
-     *
-     * When vtk.js computes the coordinate transformations, it simply uses the
-     * camera matrix (no ray casting).
-     *
-     * However for the volume viewport the clipping range is set to be
-     * (-RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE, RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE).
-     * The clipping range is used in the camera method getProjectionMatrix().
-     * The projection matrix is used then for viewToWorld/worldToView methods of
-     * the renderer. This means that vkt.js will not return the coordinates of
-     * the point on the view plane (i.e. the depth coordinate will corresponded
-     * to the focal point).
-     *
-     * Therefore the clipping range has to be set to (distance, distance + 0.01),
-     * where now distance is the distance between the camera position and focal
-     * point. This is done internally, in our camera customization when the flag
-     * isPerformingCoordinateTransformation is set to true.
-     */
-
-    vtkCamera.setIsPerformingCoordinateTransformation(true);
-
-    const renderer = this.getRenderer();
-    const offscreenMultiRenderWindow =
-      this.getRenderingEngine().offscreenMultiRenderWindow;
-    const openGLRenderWindow =
-      offscreenMultiRenderWindow.getOpenGLRenderWindow();
-    const size = openGLRenderWindow.getSize();
-    const displayCoord = openGLRenderWindow.worldToDisplay(
-      ...worldPos,
-      renderer
-    );
-
-    // The y axis display coordinates are inverted with respect to canvas coords
-    displayCoord[1] = size[1] - displayCoord[1];
-
-    const canvasCoord = <Point2>[
-      displayCoord[0] - this.sx,
-      displayCoord[1] - this.sy,
-    ];
-
-    const devicePixelRatio = window.devicePixelRatio || 1;
-    const canvasCoordWithDPR = <Point2>[
-      canvasCoord[0] / devicePixelRatio,
-      canvasCoord[1] / devicePixelRatio,
-    ];
-
-    vtkCamera.setIsPerformingCoordinateTransformation(false);
-
-    return canvasCoordWithDPR;
-  };
-
-  /**
    * Uses viewport camera and volume actor to decide if the viewport
    * is looking at the volume in the direction of acquisition (imageIds).
    * If so, it uses the origin and focalPoint to calculate the slice index.
@@ -908,34 +389,6 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
    */
   public getCurrentImageIdIndex = (): number | undefined => {
     return this._getImageIdIndex();
-  };
-
-  /*
-   * Checking if the imageURI is in the volumes that are being
-   * rendered by the viewport. imageURI is the imageId without the schema
-   * for instance for the imageId of streaming-wadors:http://..., the http://... is the imageURI.
-   * Why we don't check the imageId is because the same image can be shown in
-   * another viewport (StackViewport) with a different schema
-   *
-   * @param imageURI - The imageURI to check
-   * @returns True if the imageURI is in the volumes that are being rendered by the viewport
-   */
-  public hasImageURI = (imageURI: string): boolean => {
-    const volumeActors = this.getActors().filter(({ actor }) =>
-      actor.isA('vtkVolume')
-    );
-
-    return volumeActors.some(({ uid }) => {
-      const volume = cache.getVolume(uid);
-
-      if (!volume || !volume.imageIds) {
-        return false;
-      }
-
-      const volumeImageURIs = volume.imageIds.map(imageIdToURI);
-
-      return volumeImageURIs.includes(imageURI);
-    });
   };
 
   /**

--- a/packages/core/src/RenderingEngine/VolumeViewport3D.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport3D.ts
@@ -1,0 +1,36 @@
+import BaseVolumeViewport from './BaseVolumeViewport';
+import { RENDERING_DEFAULTS } from '../constants';
+
+/**
+ * An object representing a 3-dimensional volume viewport. VolumeViewport3Ds are used to render
+ * 3D volumes in their entirety, and not just load a single slice at a time.
+ *
+ * For setting volumes on viewports you need to use {@link addVolumesToViewports}
+ * which will add volumes to the specified viewports.
+ */
+class VolumeViewport3D extends BaseVolumeViewport {
+  public resetCamera(
+    resetPan = true,
+    resetZoom = true,
+    resetToCenter = true
+  ): boolean {
+    super.resetCamera(resetPan, resetZoom, resetToCenter);
+    const activeCamera = this.getVtkActiveCamera();
+    // Set large numbers to ensure everything is always rendered
+    if (activeCamera.getParallelProjection()) {
+      activeCamera.setClippingRange(
+        -RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE,
+        RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE
+      );
+    } else {
+      activeCamera.setClippingRange(
+        RENDERING_DEFAULTS.MINIMUM_SLAB_THICKNESS,
+        RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE
+      );
+    }
+
+    return;
+  }
+}
+
+export default VolumeViewport3D;

--- a/packages/core/src/RenderingEngine/helpers/addVolumesToViewports.ts
+++ b/packages/core/src/RenderingEngine/helpers/addVolumesToViewports.ts
@@ -1,4 +1,5 @@
 import { VolumeViewport } from '../';
+import BaseVolumeViewport from '../BaseVolumeViewport';
 import type { IVolumeInput, IRenderingEngine } from '../../types';
 
 /**
@@ -28,10 +29,10 @@ async function addVolumesToViewports(
       throw new Error(`Viewport with Id ${viewportId} does not exist`);
     }
 
-    // if not instance of VolumeViewport, throw
-    if (!(viewport instanceof VolumeViewport)) {
+    // if not instance of BaseVolumeViewport, throw
+    if (!(viewport instanceof BaseVolumeViewport)) {
       console.warn(
-        `Viewport with Id ${viewportId} is not a VolumeViewport. Cannot add volume to this viewport.`
+        `Viewport with Id ${viewportId} is not a BaseVolumeViewport. Cannot add volume to this viewport.`
       );
 
       return;

--- a/packages/core/src/RenderingEngine/helpers/setVolumesForViewports.ts
+++ b/packages/core/src/RenderingEngine/helpers/setVolumesForViewports.ts
@@ -1,4 +1,4 @@
-import { VolumeViewport } from '../';
+import BaseVolumeViewport from '../BaseVolumeViewport';
 import type {
   IVolumeInput,
   IRenderingEngine,
@@ -32,9 +32,9 @@ async function setVolumesForViewports(
       throw new Error(`Viewport with Id ${viewportId} does not exist`);
     }
 
-    // if not instance of VolumeViewport, throw
-    if (!(viewport instanceof VolumeViewport)) {
-      throw new Error('setVolumesForViewports only supports VolumeViewport');
+    // if not instance of BaseVolumeViewport, throw
+    if (!(viewport instanceof BaseVolumeViewport)) {
+      throw new Error('setVolumesForViewports only supports VolumeViewport and VolumeViewport3D');
     }
   });
 

--- a/packages/core/src/RenderingEngine/helpers/viewportTypeToViewportClass.ts
+++ b/packages/core/src/RenderingEngine/helpers/viewportTypeToViewportClass.ts
@@ -2,11 +2,13 @@
 import StackViewport from '../StackViewport';
 import VolumeViewport from '../VolumeViewport';
 import ViewportType from '../../enums/ViewportType';
+import VolumeViewport3D from '../VolumeViewport3D';
 
 const viewportTypeToViewportClass = {
   [ViewportType.ORTHOGRAPHIC]: VolumeViewport,
   [ViewportType.PERSPECTIVE]: VolumeViewport,
   [ViewportType.STACK]: StackViewport,
+  [ViewportType.VOLUME_3D]: VolumeViewport3D,
 };
 
 export default viewportTypeToViewportClass;

--- a/packages/core/src/RenderingEngine/helpers/volumeNewImageEventDispatcher.ts
+++ b/packages/core/src/RenderingEngine/helpers/volumeNewImageEventDispatcher.ts
@@ -5,7 +5,7 @@ import {
 import { EventTypes } from '../../types';
 import { Events } from '../../enums';
 import { getRenderingEngine } from '../getRenderingEngine';
-import VolumeViewport from '../VolumeViewport';
+import BaseVolumeViewport from '../BaseVolumeViewport';
 
 // Keeping track of previous imageIndex for each viewportId
 type VolumeImageState = Record<string, number>;
@@ -35,9 +35,9 @@ function volumeNewImageEventDispatcher(
   const renderingEngine = getRenderingEngine(renderingEngineId);
   const viewport = renderingEngine.getViewport(viewportId);
 
-  if (!(viewport instanceof VolumeViewport)) {
+  if (!(viewport instanceof BaseVolumeViewport)) {
     throw new Error(
-      `volumeNewImageEventDispatcher: viewport is not a VolumeViewport`
+      `volumeNewImageEventDispatcher: viewport is not a BaseVolumeViewport`
     );
   }
 

--- a/packages/core/src/RenderingEngine/index.ts
+++ b/packages/core/src/RenderingEngine/index.ts
@@ -2,6 +2,7 @@ import RenderingEngine from './RenderingEngine';
 import getRenderingEngine from './getRenderingEngine';
 import VolumeViewport from './VolumeViewport';
 import StackViewport from './StackViewport';
+import VolumeViewport3D from './VolumeViewport3D';
 import {
   createVolumeActor,
   createVolumeMapper,
@@ -12,6 +13,7 @@ export {
   getRenderingEngine,
   RenderingEngine,
   VolumeViewport,
+  VolumeViewport3D,
   createVolumeActor,
   createVolumeMapper,
   getOrCreateCanvas,

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -2,5 +2,12 @@ import CPU_COLORMAPS from './cpuColormaps';
 import RENDERING_DEFAULTS from './rendering';
 import EPSILON from './epsilon';
 import MPR_CAMERA_VALUES from './mprCameraValues';
+import VIEWPORT_PRESETS from './viewportPresets';
 
-export { CPU_COLORMAPS, RENDERING_DEFAULTS, MPR_CAMERA_VALUES, EPSILON };
+export {
+  CPU_COLORMAPS,
+  RENDERING_DEFAULTS,
+  MPR_CAMERA_VALUES,
+  EPSILON,
+  VIEWPORT_PRESETS,
+};

--- a/packages/core/src/constants/viewportPresets.ts
+++ b/packages/core/src/constants/viewportPresets.ts
@@ -1,0 +1,357 @@
+import { ViewportPreset } from '../types';
+
+const presets: ViewportPreset[] = [
+  {
+    name: 'CT-AAA',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '10',
+    scalarOpacity:
+      '12 -3024 0 143.556 0 166.222 0.686275 214.389 0.696078 419.736 0.833333 3071 0.803922',
+    specular: '0.2',
+    shade: '1',
+    ambient: '0.1',
+    colorTransfer:
+      '24 -3024 0 0 0 143.556 0.615686 0.356863 0.184314 166.222 0.882353 0.603922 0.290196 214.389 1 1 1 419.736 1 0.937033 0.954531 3071 0.827451 0.658824 1',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-AAA2',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '10',
+    scalarOpacity:
+      '16 -3024 0 129.542 0 145.244 0.166667 157.02 0.5 169.918 0.627451 395.575 0.8125 1578.73 0.8125 3071 0.8125',
+    specular: '0.2',
+    shade: '1',
+    ambient: '0.1',
+    colorTransfer:
+      '32 -3024 0 0 0 129.542 0.54902 0.25098 0.14902 145.244 0.6 0.627451 0.843137 157.02 0.890196 0.47451 0.6 169.918 0.992157 0.870588 0.392157 395.575 1 0.886275 0.658824 1578.73 1 0.829256 0.957922 3071 0.827451 0.658824 1',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Bone',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '10',
+    scalarOpacity: '8 -3024 0 -16.4458 0 641.385 0.715686 3071 0.705882',
+    specular: '0.2',
+    shade: '1',
+    ambient: '0.1',
+    colorTransfer:
+      '16 -3024 0 0 0 -16.4458 0.729412 0.254902 0.301961 641.385 0.905882 0.815686 0.552941 3071 1 1 1',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Bones',
+    gradientOpacity: '4 0 1 985.12 1',
+    specularPower: '1',
+    scalarOpacity: '8 -1000 0 152.19 0 278.93 0.190476 952 0.2',
+    specular: '0',
+    shade: '1',
+    ambient: '0.2',
+    colorTransfer:
+      '20 -1000 0.3 0.3 1 -488 0.3 1 0.3 463.28 1 0 0 659.15 1 0.912535 0.0374849 953 1 0.3 0.3',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Cardiac',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '10',
+    scalarOpacity:
+      '12 -3024 0 -77.6875 0 94.9518 0.285714 179.052 0.553571 260.439 0.848214 3071 0.875',
+    specular: '0.2',
+    shade: '1',
+    ambient: '0.1',
+    colorTransfer:
+      '24 -3024 0 0 0 -77.6875 0.54902 0.25098 0.14902 94.9518 0.882353 0.603922 0.290196 179.052 1 0.937033 0.954531 260.439 0.615686 0 0 3071 0.827451 0.658824 1',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Cardiac2',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '10',
+    scalarOpacity:
+      '12 -3024 0 42.8964 0 163.488 0.428571 277.642 0.776786 1587 0.754902 3071 0.754902',
+    specular: '0.2',
+    shade: '1',
+    ambient: '0.1',
+    colorTransfer:
+      '24 -3024 0 0 0 42.8964 0.54902 0.25098 0.14902 163.488 0.917647 0.639216 0.0588235 277.642 1 0.878431 0.623529 1587 1 1 1 3071 0.827451 0.658824 1',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Cardiac3',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '10',
+    scalarOpacity:
+      '14 -3024 0 -86.9767 0 45.3791 0.169643 139.919 0.589286 347.907 0.607143 1224.16 0.607143 3071 0.616071',
+    specular: '0.2',
+    shade: '1',
+    ambient: '0.1',
+    colorTransfer:
+      '28 -3024 0 0 0 -86.9767 0 0.25098 1 45.3791 1 0 0 139.919 1 0.894893 0.894893 347.907 1 1 0.25098 1224.16 1 1 1 3071 0.827451 0.658824 1',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Chest-Contrast-Enhanced',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '10',
+    scalarOpacity:
+      '10 -3024 0 67.0106 0 251.105 0.446429 439.291 0.625 3071 0.616071',
+    specular: '0.2',
+    shade: '1',
+    ambient: '0.1',
+    colorTransfer:
+      '20 -3024 0 0 0 67.0106 0.54902 0.25098 0.14902 251.105 0.882353 0.603922 0.290196 439.291 1 0.937033 0.954531 3071 0.827451 0.658824 1',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Chest-Vessels',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '1',
+    scalarOpacity:
+      '10 -3024 0 -1278.35 0 22.8277 0.428571 439.291 0.625 3071 0.616071',
+    specular: '0',
+    shade: '1',
+    ambient: '0.2',
+    colorTransfer:
+      '20 -3024 0 0 0 -1278.35 0.54902 0.25098 0.14902 22.8277 0.882353 0.603922 0.290196 439.291 1 0.937033 0.954531 3071 0.827451 0.658824 1',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Coronary-Arteries',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '1',
+    scalarOpacity:
+      '12 -2048 0 136.47 0 159.215 0.258929 318.43 0.571429 478.693 0.776786 3661 1',
+    specular: '0',
+    shade: '0',
+    ambient: '0.2',
+    colorTransfer:
+      '24 -2048 0 0 0 136.47 0 0 0 159.215 0.159804 0.159804 0.159804 318.43 0.764706 0.764706 0.764706 478.693 1 1 1 3661 1 1 1',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Coronary-Arteries-2',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '1',
+    scalarOpacity:
+      '14 -2048 0 142.677 0 145.016 0.116071 192.174 0.5625 217.24 0.776786 384.347 0.830357 3661 0.830357',
+    specular: '0',
+    shade: '1',
+    ambient: '0.2',
+    colorTransfer:
+      '28 -2048 0 0 0 142.677 0 0 0 145.016 0.615686 0 0.0156863 192.174 0.909804 0.454902 0 217.24 0.972549 0.807843 0.611765 384.347 0.909804 0.909804 1 3661 1 1 1',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Coronary-Arteries-3',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '10',
+    scalarOpacity:
+      '14 -2048 0 128.643 0 129.982 0.0982143 173.636 0.669643 255.884 0.857143 584.878 0.866071 3661 1',
+    specular: '0.2',
+    shade: '1',
+    ambient: '0.1',
+    colorTransfer:
+      '28 -2048 0 0 0 128.643 0 0 0 129.982 0.615686 0 0.0156863 173.636 0.909804 0.454902 0 255.884 0.886275 0.886275 0.886275 584.878 0.968627 0.968627 0.968627 3661 1 1 1',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Cropped-Volume-Bone',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '1',
+    scalarOpacity: '10 -2048 0 -451 0 -450 1 1050 1 3661 1',
+    specular: '0',
+    shade: '0',
+    ambient: '0.2',
+    colorTransfer:
+      '20 -2048 0 0 0 -451 0 0 0 -450 0.0556356 0.0556356 0.0556356 1050 1 1 1 3661 1 1 1',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Fat',
+    gradientOpacity: '6 0 1 985.12 1 988 1',
+    specularPower: '1',
+    scalarOpacity: '14 -1000 0 -100 0 -99 0.15 -60 0.15 -59 0 101.2 0 952 0',
+    specular: '0',
+    shade: '0',
+    ambient: '0.2',
+    colorTransfer:
+      '36 -1000 0.3 0.3 1 -497.5 0.3 1 0.3 -99 0 0 1 -76.946 0 1 0 -65.481 0.835431 0.888889 0.0165387 83.89 1 0 0 463.28 1 0 0 659.15 1 0.912535 0.0374849 2952 1 0.300267 0.299886',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Liver-Vasculature',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '1',
+    scalarOpacity:
+      '14 -2048 0 149.113 0 157.884 0.482143 339.96 0.660714 388.526 0.830357 1197.95 0.839286 3661 0.848214',
+    specular: '0',
+    shade: '0',
+    ambient: '0.2',
+    colorTransfer:
+      '28 -2048 0 0 0 149.113 0 0 0 157.884 0.501961 0.25098 0 339.96 0.695386 0.59603 0.36886 388.526 0.854902 0.85098 0.827451 1197.95 1 1 1 3661 1 1 1',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Lung',
+    gradientOpacity: '6 0 1 985.12 1 988 1',
+    specularPower: '1',
+    scalarOpacity: '12 -1000 0 -600 0 -599 0.15 -400 0.15 -399 0 2952 0',
+    specular: '0',
+    shade: '1',
+    ambient: '0.2',
+    colorTransfer:
+      '24 -1000 0.3 0.3 1 -600 0 0 1 -530 0.134704 0.781726 0.0724558 -460 0.929244 1 0.109473 -400 0.888889 0.254949 0.0240258 2952 1 0.3 0.3',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-MIP',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '10',
+    scalarOpacity: '8 -3024 0 -637.62 0 700 1 3071 1',
+    specular: '0.2',
+    shade: '1',
+    ambient: '0.1',
+    colorTransfer: '16 -3024 0 0 0 -637.62 1 1 1 700 1 1 1 3071 1 1 1',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Muscle',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '10',
+    scalarOpacity:
+      '10 -3024 0 -155.407 0 217.641 0.676471 419.736 0.833333 3071 0.803922',
+    specular: '0.2',
+    shade: '1',
+    ambient: '0.1',
+    colorTransfer:
+      '20 -3024 0 0 0 -155.407 0.54902 0.25098 0.14902 217.641 0.882353 0.603922 0.290196 419.736 1 0.937033 0.954531 3071 0.827451 0.658824 1',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Pulmonary-Arteries',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '1',
+    scalarOpacity:
+      '14 -2048 0 -568.625 0 -364.081 0.0714286 -244.813 0.401786 18.2775 0.607143 447.798 0.830357 3592.73 0.839286',
+    specular: '0',
+    shade: '1',
+    ambient: '0.2',
+    colorTransfer:
+      '28 -2048 0 0 0 -568.625 0 0 0 -364.081 0.396078 0.301961 0.180392 -244.813 0.611765 0.352941 0.0705882 18.2775 0.843137 0.0156863 0.156863 447.798 0.752941 0.752941 0.752941 3592.73 1 1 1',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Soft-Tissue',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '1',
+    scalarOpacity: '10 -2048 0 -167.01 0 -160 1 240 1 3661 1',
+    specular: '0',
+    shade: '0',
+    ambient: '0.2',
+    colorTransfer:
+      '20 -2048 0 0 0 -167.01 0 0 0 -160 0.0556356 0.0556356 0.0556356 240 1 1 1 3661 1 1 1',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'CT-Air',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '10',
+    scalarOpacity: '8 -3024 0.705882 -900.0 0.715686 -500.0 0 3071 0',
+    specular: '0.2',
+    shade: '1',
+    ambient: '0.1',
+    colorTransfer:
+      '16 -3024 1 1 1 -900.0 0.2 1.0 1.0 -500.0 0.3 0.3 1.0 3071 0 0 0 ',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+  {
+    name: 'MR-Angio',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '1',
+    scalarOpacity:
+      '12 -2048 0 151.354 0 158.279 0.4375 190.112 0.580357 200.873 0.732143 3661 0.741071',
+    specular: '0',
+    shade: '1',
+    ambient: '0.2',
+    colorTransfer:
+      '24 -2048 0 0 0 151.354 0 0 0 158.279 0.74902 0.376471 0 190.112 1 0.866667 0.733333 200.873 0.937255 0.937255 0.937255 3661 1 1 1',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'MR-Default',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '1',
+    scalarOpacity: '12 0 0 20 0 40 0.15 120 0.3 220 0.375 1024 0.5',
+    specular: '0',
+    shade: '1',
+    ambient: '0.2',
+    colorTransfer:
+      '24 0 0 0 0 20 0.168627 0 0 40 0.403922 0.145098 0.0784314 120 0.780392 0.607843 0.380392 220 0.847059 0.835294 0.788235 1024 1 1 1',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'MR-MIP',
+    gradientOpacity: '4 0 1 255 1',
+    specularPower: '1',
+    scalarOpacity: '8 0 0 98.3725 0 416.637 1 2800 1',
+    specular: '0',
+    shade: '0',
+    ambient: '0.2',
+    colorTransfer: '16 0 1 1 1 98.3725 1 1 1 416.637 1 1 1 2800 1 1 1',
+    diffuse: '1',
+    interpolation: '1',
+  },
+  {
+    name: 'MR-T2-Brain',
+    gradientOpacity: '4 0 1 160.25 1',
+    specularPower: '40',
+    scalarOpacity: '10 0 0 36.05 0 218.302 0.171429 412.406 1 641 1',
+    specular: '0.5',
+    shade: '1',
+    ambient: '0.3',
+    colorTransfer:
+      '16 0 0 0 0 98.7223 0.956863 0.839216 0.192157 412.406 0 0.592157 0.807843 641 1 1 1',
+    diffuse: '0.6',
+    interpolation: '1',
+  },
+  {
+    name: 'DTI-FA-Brain',
+    gradientOpacity: '4 0 1 0.9950 1',
+    specularPower: '40',
+    scalarOpacity:
+      '16 0 0 0 0 0.3501 0.0158 0.49379 0.7619 0.6419 1 0.9920 1 0.9950 0 0.9950 0',
+    specular: '0.5',
+    shade: '1',
+    ambient: '0.3',
+    colorTransfer:
+      '28 0 1 0 0 0 1 0 0 0.24974 0.4941 1 0 0.49949 0 0.9882 1 0.7492 0.51764 0 1 0.9950 1 0 0 0.9950 1 0 0',
+    diffuse: '0.9',
+    interpolation: '1',
+  },
+];
+
+export default presets;

--- a/packages/core/src/enums/ViewportType.ts
+++ b/packages/core/src/enums/ViewportType.ts
@@ -15,6 +15,7 @@ enum ViewportType {
   ORTHOGRAPHIC = 'orthographic',
   /** Perspective Viewport: Not Implemented yet */
   PERSPECTIVE = 'perspective',
+  VOLUME_3D = 'volume3d',
 }
 
 export default ViewportType;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from './RenderingEngine';
 import RenderingEngine from './RenderingEngine';
 import VolumeViewport from './RenderingEngine/VolumeViewport';
+import BaseVolumeViewport from './RenderingEngine/BaseVolumeViewport';
 import StackViewport from './RenderingEngine/StackViewport';
 import Viewport from './RenderingEngine/Viewport';
 import eventTarget from './eventTarget';
@@ -62,6 +63,7 @@ export {
   //
   Settings,
   // Rendering Engine
+  BaseVolumeViewport,
   VolumeViewport,
   Viewport,
   StackViewport,

--- a/packages/core/src/types/ViewportPreset.ts
+++ b/packages/core/src/types/ViewportPreset.ts
@@ -1,0 +1,14 @@
+interface ViewportPreset {
+  name: string;
+  gradientOpacity: string;
+  specularPower: string;
+  scalarOpacity: string;
+  specular: string;
+  shade: string;
+  ambient: string;
+  colorTransfer: string;
+  diffuse: string;
+  interpolation: string;
+}
+
+export default ViewportPreset;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -40,6 +40,7 @@ import type ICachedImage from './ICachedImage';
 import type ICachedVolume from './ICachedVolume';
 import type IStackViewport from './IStackViewport';
 import type IVolumeViewport from './IVolumeViewport';
+import type ViewportPreset from './ViewportPreset';
 
 // CPU types
 import type CPUFallbackEnabledElement from './CPUFallbackEnabledElement';
@@ -93,6 +94,7 @@ export type {
   IVolumeLoadObject,
   IVolumeInput,
   VolumeInputCallback,
+  ViewportPreset,
   //
   Metadata,
   OrientationVectors,

--- a/packages/core/src/utilities/applyPreset.ts
+++ b/packages/core/src/utilities/applyPreset.ts
@@ -1,0 +1,132 @@
+import vtkColorTransferFunction from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkPiecewiseFunction from '@kitware/vtk.js/Common/DataModel/PiecewiseFunction';
+import { ViewportPreset } from '../types';
+import { VolumeActor } from '../types/IActor';
+
+/**
+ * Applies a preset to a volume actor.
+ *
+ * @param actor - The volume actor to apply the preset to.
+ * @param preset - The preset to apply.
+ */
+export default function applyPreset(actor: VolumeActor, preset: ViewportPreset) {
+  // Create color transfer function
+  const colorTransferArray = preset.colorTransfer
+    .split(' ')
+    .splice(1)
+    .map(parseFloat);
+
+  const { shiftRange } = getShiftRange(colorTransferArray);
+  const min = shiftRange[0];
+  const width = shiftRange[1] - shiftRange[0];
+  const cfun = vtkColorTransferFunction.newInstance();
+  const normColorTransferValuePoints = [];
+  for (let i = 0; i < colorTransferArray.length; i += 4) {
+    let value = colorTransferArray[i];
+    const r = colorTransferArray[i + 1];
+    const g = colorTransferArray[i + 2];
+    const b = colorTransferArray[i + 3];
+
+    value = (value - min) / width;
+    normColorTransferValuePoints.push([value, r, g, b]);
+  }
+
+  applyPointsToRGBFunction(normColorTransferValuePoints, shiftRange, cfun);
+
+  actor.getProperty().setRGBTransferFunction(0, cfun);
+
+  // Create scalar opacity function
+  const scalarOpacityArray = preset.scalarOpacity
+    .split(' ')
+    .splice(1)
+    .map(parseFloat);
+
+  const ofun = vtkPiecewiseFunction.newInstance();
+  const normPoints = [];
+  for (let i = 0; i < scalarOpacityArray.length; i += 2) {
+    let value = scalarOpacityArray[i];
+    const opacity = scalarOpacityArray[i + 1];
+
+    value = (value - min) / width;
+
+    normPoints.push([value, opacity]);
+  }
+
+  applyPointsToPiecewiseFunction(normPoints, shiftRange, ofun);
+
+  actor.getProperty().setScalarOpacity(0, ofun);
+
+  const [
+    gradientMinValue,
+    gradientMinOpacity,
+    gradientMaxValue,
+    gradientMaxOpacity,
+  ] = preset.gradientOpacity.split(' ').splice(1).map(parseFloat);
+
+  actor.getProperty().setUseGradientOpacity(0, true);
+  actor.getProperty().setGradientOpacityMinimumValue(0, gradientMinValue);
+  actor.getProperty().setGradientOpacityMinimumOpacity(0, gradientMinOpacity);
+  actor.getProperty().setGradientOpacityMaximumValue(0, gradientMaxValue);
+  actor.getProperty().setGradientOpacityMaximumOpacity(0, gradientMaxOpacity);
+
+  if (preset.interpolation === '1') {
+    actor.getProperty().setInterpolationTypeToFastLinear();
+    //actor.getProperty().setInterpolationTypeToLinear()
+  }
+
+  const ambient = parseFloat(preset.ambient);
+  const diffuse = parseFloat(preset.diffuse);
+  const specular = parseFloat(preset.specular);
+  const specularPower = parseFloat(preset.specularPower);
+
+  actor.getProperty().setAmbient(ambient);
+  actor.getProperty().setDiffuse(diffuse);
+  actor.getProperty().setSpecular(specular);
+  actor.getProperty().setSpecularPower(specularPower);
+}
+
+function getShiftRange(colorTransferArray) {
+  // Credit to paraview-glance
+  // https://github.com/Kitware/paraview-glance/blob/3fec8eeff31e9c19ad5b6bff8e7159bd745e2ba9/src/components/controls/ColorBy/script.js#L133
+
+  // shift range is original rgb/opacity range centered around 0
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < colorTransferArray.length; i += 4) {
+    min = Math.min(min, colorTransferArray[i]);
+    max = Math.max(max, colorTransferArray[i]);
+  }
+
+  const center = (max - min) / 2;
+
+  return {
+    shiftRange: [-center, center],
+    min,
+    max,
+  };
+}
+
+function applyPointsToRGBFunction(points, range, cfun) {
+  const width = range[1] - range[0];
+  const rescaled = points.map(([x, r, g, b]) => [
+    x * width + range[0],
+    r,
+    g,
+    b,
+  ]);
+
+  cfun.removeAllPoints();
+  rescaled.forEach(([x, r, g, b]) => cfun.addRGBPoint(x, r, g, b));
+
+  return rescaled;
+}
+
+function applyPointsToPiecewiseFunction(points, range, pwf) {
+  const width = range[1] - range[0];
+  const rescaled = points.map(([x, y]) => [x * width + range[0], y]);
+
+  pwf.removeAllPoints();
+  rescaled.forEach(([x, y]) => pwf.addPoint(x, y));
+
+  return rescaled;
+}

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -32,6 +32,7 @@ import calculateViewportsSpatialRegistration from './calculateViewportsSpatialRe
 import spatialRegistrationMetadataProvider from './spatialRegistrationMetadataProvider';
 import getViewportImageCornersInWorld from './getViewportImageCornersInWorld';
 import hasNaNValues from './hasNaNValues';
+import applyPreset from './applyPreset';
 
 // name spaces
 import * as planar from './planar';
@@ -74,4 +75,5 @@ export {
   spatialRegistrationMetadataProvider,
   getViewportImageCornersInWorld,
   hasNaNValues,
+  applyPreset,
 };

--- a/packages/tools/examples/volumeViewport3D/index.ts
+++ b/packages/tools/examples/volumeViewport3D/index.ts
@@ -1,0 +1,159 @@
+import {
+  RenderingEngine,
+  Types,
+  Enums,
+  setVolumesForViewports,
+  volumeLoader,
+  utilities,
+  CONSTANTS,
+} from '@cornerstonejs/core';
+import {
+  initDemo,
+  createImageIdsAndCacheMetaData,
+  setTitleAndDescription,
+} from '../../../../utils/demo/helpers';
+import * as cornerstoneTools from '@cornerstonejs/tools';
+import { VolumeActor } from 'core/src/types';
+
+// This is for debugging purposes
+console.warn(
+  'Click on index.ts to open source code for this example --------->'
+);
+
+const {
+  ToolGroupManager,
+  TrackballRotateTool,
+  Enums: csToolsEnums,
+} = cornerstoneTools;
+
+const { ViewportType } = Enums;
+const { MouseBindings } = csToolsEnums;
+
+// Define a unique id for the volume
+const volumeName = 'CT_VOLUME_ID'; // Id of the volume less loader prefix
+const volumeLoaderScheme = 'cornerstoneStreamingImageVolume'; // Loader id which defines which volume loader to use
+const volumeId = `${volumeLoaderScheme}:${volumeName}`; // VolumeId with loader id + volume id
+
+// ======== Set up page ======== //
+setTitleAndDescription(
+  '3D Volume Rendering',
+  'Here we demonstrate how to 3D render a volume.'
+);
+
+const size = '500px';
+const content = document.getElementById('content');
+const viewportGrid = document.createElement('div');
+
+viewportGrid.style.display = 'flex';
+viewportGrid.style.display = 'flex';
+viewportGrid.style.flexDirection = 'row';
+
+const element1 = document.createElement('div');
+element1.oncontextmenu = () => false;
+
+element1.style.width = size;
+element1.style.height = size;
+
+viewportGrid.appendChild(element1);
+
+content.appendChild(viewportGrid);
+
+const instructions = document.createElement('p');
+instructions.innerText = 'Click the image to rotate it.';
+
+content.append(instructions);
+// ============================= //
+
+/**
+ * Runs the demo
+ */
+async function run() {
+  // Init Cornerstone and related libraries
+  await initDemo();
+
+  const toolGroupId = 'TOOL_GROUP_ID';
+
+  // Add tools to Cornerstone3D
+  cornerstoneTools.addTool(TrackballRotateTool);
+
+  // Define a tool group, which defines how mouse events map to tool commands for
+  // Any viewport using the group
+  const toolGroup = ToolGroupManager.createToolGroup(toolGroupId);
+
+  // Add the tools to the tool group and specify which volume they are pointing at
+  toolGroup.addTool(TrackballRotateTool.toolName, {
+    configuration: { volumeId },
+  });
+
+  // Set the initial state of the tools, here we set one tool active on left click.
+  // This means left click will draw that tool.
+  toolGroup.setToolActive(TrackballRotateTool.toolName, {
+    bindings: [
+      {
+        mouseButton: MouseBindings.Primary, // Left Click
+      },
+    ],
+  });
+
+  // Get Cornerstone imageIds and fetch metadata into RAM
+  const imageIds = await createImageIdsAndCacheMetaData({
+    StudyInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463',
+    SeriesInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561',
+    wadoRsRoot: 'https://d3t6nz73ql33tx.cloudfront.net/dicomweb',
+    type: 'VOLUME',
+  });
+
+  // Instantiate a rendering engine
+  const renderingEngineId = 'myRenderingEngine';
+  const renderingEngine = new RenderingEngine(renderingEngineId);
+
+  // Create the viewports
+  const viewportIds = ['3D_VIEWPORT'];
+
+  const viewportInputArray = [
+    {
+      viewportId: viewportIds[0],
+      type: ViewportType.VOLUME_3D,
+      element: element1,
+      defaultOptions: {
+        orientation: Enums.OrientationAxis.SAGITTAL,
+        background: <Types.Point3>[0.2, 0, 0.2],
+      },
+    },
+  ];
+
+  renderingEngine.setViewports(viewportInputArray);
+
+  // Set the tool group on the viewports
+  viewportIds.forEach((viewportId) =>
+    toolGroup.addViewport(viewportId, renderingEngineId)
+  );
+
+  // Define a volume in memory
+  const volume = await volumeLoader.createAndCacheVolume(volumeId, {
+    imageIds,
+  });
+
+  // Set the volume to load
+  volume.load();
+
+  setVolumesForViewports(renderingEngine, [{ volumeId }], viewportIds).then(
+    () => {
+      viewportIds.forEach((viewportId) => {
+        const volumeActor = renderingEngine
+          .getViewport(viewportId)
+          .getDefaultActor().actor as VolumeActor;
+
+        utilities.applyPreset(
+          volumeActor,
+          CONSTANTS.VIEWPORT_PRESETS.find((preset) => preset.name === 'CT-AAA')
+        );
+      });
+    }
+  );
+  renderingEngine.render();
+}
+
+run();

--- a/packages/tools/src/utilities/segmentation/createLabelmapVolumeForViewport.ts
+++ b/packages/tools/src/utilities/segmentation/createLabelmapVolumeForViewport.ts
@@ -45,7 +45,7 @@ export default async function createLabelmapVolumeForViewport(input: {
 
   const { viewport } = enabledElement;
   if (!(viewport instanceof VolumeViewport)) {
-    throw new Error('Segmentation not ready for stackViewport');
+    throw new Error('Segmentation only supports VolumeViewport');
   }
 
   const { uid } = viewport.getDefaultActor();

--- a/packages/tools/src/utilities/viewport/isViewportPreScaled.ts
+++ b/packages/tools/src/utilities/viewport/isViewportPreScaled.ts
@@ -2,14 +2,14 @@ import {
   cache,
   StackViewport,
   Types,
-  VolumeViewport,
+  BaseVolumeViewport,
 } from '@cornerstonejs/core';
 
 function isViewportPreScaled(
   viewport: Types.IStackViewport | Types.IVolumeViewport,
   targetId: string
 ): boolean {
-  if (viewport instanceof VolumeViewport) {
+  if (viewport instanceof BaseVolumeViewport) {
     const volumeId = targetId.split('volumeId:')[1];
     const volume = cache.getVolume(volumeId);
     return volume.scaling && Object.keys(volume.scaling).length > 0;

--- a/utils/ExampleRunner/example-info.json
+++ b/utils/ExampleRunner/example-info.json
@@ -166,6 +166,10 @@
         "name": "Volume Viewport Orientation",
         "description": "Demonstrates you can switch between different orientation of a volume viewport"
       },
+      "volumeViewport3D": {
+        "name": "3D Volume Rendering",
+        "description": "Here we demonstrate how to 3D render a volume."
+      },
       "referenceCursors": {
         "name": "Referencing Cursors",
         "description": "Demonstrates how to synchronize the cursor between multiple viewports"

--- a/utils/ExampleRunner/example-info.json
+++ b/utils/ExampleRunner/example-info.json
@@ -42,6 +42,10 @@
         "name": "Volume Viewport API",
         "description": "Demonstrates how to interact with a Volume viewport  (e.g. Set VOI Range, Change Camera Position / Orientation, Change Slab Thickness, Flip H/V, Rotate, Invert, Zoom/Pan, Reset)"
       },
+      "volumeViewport3D": {
+        "name": "3D Volume Rendering",
+        "description": "Demonstrates how to 3D render a volume and apply a preset"
+      },
       "volumeEvents": {
         "name": "Volume Viewport Events",
         "description": "Demonstrates the Events that are fired during interaction with a Volume Viewport"
@@ -165,10 +169,6 @@
       "volumeViewportOrientation": {
         "name": "Volume Viewport Orientation",
         "description": "Demonstrates you can switch between different orientation of a volume viewport"
-      },
-      "volumeViewport3D": {
-        "name": "3D Volume Rendering",
-        "description": "Here we demonstrate how to 3D render a volume."
       },
       "referenceCursors": {
         "name": "Referencing Cursors",


### PR DESCRIPTION
This pull request was originated from [this issue](https://github.com/cornerstonejs/cornerstone3D-beta/issues/267).

The existing `VolumeViewport` class was refactored and all common functionality was extracted to an abstract base class called `BaseVolumeViewport`. Then both the existing `VolumeViewport` class and the new `VolumeViewport3D` extend it.

Besides that, a new utility function was added to allow easily applying a preset to a viewport.

You can try it here https://deploy-preview-281--cornerstone-3d-docs.netlify.app/live-examples/volumeviewport3d
