### PR TITLE
feat: add stack synchronization within or across studies

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { mat4 } from 'gl-matrix';
+import { mat4 } from 'gl-matrix';
 import { vec3 } from 'gl-matrix';
 import type vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';
 import type { vtkCamera } from '@kitware/vtk.js/Rendering/Core/Camera';
@@ -35,9 +35,7 @@ type ActorSliceRange = {
 };
 
 // @public (undocumented)
-function addProvider(provider: (type: string, imageId: string) => {
-    any: any;
-}, priority?: number): void;
+function addProvider(provider: (type: string, query: any) => any, priority?: number): void;
 
 // @public (undocumented)
 export function addVolumesToViewports(renderingEngine: IRenderingEngine, volumeInputs: Array<IVolumeInput>, viewportIds: Array<string>, immediateRender?: boolean, suppressEvents?: boolean): Promise<void>;
@@ -56,6 +54,9 @@ enum BlendModes {
 
 // @public (undocumented)
 export const cache: Cache_2;
+
+// @public (undocumented)
+function calculateViewportsSpatialRegistration(viewport1: IStackViewport, viewport2: IStackViewport): void;
 
 // @public (undocumented)
 type CameraModifiedEvent = CustomEvent_2<CameraModifiedEventDetail>;
@@ -551,7 +552,7 @@ export function getEnabledElements(): IEnabledElement[];
 function getImageSliceDataForVolumeViewport(viewport: IVolumeViewport): ImageSliceData;
 
 // @public (undocumented)
-function getMetaData(type: string, imageId: string): any;
+function getMetaData(type: string, query: string): any;
 
 // @public (undocumented)
 function getMinMax(storedPixelData: number[]): {
@@ -1566,7 +1567,7 @@ function registerVolumeLoader(scheme: string, volumeLoader: Types.VolumeLoaderFn
 function removeAllProviders(): void;
 
 // @public (undocumented)
-function removeProvider(provider: (type: string, imageId: string) => {
+function removeProvider(provider: (type: string, query: any) => {
     any: any;
 }): void;
 
@@ -1694,6 +1695,12 @@ export function setVolumesForViewports(renderingEngine: IRenderingEngine, volume
 function snapFocalPointToSlice(focalPoint: Point3, position: Point3, sliceRange: ActorSliceRange, viewPlaneNormal: Point3, spacingInNormalDirection: number, deltaFrames: number): {
     newFocalPoint: Point3;
     newPosition: Point3;
+};
+
+// @public (undocumented)
+const spatialRegistrationMetadataProvider: {
+    add: (query: string[], payload: mat4) => void;
+    get: (type: string, query: string[]) => mat4;
 };
 
 // @public (undocumented)
@@ -1943,7 +1950,9 @@ declare namespace utilities {
         snapFocalPointToSlice,
         getImageSliceDataForVolumeViewport,
         isImageActor,
-        getViewportsWithImageURI
+        getViewportsWithImageURI,
+        calculateViewportsSpatialRegistration,
+        spatialRegistrationMetadataProvider
     }
 }
 export { utilities }

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -993,6 +993,9 @@ function createLabelmapVolumeForViewport(input: {
 function createMergedLabelmapForIndex(labelmaps: Array<Types_2.IImageVolume>, segmentIndex?: number, volumeId?: string): Types_2.IImageVolume;
 
 // @public (undocumented)
+function createStackImageSynchronizer(synchronizerName: string): Synchronizer;
+
+// @public (undocumented)
 function createSynchronizer(synchronizerId: string, eventName: string, eventHandler: ISynchronizerEventHandler): Synchronizer;
 
 // @public (undocumented)
@@ -4101,7 +4104,8 @@ declare namespace synchronizers {
     export {
         createCameraPositionSynchronizer,
         createVOISynchronizer,
-        createZoomPanSynchronizer
+        createZoomPanSynchronizer,
+        createStackImageSynchronizer
     }
 }
 export { synchronizers }

--- a/packages/core/src/RenderingEngine/index.ts
+++ b/packages/core/src/RenderingEngine/index.ts
@@ -1,6 +1,7 @@
 import RenderingEngine from './RenderingEngine';
 import getRenderingEngine from './getRenderingEngine';
 import VolumeViewport from './VolumeViewport';
+import StackViewport from './StackViewport';
 import {
   createVolumeActor,
   createVolumeMapper,
@@ -14,6 +15,7 @@ export {
   createVolumeActor,
   createVolumeMapper,
   getOrCreateCanvas,
+  StackViewport,
 };
 
 export default RenderingEngine;

--- a/packages/core/src/metaData.ts
+++ b/packages/core/src/metaData.ts
@@ -11,7 +11,7 @@ const providers = [];
  * @category MetaData
  */
 export function addProvider(
-  provider: (type: string, imageId: string) => { any },
+  provider: (type: string, query: any) => any,
   priority = 0
 ): void {
   let i;
@@ -38,7 +38,7 @@ export function addProvider(
  * @category MetaData
  */
 export function removeProvider(
-  provider: (type: string, imageId: string) => { any }
+  provider: (type: string, query: any) => { any }
 ): void {
   for (let i = 0; i < providers.length; i++) {
     if (providers[i].provider === provider) {
@@ -65,15 +65,15 @@ export function removeAllProviders(): void {
  * until one responds
  *
  * @param type -  The type of metadata requested from the metadata store
- * @param imageId - The Cornerstone Image Object's imageId
+ * @param query - The query for the metadata store, often imageId
  *
  * @returns The metadata retrieved from the metadata store
  * @category MetaData
  */
-function getMetaData(type: string, imageId: string): any {
+function getMetaData(type: string, query: string): any {
   // Invoke each provider in priority order until one returns something
   for (let i = 0; i < providers.length; i++) {
-    const result = providers[i].provider(type, imageId);
+    const result = providers[i].provider(type, query);
 
     if (result !== undefined) {
       return result;

--- a/packages/core/src/utilities/calculateViewportsSpatialRegistration.ts
+++ b/packages/core/src/utilities/calculateViewportsSpatialRegistration.ts
@@ -1,0 +1,74 @@
+import { vec3, mat4 } from 'gl-matrix';
+import { IStackViewport } from '../types';
+import { StackViewport } from '../RenderingEngine';
+import spatialRegistrationMetadataProvider from './spatialRegistrationMetadataProvider';
+import { metaData } from '..';
+import isEqual from './isEqual';
+
+/**
+ * It calculates the registration matrix between two viewports (currently only
+ * translation is supported)
+ * If the viewports are in the same frame of reference, it will return early,
+ * but otherwise it will use the current image's metadata to calculate the
+ * translation between the two viewports and adds it to the spatialRegistrationModule
+ * metadata provider
+ *
+ *
+ * @param viewport1 - The first stack viewport
+ * @param viewport2 - The second stack viewport
+ */
+function calculateViewportsSpatialRegistration(
+  viewport1: IStackViewport,
+  viewport2: IStackViewport
+): void {
+  if (
+    !(viewport1 instanceof StackViewport) ||
+    !(viewport2 instanceof StackViewport)
+  ) {
+    throw new Error(
+      'calculateViewportsSpatialRegistration: Both viewports must be StackViewports, volume viewports are not supported yet'
+    );
+  }
+
+  const isSameFrameOfReference =
+    viewport1.getFrameOfReferenceUID() === viewport2.getFrameOfReferenceUID();
+
+  if (isSameFrameOfReference) {
+    return;
+  }
+
+  const imageId1 = viewport1.getCurrentImageId();
+  const imageId2 = viewport2.getCurrentImageId();
+
+  const imagePlaneModule1 = metaData.get('imagePlaneModule', imageId1);
+  const imagePlaneModule2 = metaData.get('imagePlaneModule', imageId2);
+
+  const isSameImagePlane =
+    imagePlaneModule1 &&
+    imagePlaneModule2 &&
+    isEqual(
+      imagePlaneModule1.imageOrientationPatient,
+      imagePlaneModule2.imageOrientationPatient
+    );
+
+  if (!isSameImagePlane) {
+    throw new Error(
+      'Viewport spatial registration only supported for same orientation (hence translation only) for now'
+    );
+  }
+
+  const imagePositionPatient1 = imagePlaneModule1.imagePositionPatient;
+  const imagePositionPatient2 = imagePlaneModule2.imagePositionPatient;
+
+  const translation = vec3.subtract(
+    vec3.create(),
+    imagePositionPatient1,
+    imagePositionPatient2
+  );
+
+  const mat = mat4.fromTranslation(mat4.create(), translation);
+
+  spatialRegistrationMetadataProvider.add([viewport1.id, viewport2.id], mat);
+}
+
+export default calculateViewportsSpatialRegistration;

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -27,6 +27,8 @@ import snapFocalPointToSlice from './snapFocalPointToSlice';
 import getImageSliceDataForVolumeViewport from './getImageSliceDataForVolumeViewport';
 import isImageActor from './isImageActor';
 import getViewportsWithImageURI from './getViewportsWithImageURI';
+import calculateViewportsSpatialRegistration from './calculateViewportsSpatialRegistration';
+import spatialRegistrationMetadataProvider from './spatialRegistrationMetadataProvider';
 
 // name spaces
 import * as planar from './planar';
@@ -64,4 +66,6 @@ export {
   getImageSliceDataForVolumeViewport,
   isImageActor,
   getViewportsWithImageURI,
+  calculateViewportsSpatialRegistration,
+  spatialRegistrationMetadataProvider,
 };

--- a/packages/core/src/utilities/spatialRegistrationMetadataProvider.ts
+++ b/packages/core/src/utilities/spatialRegistrationMetadataProvider.ts
@@ -1,0 +1,50 @@
+import { mat4 } from 'gl-matrix';
+import { addProvider } from '../metaData';
+
+const state = {};
+
+/**
+ * Simple metadataProvider object to store metadata for spatial registration module.
+ */
+const spatialRegistrationMetadataProvider = {
+  /* Adding a new entry to the state object. */
+  add: (query: string[], payload: mat4): void => {
+    const [viewportId1, viewportId2] = query;
+    const entryId = `${viewportId1}_${viewportId2}`;
+
+    if (!state[entryId]) {
+      state[entryId] = {};
+    }
+
+    state[entryId] = payload;
+  },
+
+  get: (type: string, query: string[]): mat4 => {
+    if (type !== 'spatialRegistrationModule') {
+      return;
+    }
+
+    const [viewportId1, viewportId2] = query;
+
+    // check both ways
+    const entryId = `${viewportId1}_${viewportId2}`;
+
+    if (state[entryId]) {
+      return state[entryId];
+    }
+
+    const entryIdReverse = `${viewportId2}_${viewportId1}`;
+
+    if (state[entryIdReverse]) {
+      return mat4.invert(mat4.create(), state[entryIdReverse]);
+    }
+  },
+};
+
+addProvider(
+  spatialRegistrationMetadataProvider.get.bind(
+    spatialRegistrationMetadataProvider
+  )
+);
+
+export default spatialRegistrationMetadataProvider;

--- a/packages/tools/src/store/SynchronizerManager/Synchronizer.ts
+++ b/packages/tools/src/store/SynchronizerManager/Synchronizer.ts
@@ -196,12 +196,16 @@ class Synchronizer {
     });
   }
 
-  private fireEvent(sourceViewport: Types.IViewportId, sourceEvent: any): void {
+  private async fireEvent(
+    sourceViewport: Types.IViewportId,
+    sourceEvent: any
+  ): Promise<void> {
     if (this.isDisabled() || this._ignoreFiredEvents) {
       return;
     }
 
     this._ignoreFiredEvents = true;
+
     try {
       for (let i = 0; i < this._targetViewports.length; i++) {
         const targetViewport = this._targetViewports[i];
@@ -212,7 +216,23 @@ class Synchronizer {
           continue;
         }
 
-        this._eventHandler(this, sourceViewport, targetViewport, sourceEvent);
+        // Note: since the eventHandlers for synchronizers can be async (e.g. scroll,
+        // or new image set), we need to make sure that each handler has completed
+        // before we move to the next one. If the callback is async and we don't await
+        // here, then we will just finish all the handlers (while the async ones are
+        // still running), and later we set the ignoreFireEvents flag to false, which
+        // lets the targetViewports fire events again. This means that the async handlers
+        // will fire again, and we will have multiple handlers running at the same time.
+        // so just await here to make sure we don't have this unnecessary
+        // eventHandler running.
+        // Note: this might be very slow if the eventHandlers are very slow, so
+        // we might need to find a better way to do this.
+        await this._eventHandler(
+          this,
+          sourceViewport,
+          targetViewport,
+          sourceEvent
+        );
       }
     } catch (ex) {
       console.warn(`Synchronizer, for: ${this._eventName}`, ex);

--- a/packages/tools/src/synchronizers/callbacks/stackImageSyncCallback.ts
+++ b/packages/tools/src/synchronizers/callbacks/stackImageSyncCallback.ts
@@ -1,0 +1,153 @@
+import { vec3 } from 'gl-matrix';
+import {
+  getRenderingEngine,
+  Types,
+  metaData,
+  utilities,
+} from '@cornerstonejs/core';
+import { Synchronizer } from '../../store';
+import { jumpToSlice } from '../../utilities';
+
+/**
+ * Synchronizer callback to synchronize the source viewport image to the
+ * target viewports closest image in its stack. There are two scenarios
+ *
+ * 1) viewports are in the same frameOfReferenceUID then we can use the
+ * absolute imagePositionPatient for the source viewport's current image
+ * and set the target viewport's image to the closest image in its stack
+ * (which might have different slice thickness so cannot use slice number)
+ *
+ * 2) viewports have different frameOfReferenceUIDs then we look inside the
+ * registrationMetadataProvider to check if there is a corresponding matrix
+ * for mapping between the source and target viewport if so it is used to
+ * and is applied to the imagePositionPatient of the source viewport's to
+ * get the imagePositionPatient of the target viewport's closest image in
+ * its stack.
+ * Note for 2) The consuming apps using Cornerstone3D (OHIF, etc) are responsible
+ * to provide such data in the registrationMetadataProvider. This can be done
+ * by various methods 1) Using spatialRegistrationModule inside dicom 2) assuming
+ * the user has actually manually scrolled the target viewport to the correct
+ * slice before initiating the synchronization 3) using some other method
+ * But overall, the consuming app is responsible for providing the data.
+ *
+ *
+ * @param synchronizerInstance - The Instance of the Synchronizer
+ * @param sourceViewport - The list of IDs defining the source viewport.
+ * @param targetViewport - The list of IDs defining the target viewport, never
+ *   the same as sourceViewport.
+ * @param cameraModifiedEvent - The CAMERA_MODIFIED event.
+ */
+export default async function stackImageSyncCallback(
+  synchronizerInstance: Synchronizer,
+  sourceViewport: Types.IViewportId,
+  targetViewport: Types.IViewportId
+): Promise<void> {
+  const renderingEngine = getRenderingEngine(targetViewport.renderingEngineId);
+  if (!renderingEngine) {
+    throw new Error(
+      `No RenderingEngine for Id: ${targetViewport.renderingEngineId}`
+    );
+  }
+
+  const sViewport = renderingEngine.getViewport(
+    sourceViewport.viewportId
+  ) as Types.IStackViewport;
+
+  const tViewport = renderingEngine.getViewport(
+    targetViewport.viewportId
+  ) as Types.IStackViewport;
+
+  const frameOfReferenceUID1 = sViewport.getFrameOfReferenceUID();
+  const frameOfReferenceUID2 = tViewport.getFrameOfReferenceUID();
+
+  const imageId1 = sViewport.getCurrentImageId();
+  const imagePlaneModule1 = metaData.get('imagePlaneModule', imageId1);
+  const sourceImagePositionPatient = imagePlaneModule1.imagePositionPatient;
+
+  const targetImageIds = tViewport.getImageIds();
+
+  if (frameOfReferenceUID1 === frameOfReferenceUID2) {
+    // if frames of references are the same we can use the absolute
+    // imagePositionPatient to find the closest image in the target viewport's stack
+    const closestImageIdIndex = _getClosestImageIdIndex(
+      sourceImagePositionPatient,
+      targetImageIds
+    );
+
+    if (
+      closestImageIdIndex.index !== -1 &&
+      tViewport.getCurrentImageIdIndex() !== closestImageIdIndex.index
+    ) {
+      // await tViewport.setImageIdIndex(closestImageIdIndex.index);
+      await jumpToSlice(tViewport.element, {
+        imageIndex: closestImageIdIndex.index,
+      });
+
+      return;
+    }
+  } else {
+    // if the frame of reference is different we need to use the registrationMetadataProvider
+    // and add that to the imagePositionPatient of the source viewport to get the
+    // imagePositionPatient of the target viewport's closest image in its stack
+    const registrationMatrixMat4 =
+      utilities.spatialRegistrationMetadataProvider.get(
+        'spatialRegistrationModule',
+        [targetViewport.viewportId, sourceViewport.viewportId]
+      );
+
+    if (!registrationMatrixMat4) {
+      throw new Error(
+        `No registration matrix found for sourceViewport: ${sourceViewport.viewportId} and targetViewport: ${targetViewport.viewportId}, viewports with different frameOfReferenceUIDs must have a registration matrix in the registrationMetadataProvider. Use calculateViewportsRegistrationMatrix to calculate the matrix.`
+      );
+    }
+
+    // apply the registration matrix to the source viewport's imagePositionPatient
+    // to get the target viewport's imagePositionPatient
+    const targetImagePositionPatientWithRegistrationMatrix = vec3.transformMat4(
+      vec3.create(),
+      sourceImagePositionPatient,
+      registrationMatrixMat4
+    );
+
+    // find the closest image in the target viewport's stack to the
+    // targetImagePositionPatientWithRegistrationMatrix
+    const closestImageIdIndex2 = _getClosestImageIdIndex(
+      targetImagePositionPatientWithRegistrationMatrix,
+      targetImageIds
+    );
+
+    if (
+      closestImageIdIndex2.index !== -1 &&
+      tViewport.getCurrentImageIdIndex() !== closestImageIdIndex2.index
+    ) {
+      await jumpToSlice(tViewport.element, {
+        imageIndex: closestImageIdIndex2.index,
+      });
+    }
+  }
+}
+
+function _getClosestImageIdIndex(targetPoint, imageIds) {
+  // todo: this does not assume orientation yet, but that can be added later
+  return imageIds.reduce(
+    (closestImageIdIndex, imageId, index) => {
+      const { imagePositionPatient } = metaData.get(
+        'imagePlaneModule',
+        imageId
+      );
+      const distance = vec3.distance(imagePositionPatient, targetPoint);
+
+      if (distance < closestImageIdIndex.distance) {
+        return {
+          distance,
+          index,
+        };
+      }
+      return closestImageIdIndex;
+    },
+    {
+      distance: Infinity,
+      index: -1,
+    }
+  );
+}

--- a/packages/tools/src/synchronizers/index.ts
+++ b/packages/tools/src/synchronizers/index.ts
@@ -1,9 +1,11 @@
 import createCameraPositionSynchronizer from './synchronizers/createCameraPositionSynchronizer';
 import createVOISynchronizer from './synchronizers/createVOISynchronizer';
 import createZoomPanSynchronizer from './synchronizers/createZoomPanSynchronizer';
+import createStackImageSynchronizer from './synchronizers/createStackImageSynchronizer';
 
 export {
   createCameraPositionSynchronizer,
   createVOISynchronizer,
   createZoomPanSynchronizer,
+  createStackImageSynchronizer,
 };

--- a/packages/tools/src/synchronizers/synchronizers/createStackImageSynchronizer.ts
+++ b/packages/tools/src/synchronizers/synchronizers/createStackImageSynchronizer.ts
@@ -1,0 +1,25 @@
+import { createSynchronizer } from '../../store/SynchronizerManager';
+import { Enums } from '@cornerstonejs/core';
+import stackImageSyncCallback from '../callbacks/stackImageSyncCallback';
+import Synchronizer from '../../store/SynchronizerManager/Synchronizer';
+
+const { STACK_NEW_IMAGE } = Enums.Events;
+
+/**
+ * A helper that creates a new `Synchronizer` which listens to the `STACK_NEW_IMAGE`
+ * rendering event and calls the `stackImageSyncCallback`.
+ *
+ * @param synchronizerName - The name of the synchronizer.
+ * @returns A new `Synchronizer` instance.
+ */
+export default function createStackImageSynchronizer(
+  synchronizerName: string
+): Synchronizer {
+  const stackImageSynchronizer = createSynchronizer(
+    synchronizerName,
+    STACK_NEW_IMAGE,
+    stackImageSyncCallback
+  );
+
+  return stackImageSynchronizer;
+}

--- a/packages/tools/src/synchronizers/synchronizers/index.ts
+++ b/packages/tools/src/synchronizers/synchronizers/index.ts
@@ -1,9 +1,11 @@
 import createCameraPositionSynchronizer from './createCameraPositionSynchronizer';
 import createVOISynchronizer from './createVOISynchronizer';
 import createZoomPanSynchronizer from './createZoomPanSynchronizer';
+import createStackImageSynchronizer from './createStackImageSynchronizer';
 
 export {
   createCameraPositionSynchronizer,
   createVOISynchronizer,
   createZoomPanSynchronizer,
+  createStackImageSynchronizer,
 };

--- a/packages/tools/test/synchronizerManager_test.js
+++ b/packages/tools/test/synchronizerManager_test.js
@@ -195,6 +195,8 @@ describe('Synchronizer Manager: ', () => {
           [viewportId2]
         );
       });
+
+      this.renderingEngine.render();
     } catch (e) {
       done.fail(e);
     }


### PR DESCRIPTION
Add stack synchronization for stack viewports. This works for viewports in the same frame of reference and viewports that are not in the same frame of reference 

Make the synchronizer callbacks async