### PR TITLE
fix: colored images using rgba in CPU rendering #338

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1517,7 +1517,7 @@ class StackViewport extends Viewport implements IStackViewport {
         preScale: {
           enabled: true,
         },
-        useRGBA: false,
+        useRGBA: true,
       };
 
       imageLoadPoolManager.addRequest(


### PR DESCRIPTION
flip the useRGBA in StackViewport to true in the CPU path as discussed here: https://github.com/cornerstonejs/cornerstone3D-beta/issues/338
