### PR TITLE
Hide PlanarFreehandROITool annotations

### DIFF
--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -510,6 +510,10 @@ class PlanarFreehandROITool extends AnnotationTool {
       const data = annotation.data;
       const point = data.polyline[0];
 
+      if (!annotation.isVisible) {
+        continue;
+      }
+
       // A = point
       // B = focal point
       // P = normal


### PR DESCRIPTION
Closes #307: if planar annotation is not visible, filter it. 