### PR TITLE
feat: enable having multiple instances of the same tool and add more seg tools

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -432,6 +432,8 @@ export abstract class BaseTool implements IBaseTool {
     // (undocumented)
     getToolName(): string;
     // (undocumented)
+    readonly instanceName: string;
+    // (undocumented)
     mode: ToolModes;
     // (undocumented)
     setActiveStrategy(strategyName: string): void;
@@ -554,13 +556,21 @@ type BoundsIJK = [Types_2.Point2, Types_2.Point2, Types_2.Point2];
 export class BrushTool extends BaseTool {
     constructor(toolProps?: PublicToolProps, defaultToolProps?: ToolProps);
     // (undocumented)
+    invalidateBrushCursor(): void;
+    // (undocumented)
     mouseMoveCallback: (evt: EventTypes_2.MouseMoveEventType) => void;
+    // (undocumented)
+    onSetToolDisabled: () => void;
+    // (undocumented)
+    onSetToolEnabled: () => void;
+    // (undocumented)
+    onSetToolPassive: () => void;
     // (undocumented)
     preMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => boolean;
     // (undocumented)
     renderAnnotation(enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper): void;
     // (undocumented)
-    static toolName: any;
+    static toolName: string;
 }
 
 // @public (undocumented)
@@ -1202,6 +1212,9 @@ const _default: {
 };
 
 // @public (undocumented)
+function (getter: FloodFillGetter, seed: Types_2.Point2 | Types_2.Point3, options?: FloodFillOptions): FloodFillResult;
+
+// @public (undocumented)
 const _default_2: {
     interpolateAnnotation: typeof interpolateAnnotation;
 };
@@ -1659,6 +1672,23 @@ type FlipDirection = {
 };
 
 // @public (undocumented)
+type FloodFillGetter = FloodFillGetter2D | FloodFillGetter3D;
+
+// @public (undocumented)
+type FloodFillOptions = {
+    onFlood?: (x: any, y: any) => void;
+    onBoundary?: (x: any, y: any) => void;
+    equals?: (a: any, b: any) => boolean;
+    diagonals?: boolean;
+};
+
+// @public (undocumented)
+type FloodFillResult = {
+    flooded: Types_2.Point2[] | Types_2.Point3[];
+    boundaries: Types_2.Point2[] | Types_2.Point3[];
+};
+
+// @public (undocumented)
 class FrameOfReferenceSpecificAnnotationManager {
     constructor(uid?: string);
     // (undocumented)
@@ -1738,6 +1768,12 @@ function getBoundingBoxAroundShape(points: Types_2.Point3[], dimensions?: Types_
 
 // @public (undocumented)
 function getBoundsIJKFromRectangleAnnotations(annotations: any, referenceVolume: any, options?: Options): any;
+
+// @public (undocumented)
+function getBrushSizeForToolGroup(toolGroupId: string): void;
+
+// @public (undocumented)
+function getBrushThresholdForToolGroup(toolGroupId: string): any;
 
 // @public (undocumented)
 function getCanvasEllipseCorners(ellipseCanvasPoints: canvasCoordinates): Array<Types_2.Point2>;
@@ -2367,7 +2403,7 @@ type IToolBinding = {
 interface IToolGroup {
     // (undocumented)
     addTool: {
-        (toolName: string, toolConfiguration?: any): void;
+        (toolName: string, toolConfiguration?: any, toolInstanceName?: string): void;
     };
     // (undocumented)
     addViewport: {
@@ -2375,19 +2411,17 @@ interface IToolGroup {
     };
     // (undocumented)
     getActivePrimaryMouseButtonTool: {
-        (): undefined | string;
-    };
-    // (undocumented)
-    getToolConfiguration: {
-        (toolName: string, configurationPath: string): any;
+        (): ToolIdentifierType | undefined;
     };
     // (undocumented)
     getToolInstance: {
-        (toolName: string): any;
+        (toolName: string, toolInstanceName?: string): any;
     };
     // (undocumented)
+    getToolInstanceNames: (toolName: string) => string[];
+    // (undocumented)
     getToolOptions: {
-        (toolName: string): ToolOptionsType;
+        (toolName: string, toolInstanceName: string): ToolOptionsType;
     };
     // (undocumented)
     getViewportIds: () => string[];
@@ -2400,24 +2434,28 @@ interface IToolGroup {
         (renderingEngineId: string, viewportId?: string): void;
     };
     // (undocumented)
+    setActiveStrategy: {
+        (toolName: string, strategyName: string, toolInstanceName?: string): void;
+    };
+    // (undocumented)
     setToolActive: {
-        (toolName: string, toolBindingsOption?: SetToolBindingsType): void;
+        (toolName: string, toolBindingsOption?: SetToolBindingsType, toolInstanceName?: string): void;
     };
     // (undocumented)
     setToolConfiguration: {
-        (toolName: string, configuration: Record<any, any>, overwrite?: boolean): void;
+        (toolName: string, configuration: Record<any, any>, overwrite?: boolean): boolean;
     };
     // (undocumented)
     setToolDisabled: {
-        (toolName: string): void;
+        (toolName: string, toolInstanceName?: string): void;
     };
     // (undocumented)
     setToolEnabled: {
-        (toolName: string): void;
+        (toolName: string, toolInstanceName?: string): void;
     };
     // (undocumented)
     setToolPassive: {
-        (toolName: string): void;
+        (toolName: string, toolInstanceName?: string): void;
     };
     // (undocumented)
     setViewportsCursorByToolName: {
@@ -3012,6 +3050,15 @@ type OrientationVectors = {
 };
 
 // @public (undocumented)
+export class PaintFillTool extends BaseTool {
+    constructor(toolProps?: PublicToolProps, defaultToolProps?: ToolProps);
+    // (undocumented)
+    preMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => boolean;
+    // (undocumented)
+    static toolName: string;
+}
+
+// @public (undocumented)
 export class PanTool extends BaseTool {
     constructor(toolProps?: PublicToolProps, defaultToolProps?: ToolProps);
     // (undocumented)
@@ -3272,6 +3319,7 @@ type PTScaling = {
 // @public (undocumented)
 type PublicToolProps = SharedToolProp & {
     name?: string;
+    instanceName?: string;
 };
 
 // @public
@@ -3797,7 +3845,12 @@ declare namespace segmentation_2 {
         getDefaultRepresentationConfig,
         createLabelmapVolumeForViewport,
         rectangleROIThresholdVolumeByRange,
-        triggerSegmentationRender
+        triggerSegmentationRender,
+        default_2 as floodFill,
+        getBrushSizeForToolGroup,
+        setBrushSizeForToolGroup,
+        getBrushThresholdForToolGroup,
+        setBrushThresholdForToolGroup
     }
 }
 
@@ -3938,6 +3991,12 @@ function setAnnotationSelected(annotationUID: string, selected?: boolean, preser
 
 // @public (undocumented)
 function setAnnotationVisibility(annotationUID: string, visible?: boolean): void;
+
+// @public (undocumented)
+function setBrushSizeForToolGroup(toolGroupId: string, brushSize: number): void;
+
+// @public (undocumented)
+function setBrushThresholdForToolGroup(toolGroupId: string, threshold: Types_2.Point2): void;
 
 // @public (undocumented)
 function setColorForSegmentIndex(toolGroupId: string, segmentationRepresentationUID: string, segmentIndex: number, color: Color): void;
@@ -4361,6 +4420,12 @@ type ToolGroupSpecificRepresentationState = {
 type ToolHandle = AnnotationHandle | TextBoxHandle;
 
 // @public (undocumented)
+type ToolIdentifierType = {
+    toolName: string;
+    toolInstanceName: string;
+};
+
+// @public (undocumented)
 enum ToolModes {
     // (undocumented)
     Active = "Active",
@@ -4496,6 +4561,7 @@ declare namespace Types {
         SetToolBindingsType,
         ToolOptionsType,
         InteractionTypes,
+        ToolIdentifierType,
         IToolGroup,
         ISynchronizerEventHandler,
         ToolHandle,
@@ -4518,7 +4584,10 @@ declare namespace Types {
         ScrollOptions_2 as ScrollOptions,
         CINETypes,
         BoundsIJK,
-        SVGDrawingHelper
+        SVGDrawingHelper,
+        FloodFillResult,
+        FloodFillGetter,
+        FloodFillOptions
     }
 }
 export { Types }

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -432,8 +432,6 @@ export abstract class BaseTool implements IBaseTool {
     // (undocumented)
     getToolName(): string;
     // (undocumented)
-    readonly instanceName: string;
-    // (undocumented)
     mode: ToolModes;
     // (undocumented)
     setActiveStrategy(strategyName: string): void;
@@ -2400,10 +2398,17 @@ type IToolBinding = {
 };
 
 // @public (undocumented)
+type IToolClassReference = new <T extends BaseTool>(config: any) => T;
+
+// @public (undocumented)
 interface IToolGroup {
     // (undocumented)
     addTool: {
-        (toolName: string, toolConfiguration?: any, toolInstanceName?: string): void;
+        (toolName: string, toolConfiguration?: any): void;
+    };
+    // (undocumented)
+    addToolInstance: {
+        (ttoolName: string, parentClassName: string, configuration?: any): void;
     };
     // (undocumented)
     addViewport: {
@@ -2411,17 +2416,19 @@ interface IToolGroup {
     };
     // (undocumented)
     getActivePrimaryMouseButtonTool: {
-        (): ToolIdentifierType | undefined;
+        (): undefined | string;
+    };
+    // (undocumented)
+    getToolConfiguration: {
+        (toolName: string, configurationPath: string): any;
     };
     // (undocumented)
     getToolInstance: {
-        (toolName: string, toolInstanceName?: string): any;
+        (toolName: string): any;
     };
     // (undocumented)
-    getToolInstanceNames: (toolName: string) => string[];
-    // (undocumented)
     getToolOptions: {
-        (toolName: string, toolInstanceName: string): ToolOptionsType;
+        (toolName: string): ToolOptionsType;
     };
     // (undocumented)
     getViewportIds: () => string[];
@@ -2434,28 +2441,24 @@ interface IToolGroup {
         (renderingEngineId: string, viewportId?: string): void;
     };
     // (undocumented)
-    setActiveStrategy: {
-        (toolName: string, strategyName: string, toolInstanceName?: string): void;
-    };
-    // (undocumented)
     setToolActive: {
-        (toolName: string, toolBindingsOption?: SetToolBindingsType, toolInstanceName?: string): void;
+        (toolName: string, toolBindingsOption?: SetToolBindingsType): void;
     };
     // (undocumented)
     setToolConfiguration: {
-        (toolName: string, configuration: Record<any, any>, overwrite?: boolean): boolean;
+        (toolName: string, configuration: Record<any, any>, overwrite?: boolean): void;
     };
     // (undocumented)
     setToolDisabled: {
-        (toolName: string, toolInstanceName?: string): void;
+        (toolName: string): void;
     };
     // (undocumented)
     setToolEnabled: {
-        (toolName: string, toolInstanceName?: string): void;
+        (toolName: string): void;
     };
     // (undocumented)
     setToolPassive: {
-        (toolName: string, toolInstanceName?: string): void;
+        (toolName: string): void;
     };
     // (undocumented)
     setViewportsCursorByToolName: {
@@ -3319,7 +3322,6 @@ type PTScaling = {
 // @public (undocumented)
 type PublicToolProps = SharedToolProp & {
     name?: string;
-    instanceName?: string;
 };
 
 // @public
@@ -4420,12 +4422,6 @@ type ToolGroupSpecificRepresentationState = {
 type ToolHandle = AnnotationHandle | TextBoxHandle;
 
 // @public (undocumented)
-type ToolIdentifierType = {
-    toolName: string;
-    toolInstanceName: string;
-};
-
-// @public (undocumented)
 enum ToolModes {
     // (undocumented)
     Active = "Active",
@@ -4561,8 +4557,8 @@ declare namespace Types {
         SetToolBindingsType,
         ToolOptionsType,
         InteractionTypes,
-        ToolIdentifierType,
         IToolGroup,
+        IToolClassReference,
         ISynchronizerEventHandler,
         ToolHandle,
         AnnotationHandle,

--- a/packages/tools/examples/basicSegmentationTools/index.ts
+++ b/packages/tools/examples/basicSegmentationTools/index.ts
@@ -10,6 +10,7 @@ import {
   createImageIdsAndCacheMetaData,
   setTitleAndDescription,
   addDropdownToToolbar,
+  addSliderToToolbar,
   setCtTransferFunctionForVolumeActor,
 } from '../../../../utils/demo/helpers';
 import * as cornerstoneTools from '@cornerstonejs/tools';
@@ -28,13 +29,16 @@ const {
   SphereScissorsTool,
   CircleScissorsTool,
   BrushTool,
+  PaintFillTool,
   PanTool,
   ZoomTool,
   StackScrollMouseWheelTool,
+  utilities: cstUtils,
 } = cornerstoneTools;
 
 const { MouseBindings } = csToolsEnums;
 const { ViewportType } = Enums;
+const { segmentation: segmentationUtils } = cstUtils;
 
 // Define a unique id for the volume
 const volumeName = 'CT_VOLUME_ID'; // Id of the volume less loader prefix
@@ -88,29 +92,91 @@ instructions.innerText = `
 
 content.append(instructions);
 
+const brushInstanceNames = {
+  CircularBrush: 'CircularBrush',
+  CircularEraser: 'CircularEraser',
+  SphereBrush: 'SphereBrush',
+  SphereEraser: 'SphereEraser',
+  ThresholdBrush: 'ThresholdBrush',
+};
+
+const brushStrategies = {
+  [brushInstanceNames.CircularBrush]: 'FILL_INSIDE_CIRCLE',
+  [brushInstanceNames.CircularEraser]: 'ERASE_INSIDE_CIRCLE',
+  [brushInstanceNames.SphereBrush]: 'FILL_INSIDE_SPHERE',
+  [brushInstanceNames.SphereEraser]: 'ERASE_INSIDE_SPHERE',
+  [brushInstanceNames.ThresholdBrush]: 'THRESHOLD_INSIDE_CIRCLE',
+};
+
+const brushValues = [
+  brushInstanceNames.CircularBrush,
+  brushInstanceNames.CircularEraser,
+  brushInstanceNames.SphereBrush,
+  brushInstanceNames.SphereEraser,
+  brushInstanceNames.ThresholdBrush,
+];
+
 const optionsValues = [
-  BrushTool.toolName,
+  ...brushValues,
   RectangleScissorsTool.toolName,
   CircleScissorsTool.toolName,
   SphereScissorsTool.toolName,
+  PaintFillTool.toolName,
 ];
 
 // ============================= //
 addDropdownToToolbar({
   options: { values: optionsValues, defaultValue: BrushTool.toolName },
-  onSelectedValueChange: (toolNameAsStringOrNumber) => {
-    const toolName = String(toolNameAsStringOrNumber);
+  onSelectedValueChange: (nameAsStringOrNumber) => {
+    const name = String(nameAsStringOrNumber);
     const toolGroup = ToolGroupManager.getToolGroup(toolGroupId);
 
-    // Set the other tools disabled so we don't get conflicts.
-    // Note we only strictly need to change the one which is currently active.
-    optionsValues.forEach((toolName) => {
-      toolGroup.setToolDisabled(toolName);
-    });
+    // Set the currently active tool disabled
+    const toolName = toolGroup.getActivePrimaryMouseButtonTool();
 
-    toolGroup.setToolActive(toolName, {
-      bindings: [{ mouseButton: MouseBindings.Primary }],
-    });
+    if (toolName) {
+      toolGroup.setToolDisabled(toolName);
+    }
+
+    if (brushValues.includes(name)) {
+      toolGroup.setToolActive(name, {
+        bindings: [{ mouseButton: MouseBindings.Primary }],
+      });
+    } else {
+      const toolName = name;
+
+      toolGroup.setToolActive(toolName, {
+        bindings: [{ mouseButton: MouseBindings.Primary }],
+      });
+    }
+  },
+});
+
+const thresholdOptions = ['CT Fat: (-150, -70)', 'CT Bone: (200, 1000)'];
+
+addDropdownToToolbar({
+  options: { values: thresholdOptions, defaultValue: thresholdOptions[0] },
+  onSelectedValueChange: (nameAsStringOrNumber) => {
+    const name = String(nameAsStringOrNumber);
+
+    let threshold;
+    if (name === thresholdOptions[0]) {
+      threshold = [-150, -70];
+    } else if (name == thresholdOptions[1]) {
+      threshold = [100, 1000];
+    }
+
+    segmentationUtils.setBrushThresholdForToolGroup(toolGroupId, threshold);
+  },
+});
+
+addSliderToToolbar({
+  title: 'Brush Size',
+  range: [5, 50],
+  defaultValue: 25,
+  onSelectedValueChange: (valueAsStringOrNumber) => {
+    const value = Number(valueAsStringOrNumber);
+    segmentationUtils.setBrushSizeForToolGroup(toolGroupId, value);
   },
 });
 
@@ -155,6 +221,7 @@ async function run() {
   cornerstoneTools.addTool(RectangleScissorsTool);
   cornerstoneTools.addTool(CircleScissorsTool);
   cornerstoneTools.addTool(SphereScissorsTool);
+  cornerstoneTools.addTool(PaintFillTool);
   cornerstoneTools.addTool(BrushTool);
 
   // Define tool groups to add the segmentation display tool to
@@ -170,10 +237,45 @@ async function run() {
   toolGroup.addTool(RectangleScissorsTool.toolName);
   toolGroup.addTool(CircleScissorsTool.toolName);
   toolGroup.addTool(SphereScissorsTool.toolName);
-  toolGroup.addTool(BrushTool.toolName);
+  toolGroup.addTool(PaintFillTool.toolName);
+  toolGroup.addToolInstance(
+    brushInstanceNames.CircularBrush,
+    BrushTool.toolName,
+    {
+      activeStrategy: brushStrategies.CircularBrush,
+    }
+  );
+  toolGroup.addToolInstance(
+    brushInstanceNames.CircularEraser,
+    BrushTool.toolName,
+    {
+      activeStrategy: brushStrategies.CircularEraser,
+    }
+  );
+  toolGroup.addToolInstance(
+    brushInstanceNames.SphereBrush,
+    BrushTool.toolName,
+    {
+      activeStrategy: brushStrategies.SphereBrush,
+    }
+  );
+  toolGroup.addToolInstance(
+    brushInstanceNames.SphereEraser,
+    BrushTool.toolName,
+    {
+      activeStrategy: brushStrategies.SphereEraser,
+    }
+  );
+  toolGroup.addToolInstance(
+    brushInstanceNames.ThresholdBrush,
+    BrushTool.toolName,
+    {
+      activeStrategy: brushStrategies.ThresholdBrush,
+    }
+  );
   toolGroup.setToolEnabled(SegmentationDisplayTool.toolName);
 
-  toolGroup.setToolActive(BrushTool.toolName, {
+  toolGroup.setToolActive(brushInstanceNames.CircularBrush, {
     bindings: [{ mouseButton: MouseBindings.Primary }],
   });
 
@@ -201,7 +303,7 @@ async function run() {
       '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463',
     SeriesInstanceUID:
       '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561',
-    wadoRsRoot: 'https://d3t6nz73ql33tx.cloudfront.net/dicomweb',
+    wadoRsRoot: 'https://d1qmxk7r72ysft.cloudfront.net/dicomweb',
     type: 'VOLUME',
   });
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -52,6 +52,7 @@ import {
   MagnifyTool,
   ReferenceCursors,
   ReferenceLines,
+  PaintFillTool,
 } from './tools';
 
 import * as Enums from './enums';
@@ -103,6 +104,7 @@ export {
   synchronizers,
   Synchronizer,
   SynchronizerManager,
+  PaintFillTool,
   Types,
   state,
   // ToolGroups

--- a/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
+++ b/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
@@ -9,7 +9,12 @@ import {
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 import { state } from '../index';
-import { IToolGroup, SetToolBindingsType, ToolOptionsType } from '../../types';
+import {
+  IToolClassReference,
+  IToolGroup,
+  SetToolBindingsType,
+  ToolOptionsType,
+} from '../../types';
 
 import { MouseCursor, SVGMouseCursor } from '../../cursors';
 import { initElementCursor } from '../../cursors/elementCursor';
@@ -121,26 +126,35 @@ export default class ToolGroup implements IToolGroup {
     this._toolInstances[toolName] = instantiatedTool;
   }
 
-  addToolInstance(toolName, parentClassName, configuration) {
-    let toolClassToUse = state.tools[toolName]?.toolClass;
+  public addToolInstance(
+    toolName: string,
+    parentClassName: string,
+    configuration = {}
+  ): void {
+    let ToolClassToUse = state.tools[toolName]
+      ?.toolClass as IToolClassReference;
 
-    if (!toolClassToUse) {
+    if (!ToolClassToUse) {
       // get parent class constructor
-      const ParentClass = state.tools[parentClassName].toolClass;
+      const ParentClass = state.tools[parentClassName]
+        .toolClass as IToolClassReference;
 
-      // create a new class that extends the parent class
+      // Todo: could not find a way to make this work with typescript
+      // @ts-ignore
       class ToolInstance extends ParentClass {}
+      // @ts-ignore
       ToolInstance.toolName = toolName;
-
-      toolClassToUse = ToolInstance;
+      // @ts-ignore
+      ToolClassToUse = ToolInstance;
 
       state.tools[toolName] = {
-        toolClass: ToolInstance,
+        toolClass: ToolInstance as IToolClassReference,
       };
     }
 
     // add the tool to the toolGroup
-    this.addTool(toolClassToUse.toolName, configuration);
+    // @ts-ignore
+    this.addTool(ToolClassToUse.toolName, configuration);
   }
 
   //   class InstanceTool extends parentClass;
@@ -178,11 +192,11 @@ export default class ToolGroup implements IToolGroup {
     }
 
     // Handle the newly added viewport's mouse cursor
-    const activeToolIdentifier = this.getActivePrimaryMouseButtonTool();
+    const toolName = this.getActivePrimaryMouseButtonTool();
 
     const runtimeSettings = Settings.getRuntimeSettings();
     if (runtimeSettings.get('useCursors')) {
-      this.setViewportsCursorByToolName(activeToolIdentifier?.toolName);
+      this.setViewportsCursorByToolName(toolName);
     }
   }
 

--- a/packages/tools/src/store/state.ts
+++ b/packages/tools/src/store/state.ts
@@ -1,18 +1,18 @@
 import _cloneDeep from 'lodash.clonedeep';
 
-import { IToolGroup } from '../types';
+import { IToolGroup, IToolClassReference } from '../types';
 import Synchronizer from './SynchronizerManager/Synchronizer';
 import svgNodeCache, { resetSvgNodeCache } from './svgNodeCache';
-import { BaseTool } from '../tools';
-
-interface IToolClassReference {
-  toolClass: new <T extends BaseTool>(config: any) => T;
-}
 
 interface ICornerstoneTools3dState {
   isInteractingWithTool: boolean;
   isMultiPartToolActive: boolean;
-  tools: Record<string, IToolClassReference>;
+  tools: Record<
+    string,
+    {
+      toolClass: IToolClassReference;
+    }
+  >;
   toolGroups: Array<IToolGroup>;
   synchronizers: Array<Synchronizer>;
   svgNodeCache: Record<string, unknown>;

--- a/packages/tools/src/tools/base/BaseTool.ts
+++ b/packages/tools/src/tools/base/BaseTool.ts
@@ -4,7 +4,7 @@ import deepMerge from '../../utilities/deepMerge';
 import { ToolModes } from '../../enums';
 import { InteractionTypes, ToolProps, PublicToolProps } from '../../types';
 
-interface IBaseTool {
+export interface IBaseTool {
   /** ToolGroup ID the tool instance belongs to */
   toolGroupId: string;
   /** Tool supported interaction types */

--- a/packages/tools/src/tools/index.ts
+++ b/packages/tools/src/tools/index.ts
@@ -33,6 +33,7 @@ import SphereScissorsTool from './segmentation/SphereScissorsTool';
 import RectangleROIThresholdTool from './segmentation/RectangleROIThresholdTool';
 import RectangleROIStartEndThresholdTool from './segmentation/RectangleROIStartEndThresholdTool';
 import BrushTool from './segmentation/BrushTool';
+import PaintFillTool from './segmentation/PaintFillTool';
 
 export {
   // ~~ BASE
@@ -71,4 +72,5 @@ export {
   BrushTool,
   MagnifyTool,
   ReferenceLines,
+  PaintFillTool,
 };

--- a/packages/tools/src/tools/segmentation/BrushTool.ts
+++ b/packages/tools/src/tools/segmentation/BrushTool.ts
@@ -8,9 +8,14 @@ import type {
   SVGDrawingHelper,
 } from '../../types';
 import { BaseTool } from '../base';
-
-import { fillInsideCircle } from './strategies/fillCircle';
-import { Events } from '../../enums';
+import { fillInsideSphere } from './strategies/fillSphere';
+import { eraseInsideSphere } from './strategies/eraseSphere';
+import {
+  thresholdInsideCircle,
+  fillInsideCircle,
+} from './strategies/fillCircle';
+import { eraseInsideCircle } from './strategies/eraseCircle';
+import { Events, ToolModes } from '../../enums';
 import { drawCircle as drawCircleSvg } from '../../drawingSvg';
 import {
   resetElementCursor,
@@ -29,13 +34,14 @@ import {
 /**
  * @public
  */
-class BrushTool extends BaseTool {
-  static toolName;
+export default class BrushTool extends BaseTool {
+  static toolName = 'Brush';
   private _editData: {
-    segmentation: any; //
+    segmentation: Types.IImageVolume;
+    imageVolume: Types.IImageVolume; //
     segmentsLocked: number[]; //
   } | null;
-  private _hoverData: {
+  private _hoverData?: {
     brushCursor: any;
     segmentationId: string;
     segmentIndex: number;
@@ -44,7 +50,6 @@ class BrushTool extends BaseTool {
     viewportIdsToRender: string[];
     centerCanvas?: Array<number>;
   };
-  private _isDrawing: boolean;
 
   constructor(
     toolProps: PublicToolProps = {},
@@ -52,11 +57,19 @@ class BrushTool extends BaseTool {
       supportedInteractionTypes: ['Mouse', 'Touch'],
       configuration: {
         strategies: {
-          FILL_INSIDE: fillInsideCircle,
-          // ERASE_INSIDE: eraseInsideCircle,
+          FILL_INSIDE_CIRCLE: fillInsideCircle,
+          THRESHOLD_INSIDE_CIRCLE: thresholdInsideCircle,
+          ERASE_INSIDE_CIRCLE: eraseInsideCircle,
+          FILL_INSIDE_SPHERE: fillInsideSphere,
+          ERASE_INSIDE_SPHERE: eraseInsideSphere,
         },
-        defaultStrategy: 'FILL_INSIDE',
-        activeStrategy: 'FILL_INSIDE',
+        strategySpecificConfiguration: {
+          THRESHOLD_INSIDE_CIRCLE: {
+            threshold: [-150, -70], // E.g. CT Fat // Only used during threshold strategies.
+          },
+        },
+        defaultStrategy: 'FILL_INSIDE_CIRCLE',
+        activeStrategy: 'FILL_INSIDE_CIRCLE',
         brushSize: 25,
       },
     }
@@ -64,22 +77,35 @@ class BrushTool extends BaseTool {
     super(toolProps, defaultToolProps);
   }
 
+  onSetToolPassive = () => {
+    this.disableCursor();
+  };
+
+  onSetToolEnabled = () => {
+    this.disableCursor();
+  };
+
+  onSetToolDisabled = () => {
+    this.disableCursor();
+  };
+
+  private disableCursor() {
+    this._hoverData = undefined;
+  }
+
   preMouseDownCallback = (
     evt: EventTypes.MouseDownActivateEventType
   ): boolean => {
     const eventData = evt.detail;
-    const { currentPoints, element } = eventData;
-    const worldPos = currentPoints.world;
-    const canvasPos = currentPoints.canvas;
+    const { element } = eventData;
 
     const enabledElement = getEnabledElement(element);
     const { viewport, renderingEngine } = enabledElement;
-    const { canvasToWorld } = viewport;
 
-    this._isDrawing = true;
+    if (viewport instanceof StackViewport) {
+      throw new Error('Not implemented yet');
+    }
 
-    const camera = viewport.getCamera();
-    const { viewPlaneNormal, viewUp } = camera;
     const toolGroupId = this.toolGroupId;
 
     const activeSegmentationRepresentation =
@@ -90,16 +116,8 @@ class BrushTool extends BaseTool {
       );
     }
 
-    const { segmentationRepresentationUID, segmentationId, type } =
-      activeSegmentationRepresentation;
-    const segmentIndex =
-      segmentIndexController.getActiveSegmentIndex(segmentationId);
+    const { segmentationId, type } = activeSegmentationRepresentation;
     const segmentsLocked = segmentLocking.getLockedSegments(segmentationId);
-    const segmentColor = segmentationConfig.color.getColorForSegmentIndex(
-      toolGroupId,
-      segmentationRepresentationUID,
-      segmentIndex
-    );
 
     const { representationData } =
       segmentationState.getSegmentation(segmentationId);
@@ -108,54 +126,18 @@ class BrushTool extends BaseTool {
     const { volumeId } = representationData[type];
     const segmentation = cache.getVolume(volumeId);
 
-    // Todo: Used for drawing the svg only, we might not need it at all
-    const centerCanvas = canvasPos;
+    const actors = viewport.getActors();
 
-    const radius = this.configuration.brushSize;
-
-    const bottomCanvas: Types.Point2 = [
-      centerCanvas[0],
-      centerCanvas[1] + radius,
-    ];
-    const topCanvas: Types.Point2 = [centerCanvas[0], centerCanvas[1] - radius];
-    const leftCanvas: Types.Point2 = [
-      centerCanvas[0] - radius,
-      centerCanvas[1],
-    ];
-    const rightCanvas: Types.Point2 = [
-      centerCanvas[0] + radius,
-      centerCanvas[1],
-    ];
-
-    const brushCursor = {
-      metadata: {
-        viewPlaneNormal: <Types.Point3>[...viewPlaneNormal],
-        viewUp: <Types.Point3>[...viewUp],
-        FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
-        referencedImageId: '',
-        toolName: this.getToolName(),
-        segmentColor,
-      },
-      data: {
-        invalidated: true,
-        handles: {
-          points: [
-            canvasToWorld(bottomCanvas),
-            canvasToWorld(topCanvas),
-            canvasToWorld(leftCanvas),
-            canvasToWorld(rightCanvas),
-          ],
-        },
-        cachedStats: {},
-      },
-    };
+    // Note: For tools that need the source data. Assumed to use
+    // First volume actor for now.
+    const firstVolumeActorUID = actors[0].uid;
+    const imageVolume = cache.getVolume(firstVolumeActorUID);
 
     const viewportIdsToRender = [viewport.id];
 
-    // this.updateCursor()
-
     this._editData = {
       segmentation,
+      imageVolume,
       segmentsLocked,
     };
 
@@ -174,7 +156,9 @@ class BrushTool extends BaseTool {
   };
 
   mouseMoveCallback = (evt: EventTypes.MouseMoveEventType): void => {
-    this.updateCursor(evt);
+    if (this.mode === ToolModes.Active) {
+      this.updateCursor(evt);
+    }
   };
 
   private updateCursor(
@@ -183,14 +167,12 @@ class BrushTool extends BaseTool {
       | EventTypes.MouseDragEventType
       | EventTypes.MouseUpEventType
   ) {
-    const brushSize = this.configuration.brushSize;
     const eventData = evt.detail;
     const { element } = eventData;
     const { currentPoints } = eventData;
-    const canvasPos = currentPoints.canvas;
+    const centerCanvas = currentPoints.canvas;
     const enabledElement = getEnabledElement(element);
     const { renderingEngine, viewport } = enabledElement;
-    const { canvasToWorld } = viewport;
 
     const camera = viewport.getCamera();
     const { viewPlaneNormal, viewUp } = camera;
@@ -211,7 +193,6 @@ class BrushTool extends BaseTool {
     const segmentIndex =
       segmentIndexController.getActiveSegmentIndex(segmentationId);
 
-    const segmentsLocked = segmentLocking.getLockedSegments(segmentationId);
     const segmentColor = segmentationConfig.color.getColorForSegmentIndex(
       toolGroupId,
       segmentationRepresentationUID,
@@ -220,25 +201,7 @@ class BrushTool extends BaseTool {
 
     const viewportIdsToRender = [viewport.id];
 
-    const centerCanvas = canvasPos;
-
     // Center of circle in canvas Coordinates
-
-    const radius = brushSize;
-
-    const bottomCanvas: Types.Point2 = [
-      centerCanvas[0],
-      centerCanvas[1] + radius,
-    ];
-    const topCanvas: Types.Point2 = [centerCanvas[0], centerCanvas[1] - radius];
-    const leftCanvas: Types.Point2 = [
-      centerCanvas[0] - radius,
-      centerCanvas[1],
-    ];
-    const rightCanvas: Types.Point2 = [
-      centerCanvas[0] + radius,
-      centerCanvas[1],
-    ];
 
     const brushCursor = {
       metadata: {
@@ -249,18 +212,7 @@ class BrushTool extends BaseTool {
         toolName: this.getToolName(),
         segmentColor,
       },
-      data: {
-        invalidated: true,
-        handles: {
-          points: [
-            canvasToWorld(bottomCanvas),
-            canvasToWorld(topCanvas),
-            canvasToWorld(leftCanvas),
-            canvasToWorld(rightCanvas),
-          ],
-        },
-        cachedStats: {},
-      },
+      data: {},
     };
 
     this._hoverData = {
@@ -273,6 +225,8 @@ class BrushTool extends BaseTool {
       viewportIdsToRender,
     };
 
+    this._calculateCursor(element, centerCanvas);
+
     triggerAnnotationRenderForViewportUIDs(
       renderingEngine,
       viewportIdsToRender
@@ -280,17 +234,15 @@ class BrushTool extends BaseTool {
   }
 
   private _mouseDragCallback = (evt: EventTypes.MouseDragEventType): void => {
-    this._isDrawing = true;
-    const brushSize = this.configuration.brushSize;
     const eventData = evt.detail;
     const { element } = eventData;
-    const { currentPoints } = eventData;
-    const currentCanvasPoints = currentPoints.canvas;
     const enabledElement = getEnabledElement(element);
-    const { renderingEngine, viewport } = enabledElement;
-    const { canvasToWorld } = viewport;
+    const { renderingEngine } = enabledElement;
 
-    const { segmentation, segmentsLocked } = this._editData;
+    const { imageVolume, segmentation, segmentsLocked } = this._editData;
+
+    this.updateCursor(evt);
+
     const {
       segmentIndex,
       segmentationId,
@@ -299,11 +251,38 @@ class BrushTool extends BaseTool {
       viewportIdsToRender,
     } = this._hoverData;
 
-    const { viewPlaneNormal, viewUp } = brushCursor.metadata;
     const { data } = brushCursor;
+    const { viewPlaneNormal, viewUp } = brushCursor.metadata;
 
+    triggerAnnotationRenderForViewportUIDs(
+      renderingEngine,
+      viewportIdsToRender
+    );
+
+    const operationData = {
+      points: data.handles.points,
+      volume: segmentation, // todo: just pass the segmentationId instead
+      imageVolume,
+      segmentIndex,
+      segmentsLocked,
+      viewPlaneNormal,
+      toolGroupId: this.toolGroupId,
+      segmentationId,
+      segmentationRepresentationUID,
+      viewUp,
+      strategySpecificConfiguration:
+        this.configuration.strategySpecificConfiguration,
+    };
+
+    this.applyActiveStrategy(enabledElement, operationData);
+  };
+
+  private _calculateCursor(element, centerCanvas) {
+    const enabledElement = getEnabledElement(element);
+    const { viewport } = enabledElement;
+    const { canvasToWorld } = viewport;
+    const { brushSize } = this.configuration;
     // Center of circle in canvas Coordinates
-    const centerCanvas = currentCanvasPoints;
 
     const radius = brushSize;
 
@@ -321,6 +300,13 @@ class BrushTool extends BaseTool {
       centerCanvas[1],
     ];
 
+    const { brushCursor } = this._hoverData;
+    const { data } = brushCursor;
+
+    if (data.handles === undefined) {
+      data.handles = {};
+    }
+
     data.handles.points = [
       canvasToWorld(bottomCanvas),
       canvasToWorld(topCanvas),
@@ -328,33 +314,14 @@ class BrushTool extends BaseTool {
       canvasToWorld(rightCanvas),
     ];
 
-    data.invalidated = true;
-
-    triggerAnnotationRenderForViewportUIDs(
-      renderingEngine,
-      viewportIdsToRender
-    );
-
-    const operationData = {
-      points: data.handles.points,
-      volume: segmentation, // todo: just pass the segmentationId instead
-      segmentIndex,
-      segmentsLocked,
-      viewPlaneNormal,
-      toolGroupId: this.toolGroupId,
-      segmentationId,
-      segmentationRepresentationUID,
-      viewUp,
-    };
-
-    this.applyActiveStrategy(enabledElement, operationData);
-  };
+    data.invalidated = false;
+  }
 
   private _mouseUpCallback = (evt: EventTypes.MouseUpEventType): void => {
     const eventData = evt.detail;
     const { element } = eventData;
 
-    const { segmentation, segmentsLocked } = this._editData;
+    const { imageVolume, segmentation, segmentsLocked } = this._editData;
     const {
       segmentIndex,
       segmentationId,
@@ -373,7 +340,6 @@ class BrushTool extends BaseTool {
     const { viewport } = enabledElement;
 
     this._editData = null;
-    this._isDrawing = false;
     this.updateCursor(evt);
 
     if (viewport instanceof StackViewport) {
@@ -383,6 +349,7 @@ class BrushTool extends BaseTool {
     const operationData = {
       points: data.handles.points,
       volume: segmentation,
+      imageVolume,
       segmentIndex,
       segmentsLocked,
       viewPlaneNormal,
@@ -390,6 +357,8 @@ class BrushTool extends BaseTool {
       segmentationId,
       segmentationRepresentationUID,
       viewUp,
+      strategySpecificConfiguration:
+        this.configuration.strategySpecificConfiguration,
     };
 
     this.applyActiveStrategy(enabledElement, operationData);
@@ -399,43 +368,27 @@ class BrushTool extends BaseTool {
    * Add event handlers for the modify event loop, and prevent default event propagation.
    */
   private _activateDraw = (element: HTMLDivElement): void => {
-    element.addEventListener(
-      Events.MOUSE_UP,
-      this._mouseUpCallback as EventListener
-    );
-    element.addEventListener(
-      Events.MOUSE_DRAG,
-      this._mouseDragCallback as EventListener
-    );
-    element.addEventListener(
-      Events.MOUSE_CLICK,
-      this._mouseUpCallback as EventListener
-    );
-
-    //element.addEventListener(Events.TOUCH_END, this._mouseUpCallback)
-    //element.addEventListener(Events.TOUCH_DRAG, this._mouseDragCallback)
+    element.addEventListener(Events.MOUSE_UP, this._mouseUpCallback);
+    element.addEventListener(Events.MOUSE_DRAG, this._mouseDragCallback);
+    element.addEventListener(Events.MOUSE_CLICK, this._mouseUpCallback);
   };
 
   /**
    * Add event handlers for the modify event loop, and prevent default event prapogation.
    */
   private _deactivateDraw = (element: HTMLDivElement): void => {
-    element.removeEventListener(
-      Events.MOUSE_UP,
-      this._mouseUpCallback as EventListener
-    );
-    element.removeEventListener(
-      Events.MOUSE_DRAG,
-      this._mouseDragCallback as EventListener
-    );
-    element.removeEventListener(
-      Events.MOUSE_CLICK,
-      this._mouseUpCallback as EventListener
-    );
-
-    //element.removeEventListener(Events.TOUCH_END, this._mouseUpCallback)
-    //element.removeEventListener(Events.TOUCH_DRAG, this._mouseDragCallback)
+    element.removeEventListener(Events.MOUSE_UP, this._mouseUpCallback);
+    element.removeEventListener(Events.MOUSE_DRAG, this._mouseDragCallback);
+    element.removeEventListener(Events.MOUSE_CLICK, this._mouseUpCallback);
   };
+
+  public invalidateBrushCursor() {
+    if (this._hoverData !== undefined) {
+      const { data } = this._hoverData.brushCursor;
+
+      data.invalidated = true;
+    }
+  }
 
   renderAnnotation(
     enabledElement: Types.IEnabledElement,
@@ -444,6 +397,7 @@ class BrushTool extends BaseTool {
     if (!this._hoverData) {
       return;
     }
+
     const { viewport } = enabledElement;
 
     const viewportIdsToRender = this._hoverData.viewportIdsToRender;
@@ -453,6 +407,15 @@ class BrushTool extends BaseTool {
     }
 
     const brushCursor = this._hoverData.brushCursor;
+
+    if (brushCursor.data.invalidated === true) {
+      const { centerCanvas } = this._hoverData;
+      const { element } = viewport;
+
+      // This can be set true when changing the brush size programmatically
+      // whilst the cursor is being rendered.
+      this._calculateCursor(element, centerCanvas);
+    }
 
     const toolMetadata = brushCursor.metadata;
     const annotationUID = toolMetadata.brushCursorUID;
@@ -492,6 +455,3 @@ class BrushTool extends BaseTool {
     );
   }
 }
-
-BrushTool.toolName = 'Brush';
-export default BrushTool;

--- a/packages/tools/src/tools/segmentation/BrushTool.ts
+++ b/packages/tools/src/tools/segmentation/BrushTool.ts
@@ -368,18 +368,36 @@ export default class BrushTool extends BaseTool {
    * Add event handlers for the modify event loop, and prevent default event propagation.
    */
   private _activateDraw = (element: HTMLDivElement): void => {
-    element.addEventListener(Events.MOUSE_UP, this._mouseUpCallback);
-    element.addEventListener(Events.MOUSE_DRAG, this._mouseDragCallback);
-    element.addEventListener(Events.MOUSE_CLICK, this._mouseUpCallback);
+    element.addEventListener(
+      Events.MOUSE_UP,
+      this._mouseUpCallback as EventListener
+    );
+    element.addEventListener(
+      Events.MOUSE_DRAG,
+      this._mouseDragCallback as EventListener
+    );
+    element.addEventListener(
+      Events.MOUSE_CLICK,
+      this._mouseUpCallback as EventListener
+    );
   };
 
   /**
    * Add event handlers for the modify event loop, and prevent default event prapogation.
    */
   private _deactivateDraw = (element: HTMLDivElement): void => {
-    element.removeEventListener(Events.MOUSE_UP, this._mouseUpCallback);
-    element.removeEventListener(Events.MOUSE_DRAG, this._mouseDragCallback);
-    element.removeEventListener(Events.MOUSE_CLICK, this._mouseUpCallback);
+    element.removeEventListener(
+      Events.MOUSE_UP,
+      this._mouseUpCallback as EventListener
+    );
+    element.removeEventListener(
+      Events.MOUSE_DRAG,
+      this._mouseDragCallback as EventListener
+    );
+    element.removeEventListener(
+      Events.MOUSE_CLICK,
+      this._mouseUpCallback as EventListener
+    );
   };
 
   public invalidateBrushCursor() {

--- a/packages/tools/src/tools/segmentation/PaintFillTool.ts
+++ b/packages/tools/src/tools/segmentation/PaintFillTool.ts
@@ -287,7 +287,7 @@ export default class PaintFillTool extends BaseTool {
 
   // Define a getter for the fill routine to access the working label map.
   private generateFloodFillGetter = (
-    dimensions: Type.Point3,
+    dimensions: Types.Point3,
     fixedDimension: number,
     fixedDimensionValue: number,
     getLabelValue: PaintFillToolHelpers['getLabelValue']

--- a/packages/tools/src/tools/segmentation/PaintFillTool.ts
+++ b/packages/tools/src/tools/segmentation/PaintFillTool.ts
@@ -1,0 +1,368 @@
+import {
+  cache,
+  getEnabledElement,
+  utilities as csUtils,
+} from '@cornerstonejs/core';
+import type { Types } from '@cornerstonejs/core';
+
+import { BaseTool } from '../base';
+import { PublicToolProps, ToolProps, EventTypes } from '../../types';
+
+import { triggerSegmentationDataModified } from '../../stateManagement/segmentation/triggerSegmentationEvents';
+import {
+  segmentLocking,
+  activeSegmentation,
+  segmentIndex as segmentIndexController,
+} from '../../stateManagement/segmentation';
+import { segmentation as segmentationUtils } from '../../utilities';
+import { getSegmentation } from '../../stateManagement/segmentation/segmentationState';
+import { FloodFillResult, FloodFillGetter } from '../../types';
+
+const { transformWorldToIndex, isEqual } = csUtils;
+const { floodFill } = segmentationUtils;
+
+type PaintFillToolHelpers = {
+  getScalarDataPositionFromPlane: (x: number, y: number) => number;
+  getLabelValue: (x: number, y: number, z: number) => number;
+  floodFillGetter: FloodFillGetter;
+  inPlaneSeedPoint: Types.Point2;
+  fixedDimensionValue: number;
+};
+
+/**
+ * Tool for manipulating segmentation data by filling in regions. It acts on the
+ * active Segmentation on the viewport (enabled element) and requires an active
+ * segmentation to be already present. By default it will fill a given labelled
+ * or empty region with the the activeSegmentIndex label. You can use the
+ * SegmentationModule to set the active segmentation and segmentIndex.
+ */
+export default class PaintFillTool extends BaseTool {
+  static toolName = 'PaintFill';
+
+  constructor(
+    toolProps: PublicToolProps = {},
+    defaultToolProps: ToolProps = {
+      supportedInteractionTypes: ['Mouse', 'Touch'],
+    }
+  ) {
+    super(toolProps, defaultToolProps);
+  }
+
+  /**
+   * Based on the current position of the mouse and the enabledElement, it
+   * finds the active segmentation info and use it for the current tool.
+   *
+   * @param evt -  EventTypes.NormalizedMouseEventType
+   * @returns The annotation object.
+   *
+   */
+  preMouseDownCallback = (
+    evt: EventTypes.MouseDownActivateEventType
+  ): boolean => {
+    const eventDetail = evt.detail;
+    const { currentPoints, element } = eventDetail;
+    const worldPos = currentPoints.world;
+
+    const enabledElement = getEnabledElement(element);
+    const { viewport } = enabledElement;
+
+    const camera = viewport.getCamera();
+    const { viewPlaneNormal } = camera;
+    const toolGroupId = this.toolGroupId;
+
+    const activeSegmentationRepresentation =
+      activeSegmentation.getActiveSegmentationRepresentation(toolGroupId);
+    if (!activeSegmentationRepresentation) {
+      throw new Error(
+        'No active segmentation detected, create one before using scissors tool'
+      );
+    }
+
+    const { segmentationId, type } = activeSegmentationRepresentation;
+    const segmentIndex =
+      segmentIndexController.getActiveSegmentIndex(segmentationId);
+    const segmentsLocked: number[] =
+      segmentLocking.getLockedSegments(segmentationId);
+    const { representationData } = getSegmentation(segmentationId);
+
+    const { volumeId } = representationData[type];
+    const segmentation = cache.getVolume(volumeId);
+    const { scalarData, dimensions, direction } = segmentation;
+
+    const index = transformWorldToIndex(segmentation.imageData, worldPos);
+
+    const fixedDimension = this.getFixedDimension(viewPlaneNormal, direction);
+
+    if (fixedDimension === undefined) {
+      console.warn('Oblique paint fill not yet supported');
+      return;
+    }
+
+    const {
+      floodFillGetter,
+      getLabelValue,
+      getScalarDataPositionFromPlane,
+      inPlaneSeedPoint,
+      fixedDimensionValue,
+    } = this.generateHelpers(scalarData, dimensions, index, fixedDimension);
+
+    // Check if within volume
+    if (
+      index[0] < 0 ||
+      index[0] >= dimensions[0] ||
+      index[1] < 0 ||
+      index[1] >= dimensions[1] ||
+      index[2] < 0 ||
+      index[2] >= dimensions[2]
+    ) {
+      // Clicked outside segmentation volume, no good way to fill.
+      return;
+    }
+    //@ts-ignore // todo type
+    const clickedLabelValue = getLabelValue(index[0], index[1], index[2]);
+
+    if (segmentsLocked.includes(clickedLabelValue)) {
+      // Label is locked, cannot fill.
+      return;
+    }
+
+    const floodFillResult = floodFill(floodFillGetter, inPlaneSeedPoint);
+
+    const { flooded } = floodFillResult;
+
+    flooded.forEach((index) => {
+      const scalarDataPosition = getScalarDataPositionFromPlane(
+        index[0],
+        index[1]
+      );
+
+      scalarData[scalarDataPosition] = segmentIndex;
+    });
+
+    const framesModified = this.getFramesModified(
+      fixedDimension,
+      fixedDimensionValue,
+      floodFillResult
+    );
+
+    triggerSegmentationDataModified(segmentationId, framesModified);
+
+    return true;
+  };
+
+  private getFramesModified = (
+    fixedDimension: number,
+    fixedDimensionValue: number,
+    floodFillResult: FloodFillResult
+  ): number[] => {
+    const { boundaries } = floodFillResult;
+
+    if (fixedDimension === 2) {
+      return [fixedDimensionValue];
+    }
+
+    // For both the fixedDimensions being 0 and 1, the Z (stack) direction is j,
+    // so we don't need to find min/max i.
+
+    let minJ = Infinity;
+    let maxJ = -Infinity;
+
+    for (let b = 0; b < boundaries.length; b++) {
+      const j = boundaries[b][1];
+
+      if (j < minJ) minJ = j;
+      if (j > maxJ) maxJ = j;
+    }
+
+    const framesModified = [];
+
+    for (let frame = minJ; frame <= maxJ; frame++) {
+      framesModified.push(frame);
+    }
+
+    return framesModified;
+  };
+
+  private generateHelpers = (
+    scalarData: Float32Array | Uint8Array,
+    dimensions: Types.Point3,
+    seedIndex3D: Types.Point3,
+    fixedDimension = 2
+  ): PaintFillToolHelpers => {
+    let fixedDimensionValue: number;
+    let inPlaneSeedPoint: Types.Point2;
+
+    switch (fixedDimension) {
+      case 0:
+        fixedDimensionValue = seedIndex3D[0]; // X
+        inPlaneSeedPoint = [seedIndex3D[1], seedIndex3D[2]]; // Y,Z
+        break;
+      case 1:
+        fixedDimensionValue = seedIndex3D[1]; // Y
+        inPlaneSeedPoint = [seedIndex3D[0], seedIndex3D[2]]; // X,Z
+        break;
+      case 2:
+        fixedDimensionValue = seedIndex3D[2]; // Z
+        inPlaneSeedPoint = [seedIndex3D[0], seedIndex3D[1]]; // X, Y
+        break;
+      default:
+        throw new Error(`Invalid fixedDimension: ${fixedDimension}`);
+    }
+
+    const getScalarDataPosition = (x: number, y: number, z: number): number => {
+      return z * dimensions[1] * dimensions[0] + y * dimensions[0] + x;
+    };
+
+    const getLabelValue = (x: number, y: number, z: number): number => {
+      return scalarData[getScalarDataPosition(x, y, z)];
+    };
+
+    const floodFillGetter = this.generateFloodFillGetter(
+      dimensions,
+      fixedDimension,
+      fixedDimensionValue,
+      getLabelValue
+    );
+
+    const getScalarDataPositionFromPlane =
+      this.generateGetScalarDataPositionFromPlane(
+        getScalarDataPosition,
+        fixedDimension,
+        fixedDimensionValue
+      );
+
+    return {
+      getScalarDataPositionFromPlane,
+      getLabelValue,
+      floodFillGetter,
+      inPlaneSeedPoint,
+      fixedDimensionValue,
+    };
+  };
+
+  private getFixedDimension(
+    viewPlaneNormal: Types.Point3,
+    direction: number[]
+  ): number | undefined {
+    const xDirection = direction.slice(0, 3);
+    const yDirection = direction.slice(3, 6);
+    const zDirection = direction.slice(6, 9);
+
+    const absoluteOfViewPlaneNormal = [
+      Math.abs(viewPlaneNormal[0]),
+      Math.abs(viewPlaneNormal[1]),
+      Math.abs(viewPlaneNormal[2]),
+    ];
+
+    const absoluteOfXDirection = [
+      Math.abs(xDirection[0]),
+      Math.abs(xDirection[1]),
+      Math.abs(xDirection[2]),
+    ];
+
+    if (isEqual(absoluteOfViewPlaneNormal, absoluteOfXDirection)) {
+      return 0;
+    }
+
+    const absoluteOfYDirection = [
+      Math.abs(yDirection[0]),
+      Math.abs(yDirection[1]),
+      Math.abs(yDirection[2]),
+    ];
+
+    if (isEqual(absoluteOfViewPlaneNormal, absoluteOfYDirection)) {
+      return 1;
+    }
+
+    const absoluteOfZDirection = [
+      Math.abs(zDirection[0]),
+      Math.abs(zDirection[1]),
+      Math.abs(zDirection[2]),
+    ];
+
+    if (isEqual(absoluteOfViewPlaneNormal, absoluteOfZDirection)) {
+      return 2;
+    }
+  }
+
+  // Define a getter for the fill routine to access the working label map.
+  private generateFloodFillGetter = (
+    dimensions: Type.Point3,
+    fixedDimension: number,
+    fixedDimensionValue: number,
+    getLabelValue: PaintFillToolHelpers['getLabelValue']
+  ): FloodFillGetter => {
+    let floodFillGetter;
+
+    // In each helper we first check if out of bounds, as the flood filler
+    // doesn't know about the dimensions of the data structure that sits on top
+    // of the scalarData. E.g. if cols is 10, (0,1) and (10, 0) would point to
+    // the same position in these getters.
+
+    switch (fixedDimension) {
+      case 0:
+        floodFillGetter = (y, z) => {
+          if (y >= dimensions[1] || y < 0 || z >= dimensions[2] || z < 0) {
+            return;
+          }
+
+          return getLabelValue(fixedDimensionValue, y, z);
+        };
+        break;
+
+      case 1:
+        floodFillGetter = (x, z) => {
+          if (x >= dimensions[0] || x < 0 || z >= dimensions[2] || z < 0) {
+            return;
+          }
+
+          return getLabelValue(x, fixedDimensionValue, z);
+        };
+        break;
+
+      case 2:
+        floodFillGetter = (x, y) => {
+          if (x >= dimensions[0] || x < 0 || y >= dimensions[1] || y < 0) {
+            return;
+          }
+
+          return getLabelValue(x, y, fixedDimensionValue);
+        };
+        break;
+      default:
+        throw new Error(`Invalid fixedDimension: ${fixedDimension}`);
+    }
+
+    return floodFillGetter;
+  };
+
+  private generateGetScalarDataPositionFromPlane = (
+    getScalarDataPosition: (x: number, y: number, z: number) => number,
+    fixedDimension: number,
+    fixedDimensionValue: number
+  ): PaintFillToolHelpers['getScalarDataPositionFromPlane'] => {
+    let getScalarDataPositionFromPlane;
+
+    switch (fixedDimension) {
+      case 0:
+        getScalarDataPositionFromPlane = (y, z) => {
+          return getScalarDataPosition(fixedDimensionValue, y, z);
+        };
+        break;
+      case 1:
+        getScalarDataPositionFromPlane = (x, z) => {
+          return getScalarDataPosition(x, fixedDimensionValue, z);
+        };
+        break;
+      case 2:
+        getScalarDataPositionFromPlane = (x, y) => {
+          return getScalarDataPosition(x, y, fixedDimensionValue);
+        };
+        break;
+      default:
+        throw new Error(`Invalid fixedDimension: ${fixedDimension}`);
+    }
+
+    return getScalarDataPositionFromPlane;
+  };
+}

--- a/packages/tools/src/tools/segmentation/strategies/eraseCircle.ts
+++ b/packages/tools/src/tools/segmentation/strategies/eraseCircle.ts
@@ -1,0 +1,30 @@
+import type { Types } from '@cornerstonejs/core';
+
+import { fillInsideCircle } from './fillCircle';
+
+type OperationData = {
+  segmentationId: string;
+  imageVolume: Types.IImageVolume;
+  points: any; // Todo:fix
+  volume: Types.IImageVolume;
+  segmentIndex: number;
+  segmentsLocked: number[];
+  viewPlaneNormal: number[];
+  viewUp: number[];
+  strategySpecificConfiguration: any;
+  constraintFn: () => boolean;
+};
+
+export function eraseInsideCircle(
+  enabledElement: Types.IEnabledElement,
+  operationData: OperationData
+): void {
+  // Take the arguments and set the segmentIndex to 0,
+  // Then use existing fillInsideCircle functionality.
+  const eraseOperationData = {
+    ...operationData,
+    segmentIndex: 0,
+  };
+
+  fillInsideCircle(enabledElement, eraseOperationData);
+}

--- a/packages/tools/src/tools/segmentation/strategies/eraseSphere.ts
+++ b/packages/tools/src/tools/segmentation/strategies/eraseSphere.ts
@@ -1,0 +1,27 @@
+import type { Types } from '@cornerstonejs/core';
+
+import { fillInsideSphere } from './fillSphere';
+
+type OperationData = {
+  points: [Types.Point3, Types.Point3, Types.Point3, Types.Point3];
+  volume: Types.IImageVolume;
+  segmentIndex: number;
+  segmentationId: string;
+  segmentsLocked: number[];
+  viewPlaneNormal: Types.Point3;
+  viewUp: Types.Point3;
+  constraintFn: () => boolean;
+};
+
+export function eraseInsideSphere(
+  enabledElement: Types.IEnabledElement,
+  operationData: OperationData
+): void {
+  // Take the arguments and set the segmentIndex to 0,
+  // Then use existing fillInsideCircle functionality.
+  const eraseOperationData = Object.assign({}, operationData, {
+    segmentIndex: 0,
+  });
+
+  fillInsideSphere(enabledElement, eraseOperationData);
+}

--- a/packages/tools/src/types/FloodFillTypes.ts
+++ b/packages/tools/src/types/FloodFillTypes.ts
@@ -1,0 +1,19 @@
+import { Types } from '@cornerstonejs/core';
+
+type FloodFillResult = {
+  flooded: Types.Point2[] | Types.Point3[];
+  boundaries: Types.Point2[] | Types.Point3[];
+};
+
+type FloodFillGetter3D = (x: number, y: number, z: number) => number;
+type FloodFillGetter2D = (x: number, y: number) => number;
+type FloodFillGetter = FloodFillGetter2D | FloodFillGetter3D;
+
+type FloodFillOptions = {
+  onFlood?: (x, y) => void;
+  onBoundary?: (x, y) => void;
+  equals?: (a, b) => boolean; // Equality operation for your datastructure. Defaults to a === b.
+  diagonals?: boolean; // Whether to flood fill across diagonals. Default false.
+};
+
+export { FloodFillResult, FloodFillGetter, FloodFillOptions };

--- a/packages/tools/src/types/IToolClassReference.ts
+++ b/packages/tools/src/types/IToolClassReference.ts
@@ -1,0 +1,5 @@
+import { BaseTool } from '../tools';
+
+type IToolClassReference = new <T extends BaseTool>(config: any) => T;
+
+export default IToolClassReference;

--- a/packages/tools/src/types/IToolGroup.ts
+++ b/packages/tools/src/types/IToolGroup.ts
@@ -21,6 +21,10 @@ export default interface IToolGroup {
   getToolInstance: { (toolName: string): any };
   /** Add a tool to toolGroup with its configuration */
   addTool: { (toolName: string, toolConfiguration?: any): void };
+  /** Add tool instance, if you want to create more than one instance from the same tool e.g., brush/eraser tool */
+  addToolInstance: {
+    (ttoolName: string, parentClassName: string, configuration?: any): void;
+  };
   /** Add viewports to share the tools for the ToolGroup */
   addViewport: {
     (viewportId: string, renderingEngineId?: string): void;

--- a/packages/tools/src/types/index.ts
+++ b/packages/tools/src/types/index.ts
@@ -40,6 +40,11 @@ import type {
   RepresentationPublicInput,
 } from './SegmentationStateTypes';
 import ISynchronizerEventHandler from './ISynchronizerEventHandler';
+import {
+  FloodFillGetter,
+  FloodFillOptions,
+  FloodFillResult,
+} from './FloodFillTypes';
 
 export type {
   // AnnotationState
@@ -90,4 +95,8 @@ export type {
   CINETypes,
   BoundsIJK,
   SVGDrawingHelper,
+  // FloodFill
+  FloodFillResult,
+  FloodFillGetter,
+  FloodFillOptions,
 };

--- a/packages/tools/src/types/index.ts
+++ b/packages/tools/src/types/index.ts
@@ -45,6 +45,7 @@ import {
   FloodFillOptions,
   FloodFillResult,
 } from './FloodFillTypes';
+import IToolClassReference from './IToolClassReference';
 
 export type {
   // AnnotationState
@@ -69,6 +70,7 @@ export type {
   InteractionTypes,
   //
   IToolGroup,
+  IToolClassReference,
   ISynchronizerEventHandler,
   ToolHandle,
   AnnotationHandle,

--- a/packages/tools/src/utilities/segmentation/brushSizeForToolGroup.ts
+++ b/packages/tools/src/utilities/segmentation/brushSizeForToolGroup.ts
@@ -1,0 +1,82 @@
+import { getToolGroup } from '../../store/ToolGroupManager';
+import BrushTool from '../../tools/segmentation/BrushTool';
+import triggerAnnotationRenderForViewportIds from '../triggerAnnotationRenderForViewportIds';
+import { getRenderingEngine } from '@cornerstonejs/core';
+
+const brushToolName = BrushTool.toolName;
+
+export function setBrushSizeForToolGroup(
+  toolGroupId: string,
+  brushSize: number
+): void {
+  const toolGroup = getToolGroup(toolGroupId);
+
+  if (toolGroup === undefined) {
+    return;
+  }
+
+  const toolInstances = toolGroup._toolInstances;
+
+  if (!Object.keys(toolInstances).length) {
+    return;
+  }
+
+  const brushToolInstance = toolInstances[brushToolName];
+
+  if (!brushToolInstance) {
+    return;
+  }
+
+  brushToolInstance.configuration.brushSize = brushSize;
+
+  // Invalidate the brush being rendered so it can update.
+  brushToolInstance.invalidateBrushCursor();
+
+  // Trigger an annotation render for any viewports on the toolgroup
+  const viewportsInfo = toolGroup.getViewportsInfo();
+
+  const viewportsInfoArray = Object.keys(viewportsInfo).map(
+    (key) => viewportsInfo[key]
+  );
+
+  if (!viewportsInfoArray.length) {
+    return;
+  }
+
+  const { renderingEngineId } = viewportsInfoArray[0];
+
+  // Use helper to get array of viewportIds, or we just end up doing this mapping
+  // ourselves here.
+  const viewportIds = toolGroup.getViewportIds();
+
+  const renderingEngine = getRenderingEngine(renderingEngineId);
+
+  triggerAnnotationRenderForViewportIds(renderingEngine, viewportIds);
+}
+
+export function getBrushSizeForToolGroup(toolGroupId: string): void {
+  const toolGroup = getToolGroup(toolGroupId);
+
+  if (toolGroup === undefined) {
+    return;
+  }
+
+  const toolInstances = toolGroup._toolInstances;
+
+  if (!Object.keys(toolInstances).length) {
+    return;
+  }
+
+  const brushToolInstance = toolInstances[brushToolName];
+
+  if (!brushToolInstance) {
+    return;
+  }
+
+  // TODO -> Assumes the brush sizes are the same and set via these helpers.
+
+  // const toolInstanceNames = Object.keys(brushToolInstances);
+  // const firstToolInstance = brushToolInstances[toolInstanceNames[0]];
+
+  return brushToolInstance.configuration.brushSize;
+}

--- a/packages/tools/src/utilities/segmentation/brushSizeForToolGroup.ts
+++ b/packages/tools/src/utilities/segmentation/brushSizeForToolGroup.ts
@@ -2,8 +2,7 @@ import { getToolGroup } from '../../store/ToolGroupManager';
 import BrushTool from '../../tools/segmentation/BrushTool';
 import triggerAnnotationRenderForViewportIds from '../triggerAnnotationRenderForViewportIds';
 import { getRenderingEngine } from '@cornerstonejs/core';
-
-const brushToolName = BrushTool.toolName;
+import getBrushToolInstances from './utilities';
 
 export function setBrushSizeForToolGroup(
   toolGroupId: string,
@@ -15,22 +14,14 @@ export function setBrushSizeForToolGroup(
     return;
   }
 
-  const toolInstances = toolGroup._toolInstances;
+  const brushBasedToolInstances = getBrushToolInstances(toolGroupId);
 
-  if (!Object.keys(toolInstances).length) {
-    return;
-  }
+  brushBasedToolInstances.forEach((tool: BrushTool) => {
+    tool.configuration.brushSize = brushSize;
 
-  const brushToolInstance = toolInstances[brushToolName];
-
-  if (!brushToolInstance) {
-    return;
-  }
-
-  brushToolInstance.configuration.brushSize = brushSize;
-
-  // Invalidate the brush being rendered so it can update.
-  brushToolInstance.invalidateBrushCursor();
+    // Invalidate the brush being rendered so it can update.
+    tool.invalidateBrushCursor();
+  });
 
   // Trigger an annotation render for any viewports on the toolgroup
   const viewportsInfo = toolGroup.getViewportsInfo();
@@ -67,16 +58,15 @@ export function getBrushSizeForToolGroup(toolGroupId: string): void {
     return;
   }
 
-  const brushToolInstance = toolInstances[brushToolName];
+  const brushBasedToolInstances = getBrushToolInstances(toolGroupId);
+
+  // one is enough as they share the same brush size
+  const brushToolInstance = brushBasedToolInstances[0];
 
   if (!brushToolInstance) {
     return;
   }
 
   // TODO -> Assumes the brush sizes are the same and set via these helpers.
-
-  // const toolInstanceNames = Object.keys(brushToolInstances);
-  // const firstToolInstance = brushToolInstances[toolInstanceNames[0]];
-
   return brushToolInstance.configuration.brushSize;
 }

--- a/packages/tools/src/utilities/segmentation/brushThresholdForToolGroup.ts
+++ b/packages/tools/src/utilities/segmentation/brushThresholdForToolGroup.ts
@@ -1,10 +1,8 @@
 import type { Types } from '@cornerstonejs/core';
 import { getToolGroup } from '../../store/ToolGroupManager';
-import BrushTool from '../../tools/segmentation/BrushTool';
 import triggerAnnotationRenderForViewportIds from '../triggerAnnotationRenderForViewportIds';
 import { getRenderingEngine } from '@cornerstonejs/core';
-
-const brushToolName = BrushTool.toolName;
+import getBrushToolInstances from './utilities';
 
 export function setBrushThresholdForToolGroup(
   toolGroupId: string,
@@ -16,21 +14,9 @@ export function setBrushThresholdForToolGroup(
     return;
   }
 
-  const toolInstances = toolGroup._toolInstances;
+  const brushBasedToolInstances = getBrushToolInstances(toolGroupId);
 
-  if (!Object.keys(toolInstances).length) {
-    return;
-  }
-
-  const brushToolInstances = toolInstances[brushToolName];
-
-  if (!Object.keys(brushToolInstances).length) {
-    return;
-  }
-
-  Object.keys(brushToolInstances).forEach((toolInstanceName) => {
-    const tool = brushToolInstances[toolInstanceName];
-
+  brushBasedToolInstances.forEach((tool) => {
     tool.configuration.strategySpecificConfiguration.THRESHOLD_INSIDE_CIRCLE.threshold =
       threshold;
   });
@@ -66,16 +52,14 @@ export function getBrushThresholdForToolGroup(toolGroupId: string) {
     return;
   }
 
-  const brushToolInstances = toolInstances[brushToolName];
+  const brushBasedToolInstances = getBrushToolInstances(toolGroupId);
+  const brushToolInstance = brushBasedToolInstances[0];
 
-  if (!Object.keys(brushToolInstances).length) {
+  if (!brushToolInstance) {
     return;
   }
 
-  // Note: -> Assumes the thresholds are the same and set via these helpers.
-  const toolInstanceNames = Object.keys(brushToolInstances);
-  const firstToolInstance = brushToolInstances[toolInstanceNames[0]];
-
-  return firstToolInstance.configuration.strategySpecificConfiguration
+  // TODO -> Assumes the
+  return brushToolInstance.configuration.strategySpecificConfiguration
     .THRESHOLD_INSIDE_CIRCLE.threshold;
 }

--- a/packages/tools/src/utilities/segmentation/brushThresholdForToolGroup.ts
+++ b/packages/tools/src/utilities/segmentation/brushThresholdForToolGroup.ts
@@ -1,0 +1,81 @@
+import type { Types } from '@cornerstonejs/core';
+import { getToolGroup } from '../../store/ToolGroupManager';
+import BrushTool from '../../tools/segmentation/BrushTool';
+import triggerAnnotationRenderForViewportIds from '../triggerAnnotationRenderForViewportIds';
+import { getRenderingEngine } from '@cornerstonejs/core';
+
+const brushToolName = BrushTool.toolName;
+
+export function setBrushThresholdForToolGroup(
+  toolGroupId: string,
+  threshold: Types.Point2
+) {
+  const toolGroup = getToolGroup(toolGroupId);
+
+  if (toolGroup === undefined) {
+    return;
+  }
+
+  const toolInstances = toolGroup._toolInstances;
+
+  if (!Object.keys(toolInstances).length) {
+    return;
+  }
+
+  const brushToolInstances = toolInstances[brushToolName];
+
+  if (!Object.keys(brushToolInstances).length) {
+    return;
+  }
+
+  Object.keys(brushToolInstances).forEach((toolInstanceName) => {
+    const tool = brushToolInstances[toolInstanceName];
+
+    tool.configuration.strategySpecificConfiguration.THRESHOLD_INSIDE_CIRCLE.threshold =
+      threshold;
+  });
+
+  // Trigger an annotation render for any viewports on the toolgroup
+  const viewportsInfo = toolGroup.getViewportsInfo();
+
+  if (!viewportsInfo.length) {
+    return;
+  }
+
+  const { renderingEngineId } = viewportsInfo[0];
+
+  // Use helper to get array of viewportIds, or we just end up doing this mapping
+  // ourselves here.
+  const viewportIds = toolGroup.getViewportIds();
+
+  const renderingEngine = getRenderingEngine(renderingEngineId);
+
+  triggerAnnotationRenderForViewportIds(renderingEngine, viewportIds);
+}
+
+export function getBrushThresholdForToolGroup(toolGroupId: string) {
+  const toolGroup = getToolGroup(toolGroupId);
+
+  if (toolGroup === undefined) {
+    return;
+  }
+
+  const toolInstances = toolGroup._toolInstances;
+
+  if (!Object.keys(toolInstances).length) {
+    return;
+  }
+
+  const brushToolInstances = toolInstances[brushToolName];
+
+  if (!Object.keys(brushToolInstances).length) {
+    return;
+  }
+
+  // Note: -> Assumes the thresholds are the same and set via these helpers.
+  const toolInstanceNames = Object.keys(brushToolInstances);
+  const firstToolInstance = brushToolInstances[toolInstanceNames[0]];
+
+  return firstToolInstance.configuration.strategySpecificConfiguration
+    .THRESHOLD_INSIDE_CIRCLE.threshold;
+}

--- a/packages/tools/src/utilities/segmentation/floodFill.ts
+++ b/packages/tools/src/utilities/segmentation/floodFill.ts
@@ -1,0 +1,192 @@
+import type {
+  FloodFillResult,
+  FloodFillGetter,
+  FloodFillOptions,
+} from '../../types';
+import { Types } from '@cornerstonejs/core';
+
+/**
+ * floodFill.js - Taken from MIT OSS lib - https://github.com/tuzz/n-dimensional-flood-fill
+ * Refactored to ES6.
+ *
+ * @param {function} getter The getter to the elements of your data structure,
+ *                          e.g. getter(x,y) for a 2D interprettation of your structure.
+ * @param {number[]} seed The seed for your fill. The dimensionality is infered
+ *                        by the number of dimensions of the seed.
+ * @param {function} [options.onFlood] An optional callback to execute when each pixel is flooded.
+ *                             e.g. onFlood(x,y).
+ * @param {function} [options.onBoundary] An optional callback to execute whenever a boundary is reached.
+ *                                a boundary could be another segmentIndex, or the edge of your
+ *                                data structure (i.e. when your getter returns undefined).
+ * @param {function} [options.equals] An optional equality method for your datastructure.
+ *                            Default is simply value1 = value2.
+ * @param {boolean} [options.diagonals] Whether you allow flooding through diagonals. Defaults to false.
+ *
+ * @returns {Object}
+ */
+export default function (
+  getter: FloodFillGetter,
+  seed: Types.Point2 | Types.Point3,
+  options: FloodFillOptions = {}
+): FloodFillResult {
+  const onFlood = options.onFlood;
+  const onBoundary = options.onBoundary;
+  const equals = options.equals || defaultEquals;
+  const diagonals = options.diagonals || false;
+  const startNode = get(seed);
+  const permutations = prunedPermutations();
+  const stack = [];
+  const flooded = [];
+  const visits = {};
+  const bounds = {};
+
+  stack.push({ currentArgs: seed });
+
+  while (stack.length > 0) {
+    flood(stack.pop());
+  }
+
+  return {
+    flooded,
+    boundaries: boundaries(),
+  };
+
+  function flood(job) {
+    const getArgs = job.currentArgs;
+    const prevArgs = job.previousArgs;
+
+    if (visited(getArgs)) {
+      return;
+    }
+    markAsVisited(getArgs);
+
+    if (member(getArgs)) {
+      markAsFlooded(getArgs);
+      pushAdjacent(getArgs);
+    } else {
+      markAsBoundary(prevArgs);
+    }
+  }
+
+  function visited(key) {
+    return visits[key] === true;
+  }
+
+  function markAsVisited(key) {
+    visits[key] = true;
+  }
+
+  function member(getArgs) {
+    const node = safely(get, [getArgs]);
+
+    return safely(equals, [node, startNode]);
+  }
+
+  function markAsFlooded(getArgs) {
+    flooded.push(getArgs);
+    if (onFlood) {
+      //@ts-ignore
+      onFlood(...getArgs);
+    }
+  }
+
+  function markAsBoundary(prevArgs) {
+    bounds[prevArgs] = prevArgs;
+    if (onBoundary) {
+      //@ts-ignore
+      onBoundary(...prevArgs);
+    }
+  }
+
+  function pushAdjacent(getArgs) {
+    for (let i = 0; i < permutations.length; i += 1) {
+      const perm = permutations[i];
+      const nextArgs = getArgs.slice(0);
+
+      for (let j = 0; j < getArgs.length; j += 1) {
+        nextArgs[j] += perm[j];
+      }
+
+      stack.push({
+        currentArgs: nextArgs,
+        previousArgs: getArgs,
+      });
+    }
+  }
+
+  function get(getArgs) {
+    //@ts-ignore
+    return getter(...getArgs);
+  }
+
+  function safely(f, args) {
+    try {
+      return f(...args);
+    } catch (error) {
+      return;
+    }
+  }
+
+  function prunedPermutations() {
+    const permutations = permute(seed.length);
+
+    return permutations.filter(function (perm) {
+      const count = countNonZeroes(perm);
+
+      return count !== 0 && (count === 1 || diagonals);
+    });
+  }
+
+  function permute(length) {
+    const perms = [];
+
+    const permutation = function (string) {
+      return string.split('').map(function (c) {
+        return parseInt(c, 10) - 1;
+      });
+    };
+
+    for (let i = 0; i < Math.pow(3, length); i += 1) {
+      const string = lpad(i.toString(3), '0', length);
+
+      perms.push(permutation(string));
+    }
+
+    return perms;
+  }
+
+  function boundaries() {
+    const array = [];
+
+    for (const key in bounds) {
+      if (bounds[key] !== undefined) {
+        array.unshift(bounds[key]);
+      }
+    }
+
+    return array;
+  }
+}
+
+function defaultEquals(a, b) {
+  return a === b;
+}
+
+function countNonZeroes(array) {
+  let count = 0;
+
+  for (let i = 0; i < array.length; i += 1) {
+    if (array[i] !== 0) {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+function lpad(string, character, length) {
+  const array = new Array(length + 1);
+  const pad = array.join(character);
+
+  return (pad + string).slice(-length);
+}

--- a/packages/tools/src/utilities/segmentation/index.ts
+++ b/packages/tools/src/utilities/segmentation/index.ts
@@ -5,6 +5,15 @@ import isValidRepresentationConfig from './isValidRepresentationConfig';
 import getDefaultRepresentationConfig from './getDefaultRepresentationConfig';
 import createLabelmapVolumeForViewport from './createLabelmapVolumeForViewport';
 import { triggerSegmentationRender } from './triggerSegmentationRender';
+import floodFill from './floodFill';
+import {
+  getBrushSizeForToolGroup,
+  setBrushSizeForToolGroup,
+} from './brushSizeForToolGroup';
+import {
+  getBrushThresholdForToolGroup,
+  setBrushThresholdForToolGroup,
+} from './brushThresholdForToolGroup';
 
 export {
   thresholdVolumeByRange,
@@ -14,4 +23,9 @@ export {
   createLabelmapVolumeForViewport,
   rectangleROIThresholdVolumeByRange,
   triggerSegmentationRender,
+  floodFill,
+  getBrushSizeForToolGroup,
+  setBrushSizeForToolGroup,
+  getBrushThresholdForToolGroup,
+  setBrushThresholdForToolGroup,
 };

--- a/packages/tools/src/utilities/segmentation/utilities.ts
+++ b/packages/tools/src/utilities/segmentation/utilities.ts
@@ -1,0 +1,23 @@
+import { getToolGroup } from '../../store/ToolGroupManager';
+import BrushTool from '../../tools/segmentation/BrushTool';
+
+export default function getBrushToolInstances(toolGroupId) {
+  const toolGroup = getToolGroup(toolGroupId);
+
+  if (toolGroup === undefined) {
+    return;
+  }
+
+  const toolInstances = toolGroup._toolInstances;
+
+  if (!Object.keys(toolInstances).length) {
+    return;
+  }
+
+  // For each tool that has BrushTool as base class, set the brush size.
+  const brushBasedToolInstances = Object.values(toolInstances).filter(
+    (toolInstance) => toolInstance instanceof BrushTool
+  ) as BrushTool[];
+
+  return brushBasedToolInstances;
+}

--- a/utils/ExampleRunner/template-config.js
+++ b/utils/ExampleRunner/template-config.js
@@ -84,7 +84,7 @@ module.exports = {
   devServer: {
     hot: true,
     open: false,
-    port: 3001,
+    port: 3000,
     historyApiFallback: true,
     headers: {
       "Cross-Origin-Embedder-Policy": "require-corp",

--- a/utils/ExampleRunner/template-config.js
+++ b/utils/ExampleRunner/template-config.js
@@ -30,14 +30,11 @@ var webpack = require('webpack');
 var path = require('path');
 module.exports = {
   mode: 'development',
-  devtool: 'eval-source-map',
+  devtool: 'source-map',
   plugins: [
     new ESLintPlugin(),
     new HtmlWebpackPlugin({
-      template: '${root.replace(
-        /\\/g,
-        '/'
-      )}/utils/ExampleRunner/template.html',
+      template: '${root.replace(/\\/g, '/')}/utils/ExampleRunner/template.html',
     }),
     new webpack.DefinePlugin({
       __BASE_PATH__: "''",
@@ -53,10 +50,10 @@ module.exports = {
     }),
     // new BundleAnalyzerPlugin()
   ],
-  entry: path.join('${exampleBasePath.replace(
+  entry: path.join('${exampleBasePath.replace(/\\/g, '/')}', '${relPath.replace(
     /\\/g,
     '/'
-  )}', '${relPath.replace(/\\/g, '/')}'),
+  )}'),
   output: {
     path: '${destPath.replace(/\\/g, '/')}',
     filename: '${name}.js',
@@ -87,7 +84,7 @@ module.exports = {
   devServer: {
     hot: true,
     open: false,
-    port: 3000,
+    port: 3001,
     historyApiFallback: true,
     headers: {
       "Cross-Origin-Embedder-Policy": "require-corp",

--- a/utils/ExampleRunner/template-multiexample-config.js
+++ b/utils/ExampleRunner/template-multiexample-config.js
@@ -113,7 +113,7 @@ module.exports = {
   devServer: {
     hot: true,
     open: false,
-    port: 3001,
+    port: 3000,
     historyApiFallback: true,
     headers: {
       "Cross-Origin-Embedder-Policy": "require-corp",

--- a/utils/ExampleRunner/template-multiexample-config.js
+++ b/utils/ExampleRunner/template-multiexample-config.js
@@ -113,7 +113,7 @@ module.exports = {
   devServer: {
     hot: true,
     open: false,
-    port: 3000,
+    port: 3001,
     historyApiFallback: true,
     headers: {
       "Cross-Origin-Embedder-Policy": "require-corp",


### PR DESCRIPTION
## Try
https://deploy-preview-327--cornerstone-3d-docs.netlify.app/live-examples/basicsegmentationtools

## Multiple Tool Instances
There are various scenarios that we want to use the same tool but with different strategy (segmentation brush can be threshold brush, eraser, simple brush, sphere brush etc.). 


```
public addToolInstance(
    toolName: string,
    parentClassName: string,
    configuration = {}
  ): void {
```

## New Strategies
- Erase Circle 
- Erase Sphere

## New Tool
- PaintFill Tool




PS: Kudos to @JamesAPetts for this awesome piece of work




