### PR TITLE
Add coplanar check in stackImageSync callback

### DIFF
--- a/packages/tools/src/synchronizers/callbacks/areViewportsCoplanar .ts
+++ b/packages/tools/src/synchronizers/callbacks/areViewportsCoplanar .ts
@@ -1,7 +1,7 @@
 import { vec3 } from 'gl-matrix';
 import { Types } from '@cornerstonejs/core';
 
-export default function coPlanarViewports(
+export default function areViewportsCoplanar(
   viewport1: Types.IStackViewport,
   viewport2: Types.IStackViewport
 ): boolean {

--- a/packages/tools/src/synchronizers/callbacks/coPlanarViewports.ts
+++ b/packages/tools/src/synchronizers/callbacks/coPlanarViewports.ts
@@ -1,0 +1,12 @@
+import { vec3 } from 'gl-matrix';
+import { Types } from '@cornerstonejs/core';
+
+export default function coPlanarViewports(
+  viewport1: Types.IStackViewport,
+  viewport2: Types.IStackViewport
+): boolean {
+  const { viewPlaneNormal: viewPlaneNormal1 } = viewport1.getCamera();
+  const { viewPlaneNormal: viewPlaneNormal2 } = viewport2.getCamera();
+  const dotProducts = vec3.dot(viewPlaneNormal1, viewPlaneNormal2);
+  return Math.abs(dotProducts) > 0.9;
+}

--- a/packages/tools/src/synchronizers/callbacks/stackImageSyncCallback.ts
+++ b/packages/tools/src/synchronizers/callbacks/stackImageSyncCallback.ts
@@ -7,7 +7,7 @@ import {
 } from '@cornerstonejs/core';
 import { Synchronizer } from '../../store';
 import { jumpToSlice } from '../../utilities';
-
+import coPlanarViewports from './coPlanarViewports';
 /**
  * Synchronizer callback to synchronize the source viewport image to the
  * target viewports closest image in its stack. There are two scenarios
@@ -69,21 +69,23 @@ export default async function stackImageSyncCallback(
   if (frameOfReferenceUID1 === frameOfReferenceUID2) {
     // if frames of references are the same we can use the absolute
     // imagePositionPatient to find the closest image in the target viewport's stack
-    const closestImageIdIndex = _getClosestImageIdIndex(
-      sourceImagePositionPatient,
-      targetImageIds
-    );
+    if (coPlanarViewports(sViewport, tViewport)) {
+      const closestImageIdIndex = _getClosestImageIdIndex(
+        sourceImagePositionPatient,
+        targetImageIds
+      );
 
-    if (
-      closestImageIdIndex.index !== -1 &&
-      tViewport.getCurrentImageIdIndex() !== closestImageIdIndex.index
-    ) {
-      // await tViewport.setImageIdIndex(closestImageIdIndex.index);
-      await jumpToSlice(tViewport.element, {
-        imageIndex: closestImageIdIndex.index,
-      });
+      if (
+        closestImageIdIndex.index !== -1 &&
+        tViewport.getCurrentImageIdIndex() !== closestImageIdIndex.index
+      ) {
+        // await tViewport.setImageIdIndex(closestImageIdIndex.index);
+        await jumpToSlice(tViewport.element, {
+          imageIndex: closestImageIdIndex.index,
+        });
 
-      return;
+        return;
+      }
     }
   } else {
     // if the frame of reference is different we need to use the registrationMetadataProvider

--- a/packages/tools/src/synchronizers/callbacks/stackImageSyncCallback.ts
+++ b/packages/tools/src/synchronizers/callbacks/stackImageSyncCallback.ts
@@ -7,7 +7,7 @@ import {
 } from '@cornerstonejs/core';
 import { Synchronizer } from '../../store';
 import { jumpToSlice } from '../../utilities';
-import coPlanarViewports from './coPlanarViewports';
+import areViewportsCoplanar from './areViewportsCoplanar ';
 /**
  * Synchronizer callback to synchronize the source viewport image to the
  * target viewports closest image in its stack. There are two scenarios
@@ -66,26 +66,28 @@ export default async function stackImageSyncCallback(
 
   const targetImageIds = tViewport.getImageIds();
 
+  if (!areViewportsCoplanar(sViewport, tViewport)) {
+    return;
+  }
+
   if (frameOfReferenceUID1 === frameOfReferenceUID2) {
     // if frames of references are the same we can use the absolute
     // imagePositionPatient to find the closest image in the target viewport's stack
-    if (coPlanarViewports(sViewport, tViewport)) {
-      const closestImageIdIndex = _getClosestImageIdIndex(
-        sourceImagePositionPatient,
-        targetImageIds
-      );
+    const closestImageIdIndex = _getClosestImageIdIndex(
+      sourceImagePositionPatient,
+      targetImageIds
+    );
 
-      if (
-        closestImageIdIndex.index !== -1 &&
-        tViewport.getCurrentImageIdIndex() !== closestImageIdIndex.index
-      ) {
-        // await tViewport.setImageIdIndex(closestImageIdIndex.index);
-        await jumpToSlice(tViewport.element, {
-          imageIndex: closestImageIdIndex.index,
-        });
+    if (
+      closestImageIdIndex.index !== -1 &&
+      tViewport.getCurrentImageIdIndex() !== closestImageIdIndex.index
+    ) {
+      // await tViewport.setImageIdIndex(closestImageIdIndex.index);
+      await jumpToSlice(tViewport.element, {
+        imageIndex: closestImageIdIndex.index,
+      });
 
-        return;
-      }
+      return;
     }
   } else {
     // if the frame of reference is different we need to use the registrationMetadataProvider


### PR DESCRIPTION
In order to protect the stackImageSyncCallback from image sync problems, I suggest add an extra test that checks if the two viewports being considered has the same orientation. 
I add an extra function coPlanarViewports that checks if the viewPlaneNormal from the two viewports are parallel, by checking if the dot product is greater than 0.9