### PR TITLE
fix(conversion):World to image throws an exception on outside image

### DIFF
--- a/packages/core/src/utilities/worldToImageCoords.ts
+++ b/packages/core/src/utilities/worldToImageCoords.ts
@@ -58,17 +58,6 @@ function worldToImageCoords(
     columnDistance / columnPixelSpacing,
   ];
 
-  if (
-    imageCoords[0] < 0 ||
-    imageCoords[0] >= columns ||
-    imageCoords[1] < 0 ||
-    imageCoords[1] >= rows
-  ) {
-    throw new Error(
-      `The image coordinates are outside of the image, imageCoords: ${imageCoords}`
-    );
-  }
-
   return imageCoords as Point2;
 }
 


### PR DESCRIPTION
There are lots of cases where world to image should allow producing coordinates outside the image.  Make the exception optional.