### PR TITLE
Filter PlanarFreeHandROI annotations based on parallel normals instead of equal normals.

### DIFF
--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -1,4 +1,5 @@
 import {
+  CONSTANTS,
   getEnabledElement,
   triggerEvent,
   eventTarget,
@@ -42,7 +43,9 @@ import { PlanarFreehandROIAnnotation } from '../../types/ToolSpecificAnnotationT
 import { PlanarFreehandROICommonData } from '../../utilities/math/polyline/planarFreehandROIInternalTypes';
 
 const { pointCanProjectOnLine } = polyline;
+const { EPSILON } = CONSTANTS;
 
+const PARALLEL_THRESHOLD = 1 - EPSILON;
 /**
  * PlanarFreehandROITool lets you draw annotations that define an arbitrarily drawn region.
  * You can use the PlanarFreehandROITool in all perpendicular views (axial, sagittal, coronal),
@@ -488,13 +491,21 @@ class PlanarFreehandROITool extends AnnotationTool {
     spacingInNormalDirection: number
   ): Annotations {
     const { viewPlaneNormal } = camera;
-    const annotationsWithSameNormal = annotations.filter((td: Annotation) => {
-      const annotationViewPlaneNormal = td.metadata.viewPlaneNormal;
-      return csUtils.isEqual(annotationViewPlaneNormal, viewPlaneNormal);
-    });
+
+    const annotationsWithParallelNormals = annotations.filter(
+      (td: Annotation) => {
+        const annotationViewPlaneNormal = td.metadata.viewPlaneNormal;
+
+        const isParallel =
+          Math.abs(vec3.dot(viewPlaneNormal, annotationViewPlaneNormal)) >
+          PARALLEL_THRESHOLD;
+
+        return annotationViewPlaneNormal && isParallel;
+      }
+    );
 
     // No in plane annotations.
-    if (!annotationsWithSameNormal.length) {
+    if (!annotationsWithParallelNormals.length) {
       return [];
     }
 
@@ -506,7 +517,7 @@ class PlanarFreehandROITool extends AnnotationTool {
 
     const annotationsWithinSlice = [];
 
-    for (const annotation of annotationsWithSameNormal) {
+    for (const annotation of annotationsWithParallelNormals) {
       const data = annotation.data;
       const point = data.polyline[0];
 


### PR DESCRIPTION
Closes #314.