### PR TITLE
fix: could not access 'index' before initialization

### DIFF
--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -51,7 +51,6 @@ import { MouseDragEventType } from '../types/EventTypes';
 import { CONSTANTS } from '@cornerstonejs/core';
 
 const { RENDERING_DEFAULTS } = CONSTANTS;
-const { liangBarksyClip } = math.vec2;
 
 // TODO: nested config is weird
 interface ToolConfiguration {
@@ -923,8 +922,8 @@ class CrosshairsTool extends AnnotationTool {
 
       // Clipping lines to be only included in a box (canvas), we don't want
       // the lines goes beyond canvas
-      liangBarksyClip(refLinePointOne, refLinePointTwo, canvasBox);
-      liangBarksyClip(refLinePointThree, refLinePointFour, canvasBox);
+      math.vec2.liangBarksyClip(refLinePointOne, refLinePointTwo, canvasBox);
+      math.vec2.liangBarksyClip(refLinePointThree, refLinePointFour, canvasBox);
 
       // Computing rotation handle positions
       const rotHandleOne = vec2.create();
@@ -1017,7 +1016,7 @@ class CrosshairsTool extends AnnotationTool {
       );
       vec2.add(stLinePointTwo, stLinePointTwo, canvasOrthoVectorFromCenter);
 
-      liangBarksyClip(stLinePointOne, stLinePointTwo, canvasBox);
+      math.vec2.liangBarksyClip(stLinePointOne, stLinePointTwo, canvasBox);
 
       const stLinePointThree = vec2.create();
       vec2.add(
@@ -1043,7 +1042,7 @@ class CrosshairsTool extends AnnotationTool {
         canvasOrthoVectorFromCenter
       );
 
-      liangBarksyClip(stLinePointThree, stLinePointFour, canvasBox);
+      math.vec2.liangBarksyClip(stLinePointThree, stLinePointFour, canvasBox);
 
       // points for slab thickness handles
       const stHandleOne = vec2.create();

--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -31,7 +31,7 @@ import {
   resetElementCursor,
   hideElementCursor,
 } from '../cursors/elementCursor';
-import { math } from '../utilities';
+import liangBarksyClip from '../utilities/math/vec2/liangBarksyClip';
 import vtkMath from '@kitware/vtk.js/Common/Core/Math';
 import vtkMatrixBuilder from '@kitware/vtk.js/Common/Core/MatrixBuilder';
 import * as lineSegment from '../utilities/math/line';
@@ -922,8 +922,8 @@ class CrosshairsTool extends AnnotationTool {
 
       // Clipping lines to be only included in a box (canvas), we don't want
       // the lines goes beyond canvas
-      math.vec2.liangBarksyClip(refLinePointOne, refLinePointTwo, canvasBox);
-      math.vec2.liangBarksyClip(refLinePointThree, refLinePointFour, canvasBox);
+      liangBarksyClip(refLinePointOne, refLinePointTwo, canvasBox);
+      liangBarksyClip(refLinePointThree, refLinePointFour, canvasBox);
 
       // Computing rotation handle positions
       const rotHandleOne = vec2.create();
@@ -1016,7 +1016,7 @@ class CrosshairsTool extends AnnotationTool {
       );
       vec2.add(stLinePointTwo, stLinePointTwo, canvasOrthoVectorFromCenter);
 
-      math.vec2.liangBarksyClip(stLinePointOne, stLinePointTwo, canvasBox);
+      liangBarksyClip(stLinePointOne, stLinePointTwo, canvasBox);
 
       const stLinePointThree = vec2.create();
       vec2.add(
@@ -1042,7 +1042,7 @@ class CrosshairsTool extends AnnotationTool {
         canvasOrthoVectorFromCenter
       );
 
-      math.vec2.liangBarksyClip(stLinePointThree, stLinePointFour, canvasBox);
+      liangBarksyClip(stLinePointThree, stLinePointFour, canvasBox);
 
       // points for slab thickness handles
       const stHandleOne = vec2.create();


### PR DESCRIPTION
Hi,

Working on using cornerstone3d in a [Vite](https://vitejs.dev/) project, ran into an issue when running the project.
I think I have narrowed it down to a possibly circular dependency in [packages/tools/src/tools/CrosshairsTool.ts](https://github.com/cornerstonejs/cornerstone3D-beta/blob/main/packages/tools/src/tools/CrosshairsTool.ts) when importing `liangBarksyClip`
Happy to provide an example minimal repository with the error to verify.

Console error
```
cornerstonejs.bd843ac7.js:18089 Uncaught ReferenceError: Cannot access 'index' before initialization
    at cornerstonejs.bd843ac7.js:18089:29
```
with `index` being 
```
...
const { RENDERING_DEFAULTS } = CONSTANTS;
const { liangBarksyClip } = index;
function defaultReferenceLineColor() {
  return "rgb(0, 200, 0)";
}
...
```