### PR TITLE
fix(volumeViewport): Add optional scaling as the volume can be undefined

### DIFF
--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -751,7 +751,7 @@ class VolumeViewport extends Viewport implements IVolumeViewport {
       metadata: {
         Modality: volume?.metadata?.Modality,
       },
-      scaling: volume.scaling,
+      scaling: volume?.scaling,
       hasPixelSpacing: true,
     };
   }


### PR DESCRIPTION
While trying to get the volume from the cache, it can be undefined so getting the scaling attribute would throw an error in that case. This is a quick fix