### PR TITLE
feat: option to use Arraybuffer for volume loader instead of sharedArrayBuffer

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -477,7 +477,8 @@ declare namespace Enums {
         InterpolationType,
         RequestType,
         ViewportType,
-        OrientationAxis
+        OrientationAxis,
+        SharedArrayBufferModes
     }
 }
 export { Enums }
@@ -636,6 +637,9 @@ function getRuntimeId(context?: unknown, separator?: string, max?: number): stri
 
 // @public (undocumented)
 export function getShouldUseCPURendering(): boolean;
+
+// @public (undocumented)
+export function getShouldUseSharedArrayBuffer(): boolean;
 
 // @public (undocumented)
 function getSliceRange(volumeActor: VolumeActor, viewPlaneNormal: Point3, focalPoint: Point3): ActorSliceRange;
@@ -1719,6 +1723,9 @@ enum RequestType {
 export function resetUseCPURendering(): void;
 
 // @public (undocumented)
+export function resetUseSharedArrayBuffer(): void;
+
+// @public (undocumented)
 function scaleRGBTransferFunction(rgbTransferFunction: any, scalingFactor: number): void;
 
 // @public (undocumented)
@@ -1769,7 +1776,20 @@ export class Settings {
 export function setUseCPURendering(status: boolean): void;
 
 // @public (undocumented)
+export function setUseSharedArrayBuffer(mode: SharedArrayBufferModes | boolean): void;
+
+// @public (undocumented)
 export function setVolumesForViewports(renderingEngine: IRenderingEngine, volumeInputs: Array<IVolumeInput>, viewportIds: Array<string>, immediateRender?: boolean, suppressEvents?: boolean): Promise<void>;
+
+// @public (undocumented)
+enum SharedArrayBufferModes {
+    // (undocumented)
+    AUTO = "auto",
+    // (undocumented)
+    FALSE = "false",
+    // (undocumented)
+    TRUE = "true"
+}
 
 // @public (undocumented)
 function snapFocalPointToSlice(focalPoint: Point3, position: Point3, sliceRange: ActorSliceRange, viewPlaneNormal: Point3, spacingInNormalDirection: number, deltaFrames: number): {

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1147,6 +1147,15 @@ type ScalingParameters = {
 };
 
 // @public
+enum SharedArrayBufferModes {
+    AUTO = 'auto',
+    // (undocumented)
+    FALSE = 'false',
+    // (undocumented)
+    TRUE = 'true',
+}
+
+// @public
 type StackNewImageEvent = CustomEvent_2<StackNewImageEventDetail>;
 
 // @public
@@ -1207,7 +1216,7 @@ export class StreamingImageVolume extends ImageVolume {
         imageIdIndex: number;
         options: {
             targetBuffer: {
-                arrayBuffer: ArrayBufferLike;
+                arrayBuffer: SharedArrayBuffer;
                 offset: number;
                 length: number;
                 type: any;

--- a/packages/core/src/enums/SharedArrayBufferModes.ts
+++ b/packages/core/src/enums/SharedArrayBufferModes.ts
@@ -1,0 +1,11 @@
+/**
+ * SharedArrayBuffer Modes
+ */
+enum SharedArrayBufferModes {
+  TRUE = 'true',
+  FALSE = 'false',
+  /** use SharedArrayBuffer if avalaible  */
+  AUTO = 'auto',
+}
+
+export default SharedArrayBufferModes;

--- a/packages/core/src/enums/index.ts
+++ b/packages/core/src/enums/index.ts
@@ -4,6 +4,7 @@ import ViewportType from './ViewportType';
 import InterpolationType from './InterpolationType';
 import BlendModes from './BlendModes';
 import OrientationAxis from './OrientationAxis';
+import SharedArrayBufferModes from './SharedArrayBufferModes';
 
 export {
   Events,
@@ -12,4 +13,5 @@ export {
   RequestType,
   ViewportType,
   OrientationAxis,
+  SharedArrayBufferModes,
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,9 +29,12 @@ import * as metaData from './metaData';
 import {
   init,
   getShouldUseCPURendering,
+  getShouldUseSharedArrayBuffer,
   isCornerstoneInitialized,
   setUseCPURendering,
+  setUseSharedArrayBuffer,
   resetUseCPURendering,
+  resetUseSharedArrayBuffer,
 } from './init';
 
 // Classes
@@ -102,4 +105,8 @@ export {
   getShouldUseCPURendering,
   setUseCPURendering,
   resetUseCPURendering,
+  // SharedArrayBuffer
+  getShouldUseSharedArrayBuffer,
+  setUseSharedArrayBuffer,
+  resetUseSharedArrayBuffer,
 };

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -1,7 +1,9 @@
 import { getGPUTier } from 'detect-gpu';
-
+import { Enums } from '@cornerstonejs/core';
 let csRenderInitialized = false;
 let useCPURendering = false;
+let useSharedArrayBuffer = true;
+let sharedArrayBufferMode = Enums.SharedArrayBufferModes.TRUE;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/By_example/Detect_WebGL
 function hasActiveWebGLContext() {
@@ -19,6 +21,18 @@ function hasActiveWebGLContext() {
   }
 
   return false;
+}
+
+function hasSharedArrayBuffer() {
+  try {
+    if (new SharedArrayBuffer(0)) {
+      return true;
+    } else {
+      return false;
+    }
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -55,6 +69,9 @@ async function init(defaultConfiguration = {}): Promise<boolean> {
       console.log('CornerstoneRender: using GPU rendering');
     }
   }
+
+  setUseSharedArrayBuffer(sharedArrayBufferMode);
+
   csRenderInitialized = true;
   return csRenderInitialized;
 }
@@ -78,7 +95,7 @@ function setUseCPURendering(status: boolean): void {
  * @category Initialization
  *
  */
-function resetUseCPURendering() {
+function resetUseCPURendering(): void {
   useCPURendering = !hasActiveWebGLContext();
 }
 
@@ -90,6 +107,47 @@ function resetUseCPURendering() {
  */
 function getShouldUseCPURendering(): boolean {
   return useCPURendering;
+}
+
+function setUseSharedArrayBuffer(
+  mode: Enums.SharedArrayBufferModes | boolean
+): void {
+  if (mode == Enums.SharedArrayBufferModes.AUTO) {
+    sharedArrayBufferMode = Enums.SharedArrayBufferModes.AUTO;
+    const hasSharedBuffer = hasSharedArrayBuffer();
+    if (!hasSharedBuffer) {
+      useSharedArrayBuffer = false;
+      console.warn(
+        `CornerstoneRender: SharedArray Buffer not allowed, performance may be slower.
+        Try ensuring page is cross-origin isolated to enable SharedArrayBuffer.`
+      );
+    } else {
+      useSharedArrayBuffer = true;
+      // eslint-disable-next-line no-console
+      console.log('CornerstoneRender: using SharedArrayBuffer');
+    }
+    return;
+  }
+
+  if (mode == Enums.SharedArrayBufferModes.TRUE || mode == true) {
+    sharedArrayBufferMode = Enums.SharedArrayBufferModes.TRUE;
+    useSharedArrayBuffer = true;
+    return;
+  }
+
+  if (mode == Enums.SharedArrayBufferModes.FALSE || mode == false) {
+    sharedArrayBufferMode = Enums.SharedArrayBufferModes.FALSE;
+    useSharedArrayBuffer = false;
+    return;
+  }
+}
+
+function resetUseSharedArrayBuffer(): void {
+  setUseSharedArrayBuffer(sharedArrayBufferMode);
+}
+
+function getShouldUseSharedArrayBuffer(): boolean {
+  return useSharedArrayBuffer;
 }
 
 /**
@@ -106,7 +164,10 @@ function isCornerstoneInitialized(): boolean {
 export {
   init,
   getShouldUseCPURendering,
+  getShouldUseSharedArrayBuffer,
   isCornerstoneInitialized,
   setUseCPURendering,
+  setUseSharedArrayBuffer,
   resetUseCPURendering,
+  resetUseSharedArrayBuffer,
 };

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -1,9 +1,10 @@
 import { getGPUTier } from 'detect-gpu';
-import { Enums } from '@cornerstonejs/core';
+import { SharedArrayBufferModes } from './enums';
+
 let csRenderInitialized = false;
 let useCPURendering = false;
 let useSharedArrayBuffer = true;
-let sharedArrayBufferMode = Enums.SharedArrayBufferModes.TRUE;
+let sharedArrayBufferMode = SharedArrayBufferModes.TRUE;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/By_example/Detect_WebGL
 function hasActiveWebGLContext() {
@@ -109,11 +110,9 @@ function getShouldUseCPURendering(): boolean {
   return useCPURendering;
 }
 
-function setUseSharedArrayBuffer(
-  mode: Enums.SharedArrayBufferModes | boolean
-): void {
-  if (mode == Enums.SharedArrayBufferModes.AUTO) {
-    sharedArrayBufferMode = Enums.SharedArrayBufferModes.AUTO;
+function setUseSharedArrayBuffer(mode: SharedArrayBufferModes | boolean): void {
+  if (mode == SharedArrayBufferModes.AUTO) {
+    sharedArrayBufferMode = SharedArrayBufferModes.AUTO;
     const hasSharedBuffer = hasSharedArrayBuffer();
     if (!hasSharedBuffer) {
       useSharedArrayBuffer = false;
@@ -129,14 +128,14 @@ function setUseSharedArrayBuffer(
     return;
   }
 
-  if (mode == Enums.SharedArrayBufferModes.TRUE || mode == true) {
-    sharedArrayBufferMode = Enums.SharedArrayBufferModes.TRUE;
+  if (mode == SharedArrayBufferModes.TRUE || mode == true) {
+    sharedArrayBufferMode = SharedArrayBufferModes.TRUE;
     useSharedArrayBuffer = true;
     return;
   }
 
-  if (mode == Enums.SharedArrayBufferModes.FALSE || mode == false) {
-    sharedArrayBufferMode = Enums.SharedArrayBufferModes.FALSE;
+  if (mode == SharedArrayBufferModes.FALSE || mode == false) {
+    sharedArrayBufferMode = SharedArrayBufferModes.FALSE;
     useSharedArrayBuffer = false;
     return;
   }

--- a/packages/core/src/utilities/createFloat32SharedArray.ts
+++ b/packages/core/src/utilities/createFloat32SharedArray.ts
@@ -1,4 +1,5 @@
 import global from '../global';
+import { getShouldUseSharedArrayBuffer } from '../init';
 
 /**
  * A helper function that creates a new Float32Array that utilized a shared
@@ -25,7 +26,7 @@ import global from '../global';
  * @public
  */
 function createFloat32SharedArray(length: number): Float32Array {
-  if (!window.crossOriginIsolated) {
+  if (!getShouldUseSharedArrayBuffer()) {
     throw new Error(
       'Your page is NOT cross-origin isolated, see https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated'
     );

--- a/packages/core/src/utilities/createUint8SharedArray.ts
+++ b/packages/core/src/utilities/createUint8SharedArray.ts
@@ -1,4 +1,6 @@
 import global from '../global';
+import { getShouldUseSharedArrayBuffer } from '../init';
+
 /**
  * A helper function that creates a new Float32Array that utilized a shared
  * array buffer. This allows the array to be updated  simultaneously in
@@ -24,7 +26,7 @@ import global from '../global';
  * @public
  */
 function createUint8SharedArray(length: number): Uint8Array {
-  if (!window.crossOriginIsolated) {
+  if (!getShouldUseSharedArrayBuffer()) {
     throw new Error(
       'Your page is NOT cross-origin isolated, see https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated'
     );

--- a/packages/streaming-image-volume-loader/src/StreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/StreamingImageVolume.ts
@@ -384,6 +384,33 @@ export default class StreamingImageVolume extends ImageVolume {
       triggerEvent(eventTarget, Enums.Events.IMAGE_LOAD_ERROR, eventDetail);
     }
 
+    function handleArrayBufferLoad(scalarData, image, options) {
+      if (scalarData.buffer instanceof ArrayBuffer) {
+        const offset = options.targetBuffer.offset; // in bytes
+        const length = options.targetBuffer.length; // in frames
+        try {
+          if (scalarData instanceof Float32Array) {
+            const bytesInFloat = 4;
+            const floatView = new Float32Array(image.pixelData);
+            if (floatView.length !== length) {
+              throw 'Error pixelData length does not match frame length';
+            }
+            scalarData.set(floatView, offset / bytesInFloat);
+          }
+          if (scalarData instanceof Uint8Array) {
+            const bytesInUint8 = 1;
+            const intView = new Uint8Array(image.pixelData);
+            if (intView.length !== length) {
+              throw 'Error pixelData length does not match frame length';
+            }
+            scalarData.set(intView, offset / bytesInUint8);
+          }
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    }
+
     const requests = imageIds.map((imageId, imageIdIndex) => {
       if (cachedFrames[imageIdIndex]) {
         framesLoaded++;
@@ -415,7 +442,13 @@ export default class StreamingImageVolume extends ImageVolume {
       const options = {
         // WADO Image Loader
         targetBuffer: {
-          arrayBuffer,
+          // keeping this in the options means a large empty volume array buffer
+          // will be transferred to the worker. This is undesirable for streaming
+          // volume without shared array buffer because the target is now an empty
+          // 300-500MB volume array buffer. Instead the volume should be progressively
+          // set in the main thread.
+          arrayBuffer:
+            arrayBuffer instanceof ArrayBuffer ? undefined : arrayBuffer,
           offset: imageIdIndex * lengthInBytes,
           length,
           type,
@@ -434,7 +467,11 @@ export default class StreamingImageVolume extends ImageVolume {
       // when we load directly into the Volume cache
       function callLoadImage(imageId, imageIdIndex, options) {
         return imageLoader.loadImage(imageId, options).then(
-          () => {
+          (image) => {
+            // scalarData is the volume container we are progressively loading into
+            // image is the pixelData decoded from workers in cornerstoneWADOImageLoader
+            const scalarData = this.scalarData;
+            handleArrayBufferLoad(scalarData, image, options);
             successCallback(imageIdIndex, imageId, scalingParameters);
           },
           (error) => {

--- a/packages/streaming-image-volume-loader/src/StreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/StreamingImageVolume.ts
@@ -385,29 +385,31 @@ export default class StreamingImageVolume extends ImageVolume {
     }
 
     function handleArrayBufferLoad(scalarData, image, options) {
-      if (scalarData.buffer instanceof ArrayBuffer) {
-        const offset = options.targetBuffer.offset; // in bytes
-        const length = options.targetBuffer.length; // in frames
-        try {
-          if (scalarData instanceof Float32Array) {
-            const bytesInFloat = 4;
-            const floatView = new Float32Array(image.pixelData);
-            if (floatView.length !== length) {
-              throw 'Error pixelData length does not match frame length';
-            }
-            scalarData.set(floatView, offset / bytesInFloat);
+      if (!(scalarData.buffer instanceof ArrayBuffer)) {
+        return;
+      }
+
+      const offset = options.targetBuffer.offset; // in bytes
+      const length = options.targetBuffer.length; // in frames
+      try {
+        if (scalarData instanceof Float32Array) {
+          const bytesInFloat = 4;
+          const floatView = new Float32Array(image.pixelData);
+          if (floatView.length !== length) {
+            throw 'Error pixelData length does not match frame length';
           }
-          if (scalarData instanceof Uint8Array) {
-            const bytesInUint8 = 1;
-            const intView = new Uint8Array(image.pixelData);
-            if (intView.length !== length) {
-              throw 'Error pixelData length does not match frame length';
-            }
-            scalarData.set(intView, offset / bytesInUint8);
-          }
-        } catch (e) {
-          console.error(e);
+          scalarData.set(floatView, offset / bytesInFloat);
         }
+        if (scalarData instanceof Uint8Array) {
+          const bytesInUint8 = 1;
+          const intView = new Uint8Array(image.pixelData);
+          if (intView.length !== length) {
+            throw 'Error pixelData length does not match frame length';
+          }
+          scalarData.set(intView, offset / bytesInUint8);
+        }
+      } catch (e) {
+        console.error(e);
       }
     }
 

--- a/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
+++ b/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
@@ -4,6 +4,7 @@ import {
   Enums,
   imageLoader,
   imageLoadPoolManager,
+  getShouldUseSharedArrayBuffer,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 import { vec3 } from 'gl-matrix';
@@ -150,7 +151,7 @@ function cornerstoneStreamingImageVolumeLoader(
     cache.decacheIfNecessaryUntilBytesAvailable(sizeInBytes);
 
     let scalarData;
-
+    const useSharedArrayBuffer = getShouldUseSharedArrayBuffer();
     switch (BitsAllocated) {
       case 8:
         if (signed) {
@@ -158,25 +159,33 @@ function cornerstoneStreamingImageVolumeLoader(
             '8 Bit signed images are not yet supported by this plugin.'
           );
         } else {
-          scalarData = createUint8SharedArray(
-            dimensions[0] * dimensions[1] * dimensions[2]
-          );
+          scalarData = useSharedArrayBuffer
+            ? createUint8SharedArray(
+                dimensions[0] * dimensions[1] * dimensions[2]
+              )
+            : new Uint8Array(dimensions[0] * dimensions[1] * dimensions[2]);
         }
 
         break;
 
       case 16:
-        scalarData = createFloat32SharedArray(
-          dimensions[0] * dimensions[1] * dimensions[2]
-        );
+        scalarData = useSharedArrayBuffer
+          ? createFloat32SharedArray(
+              dimensions[0] * dimensions[1] * dimensions[2]
+            )
+          : new Float32Array(dimensions[0] * dimensions[1] * dimensions[2]);
 
         break;
 
       case 24:
         // hacky because we don't support alpha channel in dicom
-        scalarData = createUint8SharedArray(
-          dimensions[0] * dimensions[1] * dimensions[2] * numComponents
-        );
+        scalarData = useSharedArrayBuffer
+          ? createUint8SharedArray(
+              dimensions[0] * dimensions[1] * dimensions[2] * numComponents
+            )
+          : new Uint8Array(
+              dimensions[0] * dimensions[1] * dimensions[2] * numComponents
+            );
 
         break;
     }

--- a/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
+++ b/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
@@ -150,8 +150,10 @@ function cornerstoneStreamingImageVolumeLoader(
 
     cache.decacheIfNecessaryUntilBytesAvailable(sizeInBytes);
 
-    let scalarData;
     const useSharedArrayBuffer = getShouldUseSharedArrayBuffer();
+    const length = dimensions[0] * dimensions[1] * dimensions[2];
+
+    let scalarData;
     switch (BitsAllocated) {
       case 8:
         if (signed) {
@@ -160,37 +162,29 @@ function cornerstoneStreamingImageVolumeLoader(
           );
         } else {
           scalarData = useSharedArrayBuffer
-            ? createUint8SharedArray(
-                dimensions[0] * dimensions[1] * dimensions[2]
-              )
-            : new Uint8Array(dimensions[0] * dimensions[1] * dimensions[2]);
+            ? createUint8SharedArray(length)
+            : new Uint8Array(length);
         }
 
         break;
 
       case 16:
         scalarData = useSharedArrayBuffer
-          ? createFloat32SharedArray(
-              dimensions[0] * dimensions[1] * dimensions[2]
-            )
-          : new Float32Array(dimensions[0] * dimensions[1] * dimensions[2]);
+          ? createFloat32SharedArray(length)
+          : new Float32Array(length);
 
         break;
 
       case 24:
         // hacky because we don't support alpha channel in dicom
         scalarData = useSharedArrayBuffer
-          ? createUint8SharedArray(
-              dimensions[0] * dimensions[1] * dimensions[2] * numComponents
-            )
-          : new Uint8Array(
-              dimensions[0] * dimensions[1] * dimensions[2] * numComponents
-            );
+          ? createUint8SharedArray(length * numComponents)
+          : new Uint8Array(length * numComponents);
 
         break;
     }
 
-    let streamingImageVolume = new StreamingImageVolume(
+    const streamingImageVolume = new StreamingImageVolume(
       // ImageVolume properties
       {
         volumeId,

--- a/packages/streaming-image-volume-loader/test/StreamingImageVolume_test.js
+++ b/packages/streaming-image-volume-loader/test/StreamingImageVolume_test.js
@@ -27,17 +27,12 @@ const fakeSharedBufferImageLoader = (imageId, options) => {
     pixelData[i] = Number(imageIdNumber);
   }
 
-  // If we have a target buffer, write to that instead. This helps reduce memory duplication.
-  const { arrayBuffer, offset, length } = options.targetBuffer;
-
-  const typedArray = new Uint8Array(arrayBuffer, offset, length);
-
-  // TypedArray.Set is api level and ~50x faster than copying elements even for
-  // Arrays of different types, which aren't simply memcpy ops.
-  typedArray.set(pixelData, 0);
+  const image = {
+    pixelData,
+  };
 
   return {
-    promise: Promise.resolve(undefined),
+    promise: Promise.resolve(image),
   };
 };
 

--- a/utils/ExampleRunner/example-runner-cli.js
+++ b/utils/ExampleRunner/example-runner-cli.js
@@ -179,7 +179,7 @@ if (configuration.examples) {
     // console.log('conf', conf);
     shell.ShellString(conf).to(webpackConfigPath);
     shell.cd(exBasePath);
-    shell.exec(`webpack serve --progress --config ${webpackConfigPath}`);
+    shell.exec(`webpack serve --host 0.0.0.0 --progress --config ${webpackConfigPath}`);
   } else {
     console.log('=> To run an example:');
     console.log('  $ npm run example -- PUT_YOUR_EXAMPLE_NAME_HERE\n');


### PR DESCRIPTION
This feature allows for volumes to be loaded even if the page is not cross origin isolated.
For some use cases such as running cornerstone3D in cordova or mobile webview this is required.