### PR TITLE
fix: bidirectional tool when short and long axis changes

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -609,6 +609,9 @@ function getVolumeActorCorners(volumeActor: any): Array<Point3>;
 function getVolumeViewportsContainingSameVolumes(targetViewport: IVolumeViewport, renderingEngineId?: string): Array<IVolumeViewport>;
 
 // @public (undocumented)
+function hasNaNValues(input: number[] | number): boolean;
+
+// @public (undocumented)
 interface ICache {
     // (undocumented)
     getCacheSize: () => number;
@@ -1967,7 +1970,8 @@ declare namespace utilities {
         getViewportsWithImageURI,
         calculateViewportsSpatialRegistration,
         spatialRegistrationMetadataProvider,
-        getViewportImageCornersInWorld
+        getViewportImageCornersInWorld,
+        hasNaNValues
     }
 }
 export { utilities }

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -503,7 +503,11 @@ export class BidirectionalTool extends AnnotationTool {
         hasMoved?: boolean;
     } | null;
     // (undocumented)
+    _getSignedAngle: (vector1: any, vector2: any) => number;
+    // (undocumented)
     _getTextLines: (data: any, targetId: any) => string[];
+    // (undocumented)
+    _handleDragModify: (evt: any) => void;
     // (undocumented)
     handleSelectedCallback: (evt: EventTypes_2.MouseDownEventType, annotation: BidirectionalAnnotation, handle: ToolHandle, interactionType?: string) => void;
     // (undocumented)
@@ -521,11 +525,9 @@ export class BidirectionalTool extends AnnotationTool {
     // (undocumented)
     _mouseDragModifyCallback: (evt: MouseDragEventType) => void;
     // (undocumented)
-    _mouseDragModifyHandle: (evt: any) => void;
-    // (undocumented)
     _mouseUpCallback: (evt: EventTypes_2.MouseUpEventType | EventTypes_2.MouseClickEventType) => void;
     // (undocumented)
-    _movingLongAxisWouldPutItThroughShortAxis: (proposedFirstLineSegment: any, secondLineSegment: any) => boolean;
+    _movingLongAxisWouldPutItThroughShortAxis: (firstLineSegment: any, secondLineSegment: any) => boolean;
     // (undocumented)
     preventHandleOutsideImage: boolean;
     // (undocumented)

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "yarn": ">=1.19.1"
   },
   "scripts": {
-    "api-check": "lerna run --concurrency 1 api-check ",
+    "api-check": "lerna run api-check ",
     "build": "lerna run build --stream",
     "build:umd": "lerna run build:umd --stream",
-    "build:update-api": "lerna run  --concurrency 1 build:update-api",
+    "build:update-api": "lerna run build:update-api",
     "example": "node ./utils/ExampleRunner/example-runner-cli.js",
     "all-examples": "node ./utils/ExampleRunner/build-all-examples-cli.js --fromRoot",
     "build-all-examples": "node ./utils/ExampleRunner/build-all-examples-cli.js --build --fromRoot",

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -30,6 +30,7 @@ import getViewportsWithImageURI from './getViewportsWithImageURI';
 import calculateViewportsSpatialRegistration from './calculateViewportsSpatialRegistration';
 import spatialRegistrationMetadataProvider from './spatialRegistrationMetadataProvider';
 import getViewportImageCornersInWorld from './getViewportImageCornersInWorld';
+import hasNaNValues from './hasNaNValues';
 
 // name spaces
 import * as planar from './planar';
@@ -70,4 +71,5 @@ export {
   calculateViewportsSpatialRegistration,
   spatialRegistrationMetadataProvider,
   getViewportImageCornersInWorld,
+  hasNaNValues,
 };

--- a/utils/ExampleRunner/example-info.json
+++ b/utils/ExampleRunner/example-info.json
@@ -90,7 +90,7 @@
         "name": "DICOM P10 from the local file system",
         "description": "Provides an interface to load a DICOM P10 image from your local file system to the Cornerstone3D"
       },
-      "local (CPU)": {
+      "localCPU": {
         "name": "DICOM P10 from the local file system using CPU",
         "description": "Cornerstone3D uses WebGL for rendering by default (if available) and a fallback to CPU. This example force rendering on CPU for debugging purposes."
       },


### PR DESCRIPTION
Fix the following weird behaviours for bidirectional tool when short and long axis change (try https://deploy-preview-309--cornerstone-3d-docs.netlify.app/live-examples/stackannotationtools)

[5fc67b84-79c0-415b-aede-7cd724a73a33.webm](https://user-images.githubusercontent.com/7490180/203677775-f960f388-8d8e-41b8-928d-60b0248ad99c.webm)

[e304e93d-6386-40ae-88d3-8503e4dd362f.webm](https://user-images.githubusercontent.com/7490180/203677778-ae956de5-ec21-46f0-b22c-eedf940f9bc3.webm)
