### PR TITLE
fix: AngleTool not working after cancellation

### DIFF
--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -462,6 +462,7 @@ class AngleTool extends AnnotationTool {
       }
 
       this.editData = null;
+      this.angleStartedNotYetCompleted = false;
       return annotation.annotationUID;
     }
   };


### PR DESCRIPTION
AngleTool will be broken after annotation cancellation, because it tries to get the `annotationId` of a non-existing annotation.

Fixed this issue by setting `angleStartedNotYetCompleted` to false upon cancellation.