### PR TITLE
wip Feat/norm16 textures

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -148,6 +148,14 @@ declare namespace CONSTANTS {
 export { CONSTANTS }
 
 // @public (undocumented)
+type Cornerstone3DConfig = {
+    rendering: {
+        preferSizeOverAccuracy: boolean;
+        useCPURendering: boolean;
+    };
+};
+
+// @public (undocumented)
 interface CPUFallbackColormap {
     // (undocumented)
     addColor: (rgba: Point4) => void;
@@ -451,6 +459,9 @@ interface CustomEvent_2<T = any> extends Event {
 }
 
 // @public (undocumented)
+const deepMerge: (target?: {}, source?: {}, optionsArgument?: any) => any;
+
+// @public (undocumented)
 type ElementDisabledEvent = CustomEvent_2<ElementDisabledEventDetail>;
 
 // @public (undocumented)
@@ -600,6 +611,9 @@ function getClosestImageId(imageVolume: IImageVolume, worldPos: Point3, viewPlan
 
 // @public (undocumented)
 function getClosestStackImageIndexForPoint(point: Point3, viewport: IStackViewport): number | null;
+
+// @public (undocumented)
+export function getConfiguration(): Cornerstone3DConfig;
 
 // @public (undocumented)
 export function getEnabledElement(element: HTMLDivElement | undefined): IEnabledElement | undefined;
@@ -1134,7 +1148,7 @@ type ImageVolumeModifiedEventDetail = {
 function indexWithinDimensions(index: Point3, dimensions: Point3): boolean;
 
 // @public (undocumented)
-export function init(defaultConfiguration?: {}): Promise<boolean>;
+export function init(configuration?: {}): Promise<boolean>;
 
 // @public (undocumented)
 enum InterpolationType {
@@ -1737,6 +1751,9 @@ type ScalingParameters = {
 };
 
 // @public (undocumented)
+export function setConfiguration(newConfig: Cornerstone3DConfig): void;
+
+// @public (undocumented)
 export class Settings {
     constructor(base?: Settings);
     // (undocumented)
@@ -1931,6 +1948,7 @@ export function triggerEvent(el: EventTarget, type: string, detail?: unknown): b
 
 declare namespace Types {
     export {
+        Cornerstone3DConfig,
         ICamera,
         IStackViewport,
         IVolumeViewport,
@@ -2037,7 +2055,8 @@ declare namespace utilities {
         spatialRegistrationMetadataProvider,
         getViewportImageCornersInWorld,
         hasNaNValues,
-        applyPreset
+        applyPreset,
+        deepMerge
     }
 }
 export { utilities }

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -151,6 +151,7 @@ export { CONSTANTS }
 type Cornerstone3DConfig = {
     rendering: {
         preferSizeOverAccuracy: boolean;
+        hasNorm16TextureSupport: boolean;
         useCPURendering: boolean;
     };
 };
@@ -439,7 +440,13 @@ function createAndCacheVolume(volumeId: string, options: VolumeLoaderOptions): P
 function createFloat32SharedArray(length: number): Float32Array;
 
 // @public (undocumented)
+function createInt16SharedArray(length: number): Int16Array;
+
+// @public (undocumented)
 function createLocalVolume(options: LocalVolumeOptions, volumeId: string, preventCache?: boolean): ImageVolume;
+
+// @public (undocumented)
+function createUint16SharedArray(length: number): Uint16Array;
 
 // @public (undocumented)
 function createUint8SharedArray(length: number): Uint8Array;
@@ -647,6 +654,12 @@ export function getRenderingEngines(): IRenderingEngine[] | undefined;
 
 // @public (undocumented)
 function getRuntimeId(context?: unknown, separator?: string, max?: number): string;
+
+// @public (undocumented)
+function getScalarDataType(scalingParameters: ScalingParameters, scalarData?: any): string;
+
+// @public (undocumented)
+function getScalingParameters(imageId: string): ScalingParameters;
 
 // @public (undocumented)
 export function getShouldUseCPURendering(): boolean;
@@ -897,7 +910,7 @@ interface IImageData {
         };
     };
     // (undocumented)
-    scalarData: Float32Array;
+    scalarData: Float32Array | Uint16Array | Uint8Array | Int16Array;
     // (undocumented)
     scaling?: Scaling;
     // (undocumented)
@@ -1115,7 +1128,7 @@ export class ImageVolume implements IImageVolume {
     // (undocumented)
     referencedVolumeId?: string;
     // (undocumented)
-    scalarData: Float32Array | Uint8Array;
+    scalarData: Float32Array | Uint8Array | Uint16Array | Int16Array;
     // (undocumented)
     scaling?: {
         PET?: {
@@ -1412,7 +1425,7 @@ interface IVolume {
     // (undocumented)
     referencedVolumeId?: string;
     // (undocumented)
-    scalarData: Float32Array | Uint8Array;
+    scalarData: Float32Array | Uint8Array | Uint16Array | Int16Array;
     // (undocumented)
     scaling?: {
         PET?: {
@@ -1751,7 +1764,7 @@ type ScalingParameters = {
 };
 
 // @public (undocumented)
-export function setConfiguration(newConfig: Cornerstone3DConfig): void;
+export function setPreferSizeOverAccuracy(status: boolean): void;
 
 // @public (undocumented)
 export class Settings {
@@ -2032,6 +2045,8 @@ declare namespace utilities {
         isOpposite,
         createFloat32SharedArray,
         createUint8SharedArray,
+        createUint16SharedArray,
+        createInt16SharedArray,
         windowLevel,
         getClosestImageId,
         getSpacingInNormalDirection,
@@ -2056,7 +2071,9 @@ declare namespace utilities {
         getViewportImageCornersInWorld,
         hasNaNValues,
         applyPreset,
-        deepMerge
+        deepMerge,
+        getScalingParameters,
+        getScalarDataType
     }
 }
 export { utilities }

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -53,6 +53,26 @@ type CameraModifiedEventDetail = {
 };
 
 // @public (undocumented)
+type Cornerstone3DConfig = {
+    rendering: {
+        // vtk.js supports 8bit integer textures and 32bit float textures.
+        // However, if the client has norm16 textures (it can be seen by visiting
+        // the webGl report at https://webglreport.com/?v=2), vtk will be default
+        // to use it to improve memory usage. However, if the client don't have
+        // it still another level of optimization can happen by setting the
+        // preferSizeOverAccuracy since it will reduce the size of the texture to half
+        // float at the cost of accuracy in rendering. This is a tradeoff that the
+        // client can decide.
+        //
+        // Read more in the following Pull Request:
+        // 1. HalfFloat: https://github.com/Kitware/vtk-js/pull/2046
+        // 2. Norm16: https://github.com/Kitware/vtk-js/pull/2058
+        preferSizeOverAccuracy: boolean;
+        useCPURendering: boolean;
+    };
+};
+
+// @public (undocumented)
 export function cornerstoneStreamingImageVolumeLoader(volumeId: string, options: {
     imageIds: string[];
 }): IVolumeLoader;

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -68,6 +68,13 @@ type Cornerstone3DConfig = {
         // 1. HalfFloat: https://github.com/Kitware/vtk-js/pull/2046
         // 2. Norm16: https://github.com/Kitware/vtk-js/pull/2058
         preferSizeOverAccuracy: boolean;
+        // Whether the EXT_texture_norm16 extension is supported by the browser.
+        // WebGL 2 report (link: https://webglreport.com/?v=2) can be used to check
+        // if the browser supports this extension.
+        // In case the browser supports this extension, instead of using 32bit float
+        // textures, 16bit float textures will be used to reduce the memory usage where
+        // possible.
+        hasNorm16TextureSupport: boolean;
         useCPURendering: boolean;
     };
 };
@@ -637,7 +644,7 @@ interface IImageData {
             suvbw?: number;
         };
     };
-    scalarData: Float32Array;
+    scalarData: Float32Array | Uint16Array | Uint8Array | Int16Array;
     scaling?: Scaling;
     spacing: Point3;
 }
@@ -961,7 +968,7 @@ interface IVolume {
     metadata: Metadata;
     origin: Point3;
     referencedVolumeId?: string;
-    scalarData: Float32Array | Uint8Array;
+    scalarData: Float32Array | Uint8Array | Uint16Array | Int16Array;
     scaling?: {
         PET?: {
             // @TODO: Do these values exist?
@@ -1236,7 +1243,7 @@ export class StreamingImageVolume extends ImageVolume {
                 arrayBuffer: ArrayBufferLike;
                 offset: number;
                 length: number;
-                type: any;
+                type: string;
             };
             preScale: {
                 enabled: boolean;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -710,6 +710,26 @@ declare namespace CONSTANTS {
 export { CONSTANTS }
 
 // @public (undocumented)
+type Cornerstone3DConfig = {
+    rendering: {
+        // vtk.js supports 8bit integer textures and 32bit float textures.
+        // However, if the client has norm16 textures (it can be seen by visiting
+        // the webGl report at https://webglreport.com/?v=2), vtk will be default
+        // to use it to improve memory usage. However, if the client don't have
+        // it still another level of optimization can happen by setting the
+        // preferSizeOverAccuracy since it will reduce the size of the texture to half
+        // float at the cost of accuracy in rendering. This is a tradeoff that the
+        // client can decide.
+        //
+        // Read more in the following Pull Request:
+        // 1. HalfFloat: https://github.com/Kitware/vtk-js/pull/2046
+        // 2. Norm16: https://github.com/Kitware/vtk-js/pull/2058
+        preferSizeOverAccuracy: boolean;
+        useCPURendering: boolean;
+    };
+};
+
+// @public (undocumented)
 const CORNERSTONE_COLOR_LUT: number[][];
 
 // @public (undocumented)
@@ -1199,9 +1219,6 @@ function debounce(func: Function, wait?: number, options?: {
     maxWait?: number;
     trailing?: boolean;
 }): Function;
-
-// @public (undocumented)
-function deepmerge(target?: {}, source?: {}, optionsArgument?: any): any;
 
 // @public (undocumented)
 const _default: {
@@ -4614,7 +4631,6 @@ declare namespace utilities {
         viewportFilters,
         drawing_2 as drawing,
         debounce,
-        deepmerge as deepMerge,
         throttle,
         orientation_2 as orientation,
         isObject,

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -725,6 +725,13 @@ type Cornerstone3DConfig = {
         // 1. HalfFloat: https://github.com/Kitware/vtk-js/pull/2046
         // 2. Norm16: https://github.com/Kitware/vtk-js/pull/2058
         preferSizeOverAccuracy: boolean;
+        // Whether the EXT_texture_norm16 extension is supported by the browser.
+        // WebGL 2 report (link: https://webglreport.com/?v=2) can be used to check
+        // if the browser supports this extension.
+        // In case the browser supports this extension, instead of using 32bit float
+        // textures, 16bit float textures will be used to reduce the memory usage where
+        // possible.
+        hasNorm16TextureSupport: boolean;
         useCPURendering: boolean;
     };
 };
@@ -2093,7 +2100,7 @@ interface IImageData {
             suvbw?: number;
         };
     };
-    scalarData: Float32Array;
+    scalarData: Float32Array | Uint16Array | Uint8Array | Int16Array;
     scaling?: Scaling;
     spacing: Point3;
 }
@@ -2552,7 +2559,7 @@ interface IVolume {
     metadata: Metadata;
     origin: Point3;
     referencedVolumeId?: string;
-    scalarData: Float32Array | Uint8Array;
+    scalarData: Float32Array | Uint8Array | Uint16Array | Int16Array;
     scaling?: {
         PET?: {
             // @TODO: Do these values exist?

--- a/packages/core/examples/volumeAPI/index.ts
+++ b/packages/core/examples/volumeAPI/index.ts
@@ -5,7 +5,9 @@ import {
   volumeLoader,
   getRenderingEngine,
   utilities,
-  CONSTANTS,
+  hasNorm16TextureSupport,
+  hasActiveWebGLContext,
+  getConfiguration,
 } from '@cornerstonejs/core';
 import {
   initDemo,
@@ -45,7 +47,31 @@ element.id = 'cornerstone-element';
 element.style.width = '500px';
 element.style.height = '500px';
 
+const element1 = document.createElement('p');
+const element2 = document.createElement('p');
+const element3 = document.createElement('p');
+const element4 = document.createElement('p');
+const element5 = document.createElement('p');
+const element6 = document.createElement('p');
+const element7 = document.createElement('p');
+
+// update the element div text to have hasNorm16TextureSupport
+element2.innerText = `hasNorm16TextureSupport: ${hasNorm16TextureSupport()}`;
+element2.style.color = 'blue';
+
+element3.innerText = `isWebGL2Supported: ${hasActiveWebGLContext()}`;
+element3.style.color = 'blue';
+
+content.appendChild(element1);
+content.appendChild(element2);
+content.appendChild(element3);
+content.appendChild(element5);
+content.appendChild(element4);
+content.appendChild(element6);
+content.appendChild(element7);
+
 content.appendChild(element);
+
 // ============================= //
 
 // TODO -> Maybe some of these implementations should be pushed down to some API
@@ -285,6 +311,21 @@ async function run() {
     wadoRsRoot: 'https://d3t6nz73ql33tx.cloudfront.net/dicomweb',
     type: 'VOLUME',
   });
+
+  // @ts-ignore
+  const gpuConfig = getConfiguration().detectGPU;
+  const useCPURendering = getConfiguration().rendering.useCPURendering;
+  element4.innerText = `GPU Tier: ${JSON.stringify(gpuConfig)}`;
+  element4.style.color = 'blue';
+
+  element5.innerText = `Use CPU Rendering: ${useCPURendering}`;
+  element5.style.color = 'blue';
+
+  element6.innerText = `platform: ${navigator.platform}`;
+  element6.style.color = 'blue';
+
+  element7.innerText = `appVersion: ${navigator.appVersion}`;
+  element7.style.color = 'blue';
 
   // Instantiate a rendering engine
   const renderingEngine = new RenderingEngine(renderingEngineId);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "webpack:watch": "webpack --mode development --progress --watch  --config ./.webpack/webpack.dev.js"
   },
   "peerDependencies": {
-    "@kitware/vtk.js": "25.9.0",
+    "@kitware/vtk.js": "25.15.1",
     "gl-matrix": "^3.4.3"
   },
   "dependencies": {
@@ -35,7 +35,7 @@
     "lodash.clonedeep": "4.5.0"
   },
   "devDependencies": {
-    "@kitware/vtk.js": "25.9.0",
+    "@kitware/vtk.js": "25.15.1",
     "detect-gpu": "^4.0.45",
     "gl-matrix": "^3.4.3",
     "resemblejs": "^4.1.0"

--- a/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
+++ b/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
@@ -1,5 +1,5 @@
 import { vtkSharedVolumeMapper } from '../vtkClasses';
-
+import { getConfiguration } from '../../init';
 /**
  * Given an imageData and a vtkOpenGLTexture, it creates a "shared" vtk volume mapper
  * from which various volume actors can be created.
@@ -16,6 +16,10 @@ export default function createVolumeMapper(
 ): any {
   const volumeMapper = vtkSharedVolumeMapper.newInstance();
 
+  if (getConfiguration().rendering.preferSizeOverAccuracy) {
+    volumeMapper.setPreferSizeOverAccuracy(true);
+  }
+
   volumeMapper.setInputData(imageData);
 
   const spacing = imageData.getSpacing();
@@ -24,10 +28,9 @@ export default function createVolumeMapper(
   const sampleDistance = (spacing[0] + spacing[1] + spacing[2]) / 6;
 
   // This is to allow for good pixel level image quality.
+  // Todo: why we are setting this to 4000? Is this a good number? it should be configurable
   volumeMapper.setMaximumSamplesPerRay(4000);
-
   volumeMapper.setSampleDistance(sampleDistance);
-
   volumeMapper.setScalarTexture(vtkOpenGLTexture);
 
   return volumeMapper;

--- a/packages/core/src/RenderingEngine/helpers/setDefaultVolumeVOI.ts
+++ b/packages/core/src/RenderingEngine/helpers/setDefaultVolumeVOI.ts
@@ -161,12 +161,12 @@ async function getVOIFromMinMax(imageVolume: IImageVolume): Promise<VOIRange> {
   const byteOffset = imageIdIndex * bytesPerImage;
 
   const options = {
-    targetBuffer: {
-      arrayBuffer: scalarData.buffer,
-      offset: byteOffset,
-      length: voxelsPerImage,
-      type,
-    },
+    // targetBuffer: {
+    //   arrayBuffer: scalarData.buffer,
+    //   offset: byteOffset,
+    //   length: voxelsPerImage,
+    //   type,
+    // },
     priority: PRIORITY,
     requestType: REQUEST_TYPE,
     preScale: {

--- a/packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLTexture.js
+++ b/packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLTexture.js
@@ -133,6 +133,7 @@ function vtkStreamingOpenGLTexture(publicAPI, model) {
 
     // Cap to actual frame height:
     blockHeight = Math.min(blockHeight, model.height);
+    blockHeight = 1;
 
     const multiRowBlockLength = rowLength * blockHeight;
     const multiRowBlockLengthInBytes = multiRowBlockLength * bytesPerVoxel;

--- a/packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLTexture.js
+++ b/packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLTexture.js
@@ -21,7 +21,8 @@ function vtkStreamingOpenGLTexture(publicAPI, model) {
     depth,
     numComps,
     dataType,
-    data
+    data,
+    preferSizeOverAccuracy
   ) => {
     model.inputDataType = dataType;
     model.inputNumComps = numComps;
@@ -32,7 +33,8 @@ function vtkStreamingOpenGLTexture(publicAPI, model) {
       depth,
       numComps,
       dataType,
-      data
+      data,
+      preferSizeOverAccuracy
     );
   };
 
@@ -48,7 +50,6 @@ function vtkStreamingOpenGLTexture(publicAPI, model) {
     if (!updatedFrames.length) {
       return;
     }
-
     model._openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
@@ -62,6 +63,9 @@ function vtkStreamingOpenGLTexture(publicAPI, model) {
     } else if (data instanceof Int16Array) {
       bytesPerVoxel = 2;
       TypedArrayConstructor = Int16Array;
+    } else if (data instanceof Uint16Array) {
+      bytesPerVoxel = 2;
+      TypedArrayConstructor = Uint16Array;
     } else if (data instanceof Float32Array) {
       bytesPerVoxel = 4;
       TypedArrayConstructor = Float32Array;

--- a/packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLVolumeMapper.js
+++ b/packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLVolumeMapper.js
@@ -185,6 +185,10 @@ function vtkStreamingOpenGLVolumeMapper(publicAPI, model) {
       }
 
       if (shouldReset) {
+        model.scalarTexture.setOglNorm16Ext(
+          model.context.getExtension('EXT_texture_norm16')
+        );
+
         model.scalarTexture.releaseGraphicsResources(model._openGLRenderWindow);
         model.scalarTexture.resetFormatAndType();
 

--- a/packages/core/src/cache/classes/ImageVolume.ts
+++ b/packages/core/src/cache/classes/ImageVolume.ts
@@ -16,7 +16,7 @@ export class ImageVolume implements IImageVolume {
   /** volume origin, Note this is an opinionated origin for the volume */
   origin: Point3;
   /** volume scalar data  */
-  scalarData: Float32Array | Uint8Array;
+  scalarData: Float32Array | Uint8Array | Uint16Array | Int16Array;
   /** Whether preScaling has been performed on the volume */
   isPrescaled = false;
   /** volume scaling parameters if it contains scaled data */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,8 @@ import {
   isCornerstoneInitialized,
   setUseCPURendering,
   resetUseCPURendering,
+  setConfiguration,
+  getConfiguration,
 } from './init';
 
 // Classes
@@ -55,6 +57,9 @@ export type { Types };
 
 export {
   init,
+  getConfiguration,
+  setConfiguration,
+  //
   isCornerstoneInitialized,
   // enums
   Enums,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,8 @@ import {
   resetUseCPURendering,
   setPreferSizeOverAccuracy,
   getConfiguration,
+  hasNorm16TextureSupport,
+  hasActiveWebGLContext,
 } from './init';
 
 // Classes
@@ -58,6 +60,8 @@ export type { Types };
 export {
   // init
   init,
+  hasNorm16TextureSupport,
+  hasActiveWebGLContext,
   isCornerstoneInitialized,
   // configs
   getConfiguration,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,7 @@ import {
   isCornerstoneInitialized,
   setUseCPURendering,
   resetUseCPURendering,
-  setConfiguration,
+  setPreferSizeOverAccuracy,
   getConfiguration,
 } from './init';
 
@@ -56,11 +56,15 @@ import {
 export type { Types };
 
 export {
+  // init
   init,
-  getConfiguration,
-  setConfiguration,
-  //
   isCornerstoneInitialized,
+  // configs
+  getConfiguration,
+  setPreferSizeOverAccuracy,
+  getShouldUseCPURendering,
+  setUseCPURendering,
+  resetUseCPURendering,
   // enums
   Enums,
   CONSTANTS,
@@ -103,8 +107,4 @@ export {
   imageLoadPoolManager as requestPoolManager,
   imageRetrievalPoolManager,
   imageLoadPoolManager,
-  // CPU Rendering
-  getShouldUseCPURendering,
-  setUseCPURendering,
-  resetUseCPURendering,
 };

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -43,11 +43,14 @@ function _hasActiveWebGLContext() {
   const gl = _getGLContext();
 
   // Report the result.
-  if (
-    (gl && gl instanceof WebGLRenderingContext) ||
-    gl instanceof WebGL2RenderingContext
-  ) {
-    return true;
+  if (gl && (gl as WebGL2RenderingContext).getExtension) {
+    const ext = (gl as WebGL2RenderingContext).getExtension(
+      'EXT_texture_norm16'
+    );
+
+    if (ext) {
+      return true;
+    }
   }
 
   return false;
@@ -57,7 +60,9 @@ function _hasNorm16TextureSupport() {
   const gl = _getGLContext();
 
   if (gl) {
-    const ext = gl.getExtension('EXT_texture_norm16');
+    const ext = (gl as WebGL2RenderingContext).getExtension(
+      'EXT_texture_norm16'
+    );
 
     if (ext) {
       return true;

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -4,7 +4,8 @@ import { Cornerstone3DConfig } from './types';
 
 let csRenderInitialized = false;
 
-const defaultConfig: Cornerstone3DConfig = {
+const defaultConfig = {
+  detectGPU: {},
   rendering: {
     preferSizeOverAccuracy: true,
     useCPURendering: false,
@@ -14,7 +15,8 @@ const defaultConfig: Cornerstone3DConfig = {
   // ...
 };
 
-let config: Cornerstone3DConfig = {
+let config = {
+  detectGPU: {},
   rendering: {
     preferSizeOverAccuracy: true,
     useCPURendering: false,
@@ -96,6 +98,7 @@ async function init(configuration = {}): Promise<boolean> {
     config.rendering.useCPURendering = true;
   } else {
     const gpuTier = await getGPUTier();
+    config.detectGPU = gpuTier;
     console.log(
       'CornerstoneRender: Using detect-gpu to get the GPU benchmark:',
       gpuTier
@@ -164,7 +167,8 @@ function isCornerstoneInitialized(): boolean {
  */
 function getConfiguration(): Cornerstone3DConfig {
   // return a copy
-  return JSON.parse(JSON.stringify(config));
+  // return JSON.parse(JSON.stringify(config));
+  return config;
 }
 
 /**
@@ -189,4 +193,5 @@ export {
   resetUseCPURendering,
   setPreferSizeOverAccuracy,
   hasNorm16TextureSupport,
+  _hasActiveWebGLContext as hasActiveWebGLContext,
 };

--- a/packages/core/src/types/Cornerstone3DConfig.ts
+++ b/packages/core/src/types/Cornerstone3DConfig.ts
@@ -1,0 +1,20 @@
+type Cornerstone3DConfig = {
+  rendering: {
+    // vtk.js supports 8bit integer textures and 32bit float textures.
+    // However, if the client has norm16 textures (it can be seen by visiting
+    // the webGl report at https://webglreport.com/?v=2), vtk will be default
+    // to use it to improve memory usage. However, if the client don't have
+    // it still another level of optimization can happen by setting the
+    // preferSizeOverAccuracy since it will reduce the size of the texture to half
+    // float at the cost of accuracy in rendering. This is a tradeoff that the
+    // client can decide.
+    //
+    // Read more in the following Pull Request:
+    // 1. HalfFloat: https://github.com/Kitware/vtk-js/pull/2046
+    // 2. Norm16: https://github.com/Kitware/vtk-js/pull/2058
+    preferSizeOverAccuracy: boolean;
+    useCPURendering: boolean;
+  };
+};
+
+export default Cornerstone3DConfig;

--- a/packages/core/src/types/Cornerstone3DConfig.ts
+++ b/packages/core/src/types/Cornerstone3DConfig.ts
@@ -13,6 +13,13 @@ type Cornerstone3DConfig = {
     // 1. HalfFloat: https://github.com/Kitware/vtk-js/pull/2046
     // 2. Norm16: https://github.com/Kitware/vtk-js/pull/2058
     preferSizeOverAccuracy: boolean;
+    // Whether the EXT_texture_norm16 extension is supported by the browser.
+    // WebGL 2 report (link: https://webglreport.com/?v=2) can be used to check
+    // if the browser supports this extension.
+    // In case the browser supports this extension, instead of using 32bit float
+    // textures, 16bit float textures will be used to reduce the memory usage where
+    // possible.
+    hasNorm16TextureSupport: boolean;
     useCPURendering: boolean;
   };
 };

--- a/packages/core/src/types/IImageData.ts
+++ b/packages/core/src/types/IImageData.ts
@@ -15,7 +15,7 @@ interface IImageData {
   /** image origin */
   origin: Point3;
   /** image scalarData which stores the array of pixelData */
-  scalarData: Float32Array;
+  scalarData: Float32Array | Uint16Array | Uint8Array | Int16Array;
   /** vtkImageData object */
   imageData: vtkImageData;
   /** image metadata - currently only modality */

--- a/packages/core/src/types/IVolume.ts
+++ b/packages/core/src/types/IVolume.ts
@@ -20,7 +20,7 @@ interface IVolume {
   /** volume direction */
   direction: Mat3;
   /** volume scalarData */
-  scalarData: Float32Array | Uint8Array;
+  scalarData: Float32Array | Uint8Array | Uint16Array | Int16Array;
   /** volume size in bytes */
   sizeInBytes?: number;
   /** volume image data as vtkImageData */

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,5 +1,5 @@
 // @see: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#-type-only-imports-and-export
-
+import type Cornerstone3DConfig from './Cornerstone3DConfig';
 import type ICamera from './ICamera';
 import type IEnabledElement from './IEnabledElement';
 import type ICache from './ICache';
@@ -61,6 +61,9 @@ import type ActorSliceRange from './ActorSliceRange';
 import type ImageSliceData from './ImageSliceData';
 
 export type {
+  // config
+  Cornerstone3DConfig,
+  //
   ICamera,
   IStackViewport,
   IVolumeViewport,

--- a/packages/core/src/utilities/createInt16SharedArray.ts
+++ b/packages/core/src/utilities/createInt16SharedArray.ts
@@ -1,6 +1,6 @@
 import global from '../global';
 /**
- * A helper function that creates a new Float32Array that utilized a shared
+ * A helper function that creates a new Int16 that utilized a shared
  * array buffer. This allows the array to be updated  simultaneously in
  * workers or the main thread. Depending on the system (the CPU, the OS, the Browser)
  * it can take a while until the change is propagated to all contexts.
@@ -16,14 +16,14 @@ import global from '../global';
  * Creating an array for a Volume with known dimensions:
  * ```
  * const dimensions = [512, 512, 25];
- * const scalarData = createUint8SharedArray(dimensions[0] * dimensions[1] * dimensions[2]);
+ * const scalarData = createInt16SharedArray(dimensions[0] * dimensions[1] * dimensions[2]);
  * ```
  *
  * @param length - frame size * number of frames
- * @returns a Uint8Array with an underlying SharedArrayBuffer
+ * @returns a Int8Array with an underlying SharedArrayBuffer
  * @public
  */
-function createUint8SharedArray(length: number): Uint8Array {
+function createInt16SharedArray(length: number): Int16Array {
   if (!window.crossOriginIsolated) {
     throw new Error(
       'Your page is NOT cross-origin isolated, see https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated'
@@ -37,7 +37,7 @@ function createUint8SharedArray(length: number): Uint8Array {
 
   const sharedArrayBuffer = new SharedArrayBuffer(length * 2);
 
-  return new Uint8Array(sharedArrayBuffer);
+  return new Int16Array(sharedArrayBuffer);
 }
 
-export default createUint8SharedArray;
+export default createInt16SharedArray;

--- a/packages/core/src/utilities/createUInt16SharedArray.ts
+++ b/packages/core/src/utilities/createUInt16SharedArray.ts
@@ -35,7 +35,7 @@ function createUint16SharedArray(length: number): Uint16Array {
     );
   }
 
-  const sharedArrayBuffer = new SharedArrayBuffer(length);
+  const sharedArrayBuffer = new SharedArrayBuffer(length * 2);
 
   return new Uint16Array(sharedArrayBuffer);
 }

--- a/packages/core/src/utilities/createUInt16SharedArray.ts
+++ b/packages/core/src/utilities/createUInt16SharedArray.ts
@@ -1,6 +1,6 @@
 import global from '../global';
 /**
- * A helper function that creates a new Float32Array that utilized a shared
+ * A helper function that creates a new Uint16 that utilized a shared
  * array buffer. This allows the array to be updated  simultaneously in
  * workers or the main thread. Depending on the system (the CPU, the OS, the Browser)
  * it can take a while until the change is propagated to all contexts.
@@ -16,14 +16,14 @@ import global from '../global';
  * Creating an array for a Volume with known dimensions:
  * ```
  * const dimensions = [512, 512, 25];
- * const scalarData = createUint8SharedArray(dimensions[0] * dimensions[1] * dimensions[2]);
+ * const scalarData = createUint16SharedArray(dimensions[0] * dimensions[1] * dimensions[2]);
  * ```
  *
  * @param length - frame size * number of frames
  * @returns a Uint8Array with an underlying SharedArrayBuffer
  * @public
  */
-function createUint8SharedArray(length: number): Uint8Array {
+function createUint16SharedArray(length: number): Uint16Array {
   if (!window.crossOriginIsolated) {
     throw new Error(
       'Your page is NOT cross-origin isolated, see https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated'
@@ -35,9 +35,9 @@ function createUint8SharedArray(length: number): Uint8Array {
     );
   }
 
-  const sharedArrayBuffer = new SharedArrayBuffer(length * 2);
+  const sharedArrayBuffer = new SharedArrayBuffer(length);
 
-  return new Uint8Array(sharedArrayBuffer);
+  return new Uint16Array(sharedArrayBuffer);
 }
 
-export default createUint8SharedArray;
+export default createUint16SharedArray;

--- a/packages/core/src/utilities/createUint8SharedArray.ts
+++ b/packages/core/src/utilities/createUint8SharedArray.ts
@@ -35,7 +35,7 @@ function createUint8SharedArray(length: number): Uint8Array {
     );
   }
 
-  const sharedArrayBuffer = new SharedArrayBuffer(length * 2);
+  const sharedArrayBuffer = new SharedArrayBuffer(length);
 
   return new Uint8Array(sharedArrayBuffer);
 }

--- a/packages/core/src/utilities/deepMerge.ts
+++ b/packages/core/src/utilities/deepMerge.ts
@@ -18,7 +18,7 @@ const cloneIfNecessary = (value, optionsArgument) => {
   const clone = optionsArgument && optionsArgument.clone === true;
 
   return clone && isMergeableObject(value)
-    ? deepmerge(emptyTarget(value), value, optionsArgument)
+    ? deepMerge(emptyTarget(value), value, optionsArgument)
     : value;
 };
 
@@ -29,7 +29,7 @@ const defaultArrayMerge = (target, source, optionsArgument) => {
     if (typeof destination[i] === 'undefined') {
       destination[i] = cloneIfNecessary(e, optionsArgument);
     } else if (isMergeableObject(e)) {
-      destination[i] = deepmerge(target[i], e, optionsArgument);
+      destination[i] = deepMerge(target[i], e, optionsArgument);
     } else if (target.indexOf(e) === -1) {
       destination.push(cloneIfNecessary(e, optionsArgument));
     }
@@ -50,7 +50,7 @@ const mergeObject = (target, source, optionsArgument) => {
     if (!isMergeableObject(source[key]) || !target[key]) {
       destination[key] = cloneIfNecessary(source[key], optionsArgument);
     } else {
-      destination[key] = deepmerge(target[key], source[key], optionsArgument);
+      destination[key] = deepMerge(target[key], source[key], optionsArgument);
     }
   });
 
@@ -59,12 +59,12 @@ const mergeObject = (target, source, optionsArgument) => {
 
 /**
  * Merge two objects, recursively merging any objects that are arrays
- * @param [target] - The target object.
- * @param [source] - The source object to merge into the target object.
- * @param [optionsArgument] - The options object.
+ * @param target - The target object.
+ * @param source - The source object to merge into the target object.
+ * @param optionsArgument - The options object.
  * @returns The merged object.
  */
-const deepmerge = (target = {}, source = {}, optionsArgument = undefined) => {
+const deepMerge = (target = {}, source = {}, optionsArgument = undefined) => {
   const array = Array.isArray(source);
   const options = optionsArgument || { arrayMerge: defaultArrayMerge };
   const arrayMerge = options.arrayMerge || defaultArrayMerge;
@@ -78,4 +78,4 @@ const deepmerge = (target = {}, source = {}, optionsArgument = undefined) => {
   return mergeObject(target, source, optionsArgument);
 };
 
-export default deepmerge;
+export default deepMerge;

--- a/packages/core/src/utilities/getScalarDataType.ts
+++ b/packages/core/src/utilities/getScalarDataType.ts
@@ -1,0 +1,31 @@
+import { ScalingParameters } from '../types';
+
+/**
+ * If the scalar data is a Uint8Array, return 'Uint8Array'. If the scalar data is a
+ * Float32Array, return 'Float32Array'. If the scalar data is a Int16Array, return
+ * 'Int16Array'. If the scalar data is a Uint16Array, return 'Uint16Array'. If the
+ * scalar data is none of the above, throw an error.
+ * @param {ScalingParameters} scalingParameters - {
+ * @param {any} [scalarData] - The data to be converted.
+ * @returns The data type of the scalar data.
+ */
+export default function getScalarDataType(
+  scalingParameters: ScalingParameters,
+  scalarData?: any
+): string {
+  let type;
+
+  if (scalarData && scalarData instanceof Uint8Array) {
+    type = 'Uint8Array';
+  } else if (scalarData instanceof Float32Array) {
+    type = 'Float32Array';
+  } else if (scalarData instanceof Int16Array) {
+    type = 'Int16Array';
+  } else if (scalarData instanceof Uint16Array) {
+    type = 'Uint16Array';
+  } else {
+    throw new Error('Unsupported array type');
+  }
+
+  return type;
+}

--- a/packages/core/src/utilities/getScalingParameters.ts
+++ b/packages/core/src/utilities/getScalingParameters.ts
@@ -1,0 +1,35 @@
+import { get as metaDataGet } from '../metaData';
+import { ScalingParameters } from '../types';
+
+/**
+ * It returns the scaling parameters for the image with the given imageId. This can be
+ * used to get passed (as an option) to the imageLoader in order to apply scaling to the image inside
+ * the imageLoader.
+ * @param imageId - The imageId of the image
+ * @returns ScalingParameters
+ */
+export default function getScalingParameters(
+  imageId: string
+): ScalingParameters {
+  const modalityLutModule = metaDataGet('modalityLutModule', imageId) || {};
+  const generalSeriesModule = metaDataGet('generalSeriesModule', imageId) || {};
+
+  const { modality } = generalSeriesModule;
+
+  const scalingParameters = {
+    rescaleSlope: modalityLutModule.rescaleSlope,
+    rescaleIntercept: modalityLutModule.rescaleIntercept,
+    modality,
+  };
+
+  const suvFactor = metaDataGet('scalingModule', imageId) || {};
+
+  return {
+    ...scalingParameters,
+    ...(modality === 'PT' && {
+      suvbw: suvFactor.suvbw,
+      suvbsa: suvFactor.suvbsa,
+      suvlbm: suvFactor.suvlbm,
+    }),
+  };
+}

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -10,6 +10,8 @@ import isEqual from './isEqual';
 import isOpposite from './isOpposite';
 import createUint8SharedArray from './createUint8SharedArray';
 import createFloat32SharedArray from './createFloat32SharedArray';
+import createUint16SharedArray from './createUInt16SharedArray';
+import createInt16SharedArray from './createInt16SharedArray';
 import getClosestImageId from './getClosestImageId';
 import getSpacingInNormalDirection from './getSpacingInNormalDirection';
 import getTargetVolumeAndSpacingInNormalDir from './getTargetVolumeAndSpacingInNormalDir';
@@ -34,6 +36,8 @@ import getViewportImageCornersInWorld from './getViewportImageCornersInWorld';
 import hasNaNValues from './hasNaNValues';
 import applyPreset from './applyPreset';
 import deepMerge from './deepMerge';
+import getScalingParameters from './getScalingParameters';
+import getScalarDataType from './getScalarDataType';
 
 // name spaces
 import * as planar from './planar';
@@ -53,6 +57,8 @@ export {
   isOpposite,
   createFloat32SharedArray,
   createUint8SharedArray,
+  createUint16SharedArray,
+  createInt16SharedArray,
   windowLevel,
   getClosestImageId,
   getSpacingInNormalDirection,
@@ -78,4 +84,6 @@ export {
   hasNaNValues,
   applyPreset,
   deepMerge,
+  getScalingParameters,
+  getScalarDataType,
 };

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -33,6 +33,7 @@ import spatialRegistrationMetadataProvider from './spatialRegistrationMetadataPr
 import getViewportImageCornersInWorld from './getViewportImageCornersInWorld';
 import hasNaNValues from './hasNaNValues';
 import applyPreset from './applyPreset';
+import deepMerge from './deepMerge';
 
 // name spaces
 import * as planar from './planar';
@@ -76,4 +77,5 @@ export {
   getViewportImageCornersInWorld,
   hasNaNValues,
   applyPreset,
+  deepMerge,
 };

--- a/packages/core/src/utilities/loadImageToCanvas.ts
+++ b/packages/core/src/utilities/loadImageToCanvas.ts
@@ -58,11 +58,11 @@ export default function loadImageToCanvas(
     // IMPORTANT: Request type should be passed if not the 'interaction'
     // highest priority will be used for the request type in the imageRetrievalPool
     const options = {
-      targetBuffer: {
-        type: 'Float32Array',
-        offset: null,
-        length: null,
-      },
+      // targetBuffer: {
+      //   type: 'Float32Array',
+      //   offset: null,
+      //   length: null,
+      // },
       preScale: {
         enabled: true,
       },

--- a/packages/core/src/volumeLoader.ts
+++ b/packages/core/src/volumeLoader.ts
@@ -21,12 +21,12 @@ interface VolumeLoaderOptions {
 interface DerivedVolumeOptions {
   volumeId: string;
   targetBuffer?: {
-    type: 'Float32Array' | 'Uint8Array';
+    type: 'Float32Array' | 'Uint8Array' | 'Uint16Array' | 'Int16Array';
     sharedArrayBuffer?: boolean;
   };
 }
 interface LocalVolumeOptions {
-  scalarData: Float32Array | Uint8Array;
+  scalarData: Float32Array | Uint8Array | Uint16Array | Int16Array;
   metadata: Metadata;
   dimensions: Point3;
   spacing: Point3;
@@ -201,7 +201,8 @@ export async function createAndCacheVolume(
  * is given, it will be used to generate the intensity values for the derivedVolume.
  * Finally, it will save the volume in the cache.
  * @param referencedVolumeId - the volumeId from which the new volume will get its metadata
- * @param options - DerivedVolumeOptions {uid: derivedVolumeUID, targetBuffer: { type: FLOAT32Array | Uint8Array}, scalarData: if provided}
+ * @param options - DerivedVolumeOptions {uid: derivedVolumeUID, targetBuffer: { type: FLOAT32Array | Uint8Array |
+ * Uint16Array | Uint32Array  }, scalarData: if provided}
  *
  * @returns ImageVolume
  */
@@ -238,6 +239,12 @@ export async function createAndCacheDerivedVolume(
     } else if (targetBuffer.type === 'Uint8Array') {
       numBytes = scalarLength;
       TypedArray = Uint8Array;
+    } else if (targetBuffer.type === 'Uint16Array') {
+      numBytes = scalarLength * 2;
+      TypedArray = Uint16Array;
+    } else if (targetBuffer.type === 'Int16Array') {
+      numBytes = scalarLength * 2;
+      TypedArray = Uint16Array;
     } else {
       throw new Error('TargetBuffer should be Float32Array or Uint8Array');
     }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -38,7 +38,7 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^6.2.1",
     "clsx": "^1.1.1",
-    "cornerstone-wado-image-loader": "^4.2.1",
+    "cornerstone-wado-image-loader": "^4.5.0",
     "dcmjs": "0.19.2",
     "detect-gpu": "^4.0.45",
     "dicom-parser": "^1.8.11",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -34,7 +34,7 @@
     "@docusaurus/core": "2.0.0-rc.1",
     "@docusaurus/module-type-aliases": "2.0.0-rc.1",
     "@docusaurus/preset-classic": "2.0.0-rc.1",
-    "@kitware/vtk.js": "25.9.0",
+    "@kitware/vtk.js": "25.15.1",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^6.2.1",
     "clsx": "^1.1.1",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -38,7 +38,7 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^6.2.1",
     "clsx": "^1.1.1",
-    "cornerstone-wado-image-loader": "^4.5.0",
+    "cornerstone-wado-image-loader": "^4.5.1",
     "dcmjs": "0.19.2",
     "detect-gpu": "^4.0.45",
     "dicom-parser": "^1.8.11",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -38,7 +38,7 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^6.2.1",
     "clsx": "^1.1.1",
-    "cornerstone-wado-image-loader": "^4.5.1",
+    "cornerstone-wado-image-loader": "^4.5.2",
     "dcmjs": "0.19.2",
     "detect-gpu": "^4.0.45",
     "dicom-parser": "^1.8.11",

--- a/packages/streaming-image-volume-loader/package.json
+++ b/packages/streaming-image-volume-loader/package.json
@@ -27,14 +27,14 @@
   },
   "dependencies": {
     "@cornerstonejs/core": "^0.23.0",
-    "cornerstone-wado-image-loader": "^4.5.1"
+    "cornerstone-wado-image-loader": "^4.5.2"
   },
   "peerDependencies": {
     "@cornerstonejs/calculate-suv": "1.0.2"
   },
   "devDependencies": {
     "@cornerstonejs/calculate-suv": "1.0.2",
-    "cornerstone-wado-image-loader": "^4.5.1"
+    "cornerstone-wado-image-loader": "^4.5.2"
   },
   "contributors": [
     {

--- a/packages/streaming-image-volume-loader/package.json
+++ b/packages/streaming-image-volume-loader/package.json
@@ -27,14 +27,14 @@
   },
   "dependencies": {
     "@cornerstonejs/core": "^0.23.0",
-    "cornerstone-wado-image-loader": "^4.5.0"
+    "cornerstone-wado-image-loader": "^4.5.1"
   },
   "peerDependencies": {
     "@cornerstonejs/calculate-suv": "1.0.2"
   },
   "devDependencies": {
     "@cornerstonejs/calculate-suv": "1.0.2",
-    "cornerstone-wado-image-loader": "^4.5.0"
+    "cornerstone-wado-image-loader": "^4.5.1"
   },
   "contributors": [
     {

--- a/packages/streaming-image-volume-loader/package.json
+++ b/packages/streaming-image-volume-loader/package.json
@@ -27,14 +27,14 @@
   },
   "dependencies": {
     "@cornerstonejs/core": "^0.23.0",
-    "cornerstone-wado-image-loader": "^4.2.1"
+    "cornerstone-wado-image-loader": "^4.5.0"
   },
   "peerDependencies": {
     "@cornerstonejs/calculate-suv": "1.0.2"
   },
   "devDependencies": {
     "@cornerstonejs/calculate-suv": "1.0.2",
-    "cornerstone-wado-image-loader": "^4.2.1"
+    "cornerstone-wado-image-loader": "^4.5.0"
   },
   "contributors": [
     {

--- a/packages/streaming-image-volume-loader/src/StreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/StreamingImageVolume.ts
@@ -204,16 +204,6 @@ export default class StreamingImageVolume extends ImageVolume {
     // Length of one frame in bytes
     const lengthInBytes = arrayBuffer.byteLength / numFrames;
 
-    let type;
-
-    if (scalarData instanceof Uint8Array) {
-      type = 'Uint8Array';
-    } else if (scalarData instanceof Float32Array) {
-      type = 'Float32Array';
-    } else {
-      throw new Error('Unsupported array type');
-    }
-
     let framesLoaded = 0;
     let framesProcessed = 0;
 
@@ -391,26 +381,10 @@ export default class StreamingImageVolume extends ImageVolume {
         return;
       }
 
-      const modalityLutModule =
-        metaData.get('modalityLutModule', imageId) || {};
+      const scalingParameters = csUtils.getScalingParameters(imageId);
 
-      const generalSeriesModule =
-        metaData.get('generalSeriesModule', imageId) || {};
-
-      const scalingParameters: Types.ScalingParameters = {
-        rescaleSlope: modalityLutModule.rescaleSlope,
-        rescaleIntercept: modalityLutModule.rescaleIntercept,
-        modality: generalSeriesModule.modality,
-      };
-
-      if (scalingParameters.modality === 'PT') {
-        const suvFactor = metaData.get('scalingModule', imageId);
-
-        if (suvFactor) {
-          this._addScalingToVolume(suvFactor);
-          scalingParameters.suvbw = suvFactor.suvbw;
-        }
-      }
+      this._addScalingToVolumeIfNecessary(scalingParameters);
+      const type = csUtils.getScalarDataType(scalingParameters, scalarData);
 
       const options = {
         // WADO Image Loader
@@ -535,13 +509,20 @@ export default class StreamingImageVolume extends ImageVolume {
     return scaledArray;
   }
 
-  private _addScalingToVolume(suvFactor) {
+  private _addScalingToVolumeIfNecessary(
+    scalingParameters: Types.ScalingParameters
+  ) {
+    const { suvbsa, suvbw, suvlbm } = scalingParameters;
+    if (suvbsa !== undefined || suvbw !== undefined || suvlbm !== undefined) {
+      this._addScalingToVolume({ suvbsa, suvbw, suvlbm });
+    }
+  }
+
+  private _addScalingToVolume({ suvbsa, suvbw, suvlbm }) {
     // Todo: handle case where suvFactors are not the same for all frames
     if (this.scaling) {
       return;
     }
-
-    const { suvbw, suvlbm, suvbsa } = suvFactor;
 
     const petScaling = <Types.PTScaling>{};
 

--- a/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
+++ b/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
@@ -1,10 +1,15 @@
-import { cache, utilities, Enums } from '@cornerstonejs/core';
+import { cache, utilities, Enums, getConfiguration } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 import { vec3 } from 'gl-matrix';
 import { makeVolumeMetadata, sortImageIdsAndGetSpacing } from './helpers';
 import StreamingImageVolume from './StreamingImageVolume';
 
-const { createUint8SharedArray, createFloat32SharedArray } = utilities;
+const {
+  createUint8SharedArray,
+  createFloat32SharedArray,
+  createUint16SharedArray,
+  createInt16SharedArray,
+} = utilities;
 
 interface IVolumeLoader {
   promise: Promise<StreamingImageVolume>;
@@ -30,6 +35,7 @@ function cornerstoneStreamingImageVolumeLoader(
     imageIds: string[];
   }
 ): IVolumeLoader {
+  const { hasNorm16TextureSupport } = getConfiguration().rendering;
   if (!options || !options.imageIds || !options.imageIds.length) {
     throw new Error(
       'ImageIds must be provided to create a streaming image volume'
@@ -83,9 +89,14 @@ function cornerstoneStreamingImageVolumeLoader(
   const signed = PixelRepresentation === 1;
 
   // Check if it fits in the cache before we allocate data
-  // TODO Improve this when we have support for more types
-  // NOTE: We use 4 bytes per voxel as we are using Float32.
-  const bytesPerVoxel = BitsAllocated === 16 ? 4 : 1;
+  let bytesPerVoxel = 1;
+
+  if (BitsAllocated === 16 && hasNorm16TextureSupport) {
+    bytesPerVoxel = 2;
+  } else {
+    bytesPerVoxel = 4;
+  }
+
   const sizeInBytesPerComponent =
     bytesPerVoxel * dimensions[0] * dimensions[1] * dimensions[2];
 
@@ -121,9 +132,21 @@ function cornerstoneStreamingImageVolumeLoader(
       break;
 
     case 16:
-      scalarData = createFloat32SharedArray(
-        dimensions[0] * dimensions[1] * dimensions[2]
-      );
+      if (hasNorm16TextureSupport) {
+        if (signed) {
+          scalarData = createInt16SharedArray(
+            dimensions[0] * dimensions[1] * dimensions[2]
+          );
+        } else {
+          scalarData = createUint16SharedArray(
+            dimensions[0] * dimensions[1] * dimensions[2]
+          );
+        }
+      } else {
+        scalarData = createFloat32SharedArray(
+          dimensions[0] * dimensions[1] * dimensions[2]
+        );
+      }
 
       break;
 

--- a/packages/streaming-image-volume-loader/src/helpers/scaleArray.ts
+++ b/packages/streaming-image-volume-loader/src/helpers/scaleArray.ts
@@ -8,9 +8,9 @@ import type { Types } from '@cornerstonejs/core';
  * @returns The array is being scaled
  */
 export default function scaleArray(
-  array: Float32Array | Uint8Array,
+  array: Float32Array | Uint8Array | Uint16Array | Int16Array,
   scalingParameters: Types.ScalingParameters
-): Float32Array | Uint8Array {
+): Float32Array | Uint8Array | Uint16Array | Int16Array | undefined {
   const arrayLength = array.length;
   const { rescaleSlope, rescaleIntercept, suvbw } = scalingParameters;
 

--- a/packages/streaming-image-volume-loader/src/sharedArrayBufferImageLoader.ts
+++ b/packages/streaming-image-volume-loader/src/sharedArrayBufferImageLoader.ts
@@ -59,7 +59,8 @@ function sharedArrayBufferImageLoader(
             transferSyntax,
             pixelData,
             canvas,
-            options
+            options,
+            { convertFloatPixelDataToInt: false, use16BitDataType: true }
           );
 
           decodePromise.then(() => {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -31,7 +31,7 @@
     "lodash.get": "^4.4.2"
   },
   "peerDependencies": {
-    "@kitware/vtk.js": "25.9.0",
+    "@kitware/vtk.js": "25.15.1",
     "@types/d3-array": "^3.0.3",
     "@types/d3-interpolate": "^3.0.1",
     "d3-array": "^3.0.3",
@@ -39,7 +39,7 @@
     "gl-matrix": "^3.4.3"
   },
   "devDependencies": {
-    "@kitware/vtk.js": "25.9.0"
+    "@kitware/vtk.js": "25.15.1"
   },
   "contributors": [
     {

--- a/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
+++ b/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
@@ -6,6 +6,7 @@ import {
   getRenderingEngines,
   getEnabledElementByIds,
   Settings,
+  utilities as csUtils,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 import { state } from '../index';
@@ -18,7 +19,6 @@ import {
 
 import { MouseCursor, SVGMouseCursor } from '../../cursors';
 import { initElementCursor } from '../../cursors/elementCursor';
-import deepmerge from '../../utilities/deepMerge';
 
 const { Active, Passive, Enabled, Disabled } = ToolModes;
 
@@ -598,7 +598,7 @@ export default class ToolGroup implements IToolGroup {
     if (overwrite) {
       _configuration = configuration;
     } else {
-      _configuration = deepmerge(
+      _configuration = csUtils.deepMerge(
         this._toolInstances[toolName].configuration,
         configuration
       );

--- a/packages/tools/src/tools/WindowLevelTool.ts
+++ b/packages/tools/src/tools/WindowLevelTool.ts
@@ -222,6 +222,12 @@ class WindowLevelTool extends BaseTool {
     } else if (scalarData instanceof Uint8Array) {
       bytesPerVoxel = 1;
       TypedArrayConstructor = Uint8Array;
+    } else if (scalarData instanceof Uint16Array) {
+      bytesPerVoxel = 2;
+      TypedArrayConstructor = Uint16Array;
+    } else if (scalarData instanceof Int16Array) {
+      bytesPerVoxel = 2;
+      TypedArrayConstructor = Int16Array;
     }
 
     const buffer = scalarData.buffer;

--- a/packages/tools/src/tools/base/BaseTool.ts
+++ b/packages/tools/src/tools/base/BaseTool.ts
@@ -1,6 +1,5 @@
 import { StackViewport, VolumeViewport, utilities } from '@cornerstonejs/core';
 import { Types } from '@cornerstonejs/core';
-import deepMerge from '../../utilities/deepMerge';
 import { ToolModes } from '../../enums';
 import { InteractionTypes, ToolProps, PublicToolProps } from '../../types';
 
@@ -37,7 +36,7 @@ abstract class BaseTool implements IBaseTool {
   public mode: ToolModes;
 
   constructor(toolProps: PublicToolProps, defaultToolProps: ToolProps) {
-    const initialProps = deepMerge(defaultToolProps, toolProps);
+    const initialProps = utilities.deepMerge(defaultToolProps, toolProps);
 
     const {
       configuration = {},
@@ -87,7 +86,10 @@ abstract class BaseTool implements IBaseTool {
    * @param configuration - toolConfiguration
    */
   public setConfiguration(newConfiguration: Record<string, any>): void {
-    this.configuration = deepMerge(this.configuration, newConfiguration);
+    this.configuration = utilities.deepMerge(
+      this.configuration,
+      newConfiguration
+    );
   }
 
   /**

--- a/packages/tools/src/tools/displayTools/Labelmap/labelmapDisplay.ts
+++ b/packages/tools/src/tools/displayTools/Labelmap/labelmapDisplay.ts
@@ -21,7 +21,6 @@ import {
 
 import addLabelmapToElement from './addLabelmapToElement';
 
-import { deepMerge } from '../../../utilities';
 import removeLabelmapFromElement from './removeLabelmapFromElement';
 
 const MAX_NUMBER_COLORS = 255;
@@ -78,7 +77,7 @@ async function addSegmentationRepresentation(
     const currentToolGroupConfig =
       SegmentationConfig.getToolGroupSpecificConfig(toolGroupId);
 
-    const mergedConfig = deepMerge(
+    const mergedConfig = utilities.deepMerge(
       currentToolGroupConfig,
       toolGroupSpecificConfig
     );

--- a/packages/tools/src/tools/displayTools/SegmentationDisplayTool.ts
+++ b/packages/tools/src/tools/displayTools/SegmentationDisplayTool.ts
@@ -1,5 +1,9 @@
 import { BaseTool } from '../base';
-import { getEnabledElementByIds, Types } from '@cornerstonejs/core';
+import {
+  getEnabledElementByIds,
+  Types,
+  utilities as csUtils,
+} from '@cornerstonejs/core';
 import Representations from '../../enums/SegmentationRepresentations';
 import { getSegmentationRepresentations } from '../../stateManagement/segmentation/segmentationState';
 import { labelmapDisplay } from './Labelmap';
@@ -9,7 +13,6 @@ import { getToolGroup } from '../../store/ToolGroupManager';
 
 import { PublicToolProps, ToolProps } from '../../types';
 
-import { deepMerge } from '../../utilities';
 import {
   SegmentationRepresentationConfig,
   ToolGroupSpecificRepresentation,
@@ -173,7 +176,7 @@ class SegmentationDisplayTool extends BaseTool {
     const globalConfig = segmentationConfig.getGlobalConfig();
 
     // merge two configurations and override the global config
-    const mergedConfig = deepMerge(globalConfig, toolGroupConfig);
+    const mergedConfig = csUtils.deepMerge(globalConfig, toolGroupConfig);
 
     return mergedConfig;
   }

--- a/packages/tools/src/tools/segmentation/PaintFillTool.ts
+++ b/packages/tools/src/tools/segmentation/PaintFillTool.ts
@@ -184,7 +184,7 @@ export default class PaintFillTool extends BaseTool {
   };
 
   private generateHelpers = (
-    scalarData: Float32Array | Uint8Array,
+    scalarData: Float32Array | Uint8Array | Uint16Array | Int16Array,
     dimensions: Types.Point3,
     seedIndex3D: Types.Point3,
     fixedDimension = 2

--- a/packages/tools/src/utilities/index.ts
+++ b/packages/tools/src/utilities/index.ts
@@ -5,7 +5,6 @@ import {
 
 // Lodash/common JS functionality
 import debounce from './debounce';
-import deepMerge from './deepMerge';
 import throttle from './throttle';
 import isObject from './isObject';
 import clip from './clip';
@@ -41,7 +40,6 @@ export {
   viewportFilters,
   drawing,
   debounce,
-  deepMerge,
   throttle,
   orientation,
   isObject,

--- a/packages/tools/src/utilities/stackPrefetch/stackPrefetch.ts
+++ b/packages/tools/src/utilities/stackPrefetch/stackPrefetch.ts
@@ -247,11 +247,11 @@ function prefetch(element) {
     // IMPORTANT: Request type should be passed if not the 'interaction'
     // highest priority will be used for the request type in the imageRetrievalPool
     const options = {
-      targetBuffer: {
-        type: 'Float32Array',
-        offset: null,
-        length: null,
-      },
+      // targetBuffer: {
+      //   type: 'Float32Array',
+      //   offset: null,
+      //   length: null,
+      // },
       preScale: {
         enabled: true,
       },

--- a/utils/demo/helpers/initCornerstoneWADOImageLoader.js
+++ b/utils/demo/helpers/initCornerstoneWADOImageLoader.js
@@ -9,6 +9,7 @@ export default function initCornerstoneWADOImageLoader() {
     useWebWorkers: true,
     decodeConfig: {
       convertFloatPixelDataToInt: false,
+      use16BitDataType: true,
     },
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8199,10 +8199,10 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cornerstone-wado-image-loader@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.npmjs.org/cornerstone-wado-image-loader/-/cornerstone-wado-image-loader-4.5.0.tgz#124f197ceb3ec11c7967aa29820fcdea8df0647d"
-  integrity sha512-ruz4nGr46NcsgEu4UELtokdCO4XRBCa2NyypyqZuaXmDfDX4z2TsOIlk2pLgStI57Jm2B52BNFCJUQrNTPsB5A==
+cornerstone-wado-image-loader@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.npmjs.org/cornerstone-wado-image-loader/-/cornerstone-wado-image-loader-4.5.1.tgz#dc1b353ef3658e65e340da1c26ef919b1a4d14c3"
+  integrity sha512-/+bmzUSeTb5Hm/5STB0fgKHFe6wN7+zNngYSPefPHhkpEo5zVboBv57UvwJBaga8Cobyg7aEzTCxh3OCbyMcSA==
   dependencies:
     "@babel/eslint-parser" "^7.19.1"
     "@cornerstonejs/codec-charls" "^0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,14 +3017,15 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kitware/vtk.js@25.9.0":
-  version "25.9.0"
-  resolved "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-25.9.0.tgz#ecf555c56f6e117b454131c43aba45311a515ecc"
-  integrity sha512-L4OQavJkSZjYYvW4GsEVkX7hqPKEbzEKwitq9GcjoAijrV0MINyxkChRbYEEYnTMcSW3i2jZ/jmiXaPfXuhPFQ==
+"@kitware/vtk.js@25.15.1":
+  version "25.15.1"
+  resolved "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-25.15.1.tgz#bead245fe4bb7c169395b7fa4fe4d0638104a949"
+  integrity sha512-qrowsv8uz9ljDsAhjKGL5vW3F2wc6YGlzizk3eBQp5my0Hb9h09mf7sYbj/SOCFmwZVELjS0jfQwxzHMMrjVPA==
   dependencies:
     "@babel/runtime" "7.17.9"
     commander "9.2.0"
     d3-scale "4.0.2"
+    fast-deep-equal "^3.1.3"
     fflate "0.7.3"
     gl-matrix "3.4.3"
     globalthis "1.0.3"
@@ -3909,7 +3910,7 @@
   dependencies:
     chalk "^5.0.0"
     cron-parser "^4.1.0"
-    deepmerge "^4.2.2"
+    deepMerge "^4.2.2"
     dot-prop "^7.0.0"
     execa "^6.0.0"
     fast-safe-stringify "^2.0.7"
@@ -4593,7 +4594,7 @@
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
     builtin-modules "^3.1.0"
-    deepmerge "^4.2.2"
+    deepMerge "^4.2.2"
     is-module "^1.0.0"
     resolve "^1.19.0"
 
@@ -4856,7 +4857,7 @@
   integrity sha512-oDdMQONKOJEbuKwuy4Np6VdV6qoaLLvoY86hjvQEgU82Vx1MSWRyYms6Sl0f+NtqxLI/rDVufATbP/ev996k3Q==
   dependencies:
     cosmiconfig "^7.0.1"
-    deepmerge "^4.2.2"
+    deepMerge "^4.2.2"
     svgo "^2.5.0"
 
 "@svgr/webpack@^6.2.1":
@@ -8729,9 +8730,9 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^4.2.2:
+deepMerge@^4.2.2:
   version "4.2.2"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  resolved "https://registry.yarnpkg.com/deepMerge/-/deepMerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 default-gateway@^4.2.0:
@@ -10699,7 +10700,7 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     chalk "^4.1.0"
     chokidar "^3.4.2"
     cosmiconfig "^6.0.0"
-    deepmerge "^4.2.2"
+    deepMerge "^4.2.2"
     fs-extra "^9.0.0"
     glob "^7.1.6"
     memfs "^3.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,6 +273,11 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.8.tgz#2483f565faca607b8535590e84e7de323f27764d"
   integrity sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==
 
+"@babel/compat-data@^7.20.0":
+  version "7.20.5"
+  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.5.tgz#86f172690b093373a933223b4745deeb6049e733"
+  integrity sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g==
+
 "@babel/core@7.12.9":
   version "7.12.9"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.9.tgz#fd450c4ec10cdbb980e2928b7aa7a28484593fc8"
@@ -337,6 +342,36 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
+"@babel/core@^7.7.5":
+  version "7.20.5"
+  resolved "https://registry.npmjs.org/@babel/core/-/core-7.20.5.tgz#45e2114dc6cd4ab167f81daf7820e8fa1250d113"
+  integrity sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.20.5"
+    "@babel/helper-compilation-targets" "^7.20.0"
+    "@babel/helper-module-transforms" "^7.20.2"
+    "@babel/helpers" "^7.20.5"
+    "@babel/parser" "^7.20.5"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.20.5"
+    "@babel/types" "^7.20.5"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.1"
+    semver "^6.3.0"
+
+"@babel/eslint-parser@^7.19.1":
+  version "7.19.1"
+  resolved "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz#4f68f6b0825489e00a24b41b6a1ae35414ecd2f4"
+  integrity sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==
+  dependencies:
+    "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
+    eslint-visitor-keys "^2.1.0"
+    semver "^6.3.0"
+
 "@babel/generator@^7.12.5", "@babel/generator@^7.18.2":
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.2.tgz#33873d6f89b21efe2da63fe554460f3df1c5880d"
@@ -361,6 +396,15 @@
   integrity sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==
   dependencies:
     "@babel/types" "^7.18.9"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz#cb25abee3178adf58d6814b68517c62bdbfdda95"
+  integrity sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==
+  dependencies:
+    "@babel/types" "^7.20.5"
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
@@ -412,6 +456,16 @@
     "@babel/compat-data" "^7.18.8"
     "@babel/helper-validator-option" "^7.18.6"
     browserslist "^4.20.2"
+    semver "^6.3.0"
+
+"@babel/helper-compilation-targets@^7.20.0":
+  version "7.20.0"
+  resolved "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz#6bf5374d424e1b3922822f1d9bdaa43b1a139d0a"
+  integrity sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==
+  dependencies:
+    "@babel/compat-data" "^7.20.0"
+    "@babel/helper-validator-option" "^7.18.6"
+    browserslist "^4.21.3"
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.17.12", "@babel/helper-create-class-features-plugin@^7.18.0":
@@ -523,6 +577,14 @@
     "@babel/template" "^7.18.6"
     "@babel/types" "^7.18.9"
 
+"@babel/helper-function-name@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
+  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/types" "^7.19.0"
+
 "@babel/helper-hoist-variables@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246"
@@ -613,6 +675,20 @@
     "@babel/template" "^7.18.6"
     "@babel/traverse" "^7.18.9"
     "@babel/types" "^7.18.9"
+
+"@babel/helper-module-transforms@^7.20.2":
+  version "7.20.2"
+  resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz#ac53da669501edd37e658602a21ba14c08748712"
+  integrity sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-simple-access" "^7.20.2"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.20.1"
+    "@babel/types" "^7.20.2"
 
 "@babel/helper-optimise-call-expression@^7.16.7":
   version "7.16.7"
@@ -714,6 +790,13 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-simple-access@^7.20.2":
+  version "7.20.2"
+  resolved "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz#0ab452687fe0c2cfb1e2b9e0015de07fc2d62dd9"
+  integrity sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==
+  dependencies:
+    "@babel/types" "^7.20.2"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz#0ee3388070147c3ae051e487eca3ebb0e2e8bb09"
@@ -742,6 +825,11 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-string-parser@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
+  integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
+
 "@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
@@ -751,6 +839,11 @@
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
+
+"@babel/helper-validator-identifier@^7.19.1":
+  version "7.19.1"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
 
 "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
@@ -800,6 +893,15 @@
     "@babel/traverse" "^7.18.9"
     "@babel/types" "^7.18.9"
 
+"@babel/helpers@^7.20.5":
+  version "7.20.6"
+  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.6.tgz#e64778046b70e04779dfbdf924e7ebb45992c763"
+  integrity sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.20.5"
+    "@babel/types" "^7.20.5"
+
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.16.7":
   version "7.17.12"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.12.tgz#257de56ee5afbd20451ac0a75686b6b404257351"
@@ -827,6 +929,11 @@
   version "7.18.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.4.tgz#6774231779dd700e0af29f6ad8d479582d7ce5ef"
   integrity sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==
+
+"@babel/parser@^7.18.10", "@babel/parser@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz#7f3c7335fe417665d929f34ae5dceae4c04015e8"
+  integrity sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==
 
 "@babel/parser@^7.18.6":
   version "7.18.6"
@@ -2183,6 +2290,15 @@
     "@babel/parser" "^7.16.7"
     "@babel/types" "^7.16.7"
 
+"@babel/template@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
+  integrity sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/parser" "^7.18.10"
+    "@babel/types" "^7.18.10"
+
 "@babel/template@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.6.tgz#1283f4993e00b929d6e2d3c72fdc9168a2977a31"
@@ -2240,12 +2356,37 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.20.1", "@babel/traverse@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz#78eb244bea8270fdda1ef9af22a5d5e5b7e57133"
+  integrity sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.20.5"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.20.5"
+    "@babel/types" "^7.20.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.12.7", "@babel/types@^7.15.6", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.17.12", "@babel/types@^7.18.0", "@babel/types@^7.18.2", "@babel/types@^7.4.4":
   version "7.18.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.4.tgz#27eae9b9fd18e9dccc3f9d6ad051336f307be354"
   integrity sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.18.10", "@babel/types@^7.19.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.20.5.tgz#e206ae370b5393d94dfd1d04cd687cace53efa84"
+  integrity sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.18.6", "@babel/types@^7.18.7":
@@ -2336,6 +2477,11 @@
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@cornerstonejs/codec-openjpeg/-/codec-openjpeg-0.1.1.tgz#5bd1c52a33a425299299e970312731fa0cc2711b"
   integrity sha512-HOMMOLV6xy8O/agNGGvrl0a8DwShpBvWxAzEzv2pqq12d3r5z/3MyIgNA3Oj/8bIBVvvVXxh9RX7rMDRHJdowg==
+
+"@cornerstonejs/codec-openjph@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@cornerstonejs/codec-openjph/-/codec-openjph-1.0.3.tgz#4c82642e8a6beb0d263f5a263723aec4225e5300"
+  integrity sha512-PK+9N/JL7ZMGum6OKuReRGGhWXpWjRC9WnltQ6aEzRKEQPMg+3WFiQPZowKCCG1I4whv35DYFRi6wu7RyRaEMQ==
 
 "@cspotcode/source-map-consumer@0.8.0":
   version "0.8.0"
@@ -3016,6 +3162,17 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jsdevtools/coverage-istanbul-loader@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/@jsdevtools/coverage-istanbul-loader/-/coverage-istanbul-loader-3.0.5.tgz#2a4bc65d0271df8d4435982db4af35d81754ee26"
+  integrity sha512-EUCPEkaRPvmHjWAAZkWMT7JDzpw7FKB00WTISaiXsbNOd5hCHg77XLA8sLYLFDo1zepYLo2w7GstN8YBqRXZfA==
+  dependencies:
+    convert-source-map "^1.7.0"
+    istanbul-lib-instrument "^4.0.3"
+    loader-utils "^2.0.0"
+    merge-source-map "^1.1.0"
+    schema-utils "^2.7.0"
 
 "@kitware/vtk.js@25.15.1":
   version "25.15.1"
@@ -4317,6 +4474,13 @@
     toml "^3.0.0"
     unixify "^1.0.0"
     yargs "^16.0.0"
+
+"@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
+  version "5.1.1-v1"
+  resolved "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"
+  integrity sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==
+  dependencies:
+    eslint-scope "5.1.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -6780,6 +6944,16 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4
     node-releases "^2.0.3"
     picocolors "^1.0.0"
 
+browserslist@^4.21.3:
+  version "4.21.4"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
+  integrity sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==
+  dependencies:
+    caniuse-lite "^1.0.30001400"
+    electron-to-chromium "^1.4.251"
+    node-releases "^2.0.6"
+    update-browserslist-db "^1.0.9"
+
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
@@ -7068,6 +7242,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001332, can
   version "1.0.30001346"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz#e895551b46b9cc9cc9de852facd42f04839a8fbe"
   integrity sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==
+
+caniuse-lite@^1.0.30001400:
+  version "1.0.30001439"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz#ab7371faeb4adff4b74dad1718a6fd122e45d9cb"
+  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
 
 canvas@2.9.0:
   version "2.9.0"
@@ -8020,16 +8199,21 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cornerstone-wado-image-loader@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/cornerstone-wado-image-loader/-/cornerstone-wado-image-loader-4.2.1.tgz#ee37797fe8970dcb7e438a6d87b710e817066100"
-  integrity sha512-nRu+6GfHFERpZLytH/SCfymODCz1SC1NKRv/xn02pr3PEkzU6fvKI76sSxSFOozxDsYljupTRNi/qGMprfdBHA==
+cornerstone-wado-image-loader@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/cornerstone-wado-image-loader/-/cornerstone-wado-image-loader-4.5.0.tgz#124f197ceb3ec11c7967aa29820fcdea8df0647d"
+  integrity sha512-ruz4nGr46NcsgEu4UELtokdCO4XRBCa2NyypyqZuaXmDfDX4z2TsOIlk2pLgStI57Jm2B52BNFCJUQrNTPsB5A==
   dependencies:
+    "@babel/eslint-parser" "^7.19.1"
     "@cornerstonejs/codec-charls" "^0.1.1"
     "@cornerstonejs/codec-libjpeg-turbo-8bit" "^0.0.7"
     "@cornerstonejs/codec-openjpeg" "^0.1.0"
+    "@cornerstonejs/codec-openjph" "^1.0.3"
+    coverage-istanbul-loader "^3.0.5"
+    date-format "^4.0.14"
     dicom-parser "^1.8.9"
     pako "^2.0.4"
+    uuid "^9.0.0"
 
 cors@~2.8.5:
   version "2.8.5"
@@ -8070,6 +8254,13 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+coverage-istanbul-loader@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/coverage-istanbul-loader/-/coverage-istanbul-loader-3.0.5.tgz#bf942efc0f4e3ac27565203c17dca5008eae6637"
+  integrity sha512-xsw2phF0VNqUPk47V/vHXkdcTyl0tkMSmaZfLrTOhoPhPMXFelNju7utl5s7I93KXzipqDEK0YwofQSSflPz8A==
+  dependencies:
+    "@jsdevtools/coverage-istanbul-loader" "3.0.5"
 
 cp-file@^7.0.0:
   version "7.0.0"
@@ -8553,6 +8744,11 @@ date-format@^4.0.10:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.11.tgz#ae0d1e069d7f0687938fd06f98c12f3a6276e526"
   integrity sha512-VS20KRyorrbMCQmpdl2hg5KaOUsda1RbnsJg461FfrcyCUg+pkd0b40BSW4niQyTheww4DBXQnS7HwSrKkipLw==
+
+date-format@^4.0.14:
+  version "4.0.14"
+  resolved "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz#7a8e584434fb169a521c8b7aa481f355810d9400"
+  integrity sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==
 
 date-time@^3.1.0:
   version "3.1.0"
@@ -9369,6 +9565,11 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.144.tgz#9a5d1f41452ecc65b686d529ae919248da44f406"
   integrity sha512-R3RV3rU1xWwFJlSClVWDvARaOk6VUO/FubHLodIASDB3Mc2dzuWvNdfOgH9bwHUTqT79u92qw60NWfwUdzAqdg==
 
+electron-to-chromium@^1.4.251:
+  version "1.4.284"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
+  integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
+
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
@@ -9883,7 +10084,7 @@ eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint-visitor-keys@^2.0.0:
+eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
@@ -12857,6 +13058,16 @@ istanbul-lib-instrument@^1.7.3:
     istanbul-lib-coverage "^1.2.1"
     semver "^5.3.0"
 
+istanbul-lib-instrument@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz#873c6fff897450118222774696a3f28902d77c1d"
+  integrity sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==
+  dependencies:
+    "@babel/core" "^7.7.5"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-coverage "^3.0.0"
+    semver "^6.3.0"
+
 istanbul-lib-instrument@^5.0.4, istanbul-lib-instrument@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz#31d18bdd127f825dd02ea7bfdfd906f8ab840e9f"
@@ -14267,6 +14478,13 @@ merge-options@^3.0.4:
   dependencies:
     is-plain-obj "^2.1.0"
 
+merge-source-map@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
+  integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
+  dependencies:
+    source-map "^0.6.1"
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -15051,6 +15269,11 @@ node-releases@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.5.tgz#280ed5bc3eba0d96ce44897d8aee478bfb3d9666"
   integrity sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==
+
+node-releases@^2.0.6:
+  version "2.0.8"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz#0f349cdc8fcfa39a92ac0be9bc48b7706292b9ae"
+  integrity sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==
 
 node-source-walk@^4.0.0, node-source-walk@^4.2.0, node-source-walk@^4.2.2:
   version "4.3.0"
@@ -18541,7 +18764,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.6.5:
+schema-utils@^2.6.5, schema-utils@^2.7.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.1.tgz#1ca4f32d1b24c590c203b8e7a50bf0ea4cd394d7"
   integrity sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
@@ -20662,6 +20885,14 @@ upath@^2.0.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
   integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
 
+update-browserslist-db@^1.0.9:
+  version "1.0.10"
+  resolved "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
+  integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
+
 update-notifier@^5.0.0, update-notifier@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-5.1.0.tgz#4ab0d7c7f36a231dd7316cf7729313f0214d9ad9"
@@ -20799,6 +21030,11 @@ uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.3.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8199,10 +8199,10 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cornerstone-wado-image-loader@^4.5.1:
-  version "4.5.1"
-  resolved "https://registry.npmjs.org/cornerstone-wado-image-loader/-/cornerstone-wado-image-loader-4.5.1.tgz#dc1b353ef3658e65e340da1c26ef919b1a4d14c3"
-  integrity sha512-/+bmzUSeTb5Hm/5STB0fgKHFe6wN7+zNngYSPefPHhkpEo5zVboBv57UvwJBaga8Cobyg7aEzTCxh3OCbyMcSA==
+cornerstone-wado-image-loader@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.npmjs.org/cornerstone-wado-image-loader/-/cornerstone-wado-image-loader-4.5.2.tgz#a29cf9e8a05f49429054ea7dbd2e8bff5a3b54bb"
+  integrity sha512-rnTK1RrYcpJtf9GOKN8CnzzJHDZyS8wReKt79SrryIXqX7ZNApcKj56RQyFG1r9w8JYgOW08zzBoeUOLI3X50g==
   dependencies:
     "@babel/eslint-parser" "^7.19.1"
     "@cornerstonejs/codec-charls" "^0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3910,7 +3910,7 @@
   dependencies:
     chalk "^5.0.0"
     cron-parser "^4.1.0"
-    deepMerge "^4.2.2"
+    deepmerge "^4.2.2"
     dot-prop "^7.0.0"
     execa "^6.0.0"
     fast-safe-stringify "^2.0.7"
@@ -4594,7 +4594,7 @@
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
     builtin-modules "^3.1.0"
-    deepMerge "^4.2.2"
+    deepmerge "^4.2.2"
     is-module "^1.0.0"
     resolve "^1.19.0"
 
@@ -4857,7 +4857,7 @@
   integrity sha512-oDdMQONKOJEbuKwuy4Np6VdV6qoaLLvoY86hjvQEgU82Vx1MSWRyYms6Sl0f+NtqxLI/rDVufATbP/ev996k3Q==
   dependencies:
     cosmiconfig "^7.0.1"
-    deepMerge "^4.2.2"
+    deepmerge "^4.2.2"
     svgo "^2.5.0"
 
 "@svgr/webpack@^6.2.1":
@@ -8730,9 +8730,9 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepMerge@^4.2.2:
+deepmerge@^4.2.2:
   version "4.2.2"
-  resolved "https://registry.yarnpkg.com/deepMerge/-/deepMerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 default-gateway@^4.2.0:
@@ -10700,7 +10700,7 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     chalk "^4.1.0"
     chokidar "^3.4.2"
     cosmiconfig "^6.0.0"
-    deepMerge "^4.2.2"
+    deepmerge "^4.2.2"
     fs-extra "^9.0.0"
     glob "^7.1.6"
     memfs "^3.1.2"


### PR DESCRIPTION
~~This relies on this https://github.com/cornerstonejs/cornerstoneWADOImageLoader/pull/500~~


## Volume Viewport
- I made the necessary changes, but seems like the part where we update texture in fillImage3D has some problem, when I run `volumeAPI` example, the webGL context get lost, and I get a flash of empty screen

https://github.com/cornerstonejs/cornerstone3D-beta/blob/feat/norm16-textures/packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLTexture.js#L103

## Stack Viewport
- stack viewport not working need to be fixed. I guess we can just use Float32 for now? as before. Later we optimize this? Oh yes, I guess I didn't add vtk.js support for imageMapper for norm16, so we don't have option, we should just use it as before

## CPU 
- Needs fixing I guess since I commented out bunch of things. I don't think we need to do anything here, just uncomment what I commented out

CC @swederik @Ouwen It is very interesting, sometimes when I loose the GL context, the extension becomes unavailable (webgl report v2) I need to restart chrome for it to appear again!)
