### PR TITLE
feat: trigger annotation modified event on textbox moving

### DIFF
--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -400,6 +400,7 @@ class AngleTool extends AnnotationTool {
       worldPosition[2] += worldPosDelta[2];
 
       textBox.hasMoved = true;
+      annotation.invalidated = true;
     } else if (handleIndex === undefined) {
       // Drag mode - moving handle
       const { deltaPoints } = eventDetail as EventTypes.MouseDragEventDetail;

--- a/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
+++ b/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
@@ -380,6 +380,7 @@ class ArrowAnnotateTool extends AnnotationTool {
       worldPosition[2] += worldPosDelta[2];
 
       textBox.hasMoved = true;
+      annotation.invalidated = true;
     } else if (handleIndex === undefined) {
       // Drag mode - moving handle
       const { deltaPoints } = eventDetail as EventTypes.MouseDragEventDetail;

--- a/packages/tools/src/tools/annotation/BidirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/BidirectionalTool.ts
@@ -606,6 +606,7 @@ class BidirectionalTool extends AnnotationTool {
       worldPosition[2] += worldPosDelta[2];
 
       textBox.hasMoved = true;
+      annotation.invalidated = true;
     } else if (handleIndex === undefined) {
       // Moving tool
       const { deltaPoints } = eventDetail;

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -514,6 +514,7 @@ class EllipticalROITool extends AnnotationTool {
       worldPosition[2] += worldPosDelta[2];
 
       textBox.hasMoved = true;
+      annotation.invalidated = true;
     } else if (handleIndex === undefined) {
       // Moving tool
       const { deltaPoints } = eventDetail;

--- a/packages/tools/src/tools/annotation/LengthTool.ts
+++ b/packages/tools/src/tools/annotation/LengthTool.ts
@@ -404,6 +404,7 @@ class LengthTool extends AnnotationTool {
       worldPosition[2] += worldPosDelta[2];
 
       textBox.hasMoved = true;
+      annotation.invalidated = true;
     } else if (handleIndex === undefined) {
       // Drag mode - moving handle
       const { deltaPoints } = eventDetail as EventTypes.MouseDragEventDetail;

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -414,6 +414,7 @@ class RectangleROITool extends AnnotationTool {
       worldPosition[2] += worldPosDelta[2];
 
       textBox.hasMoved = true;
+      annotation.invalidated = true;
     } else if (handleIndex === undefined) {
       // Drag mode - Moving tool, so move all points by the world points delta
       const { deltaPoints } = eventDetail as EventTypes.MouseDragEventDetail;


### PR DESCRIPTION
This should close #274 , set invalidated attribute as true on textbox moving