### PR TITLE
fix(StackViewport): Reset camera bug when rotation happens on StackViewport

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -181,14 +181,14 @@ class StackViewport extends Viewport implements IStackViewport {
       renderer.setActiveCamera(camera);
 
       const viewPlaneNormal = <Point3>[0, 0, -1];
-      const viewUp = <Point3>[0, -1, 0];
+      this.initialViewUp = <Point3>[0, -1, 0];
 
       camera.setDirectionOfProjection(
         -viewPlaneNormal[0],
         -viewPlaneNormal[1],
         -viewPlaneNormal[2]
       );
-      camera.setViewUp(...viewUp);
+      camera.setViewUp(...this.initialViewUp);
       camera.setParallelProjection(true);
       camera.setThicknessFromFocalPoint(0.1);
       // @ts-ignore: vtkjs incorrect typing
@@ -1889,14 +1889,13 @@ class StackViewport extends Viewport implements IStackViewport {
     // Todo: we need to make the rotation a camera properties so that
     // we can reset it there, right now it is not possible to reset the rotation
     // without this
-    if (this.initialViewUp) {
-      // We do not know the ordering of various flips and rotations that have been applied, so just start like we were at the beginning.
-      this.setCamera({
-        flipHorizontal: false,
-        flipVertical: false,
-        viewUp: this.initialViewUp,
-      });
-    }
+
+    // We do not know the ordering of various flips and rotations that have been applied, so just start like we were at the beginning.
+    this.setCamera({
+      flipHorizontal: false,
+      flipVertical: false,
+      viewUp: this.initialViewUp,
+    });
 
     // For stack Viewport we since we have only one slice
     // it should be enough to reset the camera to the center of the image

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -155,6 +155,9 @@ class StackViewport extends Viewport implements IStackViewport {
   public modality: string; // this is needed for tools
   public scaling: Scaling;
 
+  // Camera properties
+  private initialViewUp: Point3;
+
   /**
    * Constructor for the StackViewport class
    * @param props - ViewportInput
@@ -1748,6 +1751,9 @@ class StackViewport extends Viewport implements IStackViewport {
 
     this.setCameraNoEvent({ viewUp, viewPlaneNormal });
 
+    // Setting this makes the following comment about resetCameraNoEvent not modifying viewUp true.
+    this.initialViewUp = viewUp;
+
     // Reset the camera to point to the new slice location, reset camera doesn't
     // modify the direction of projection and viewUp
     this.resetCameraNoEvent();
@@ -1880,12 +1886,17 @@ class StackViewport extends Viewport implements IStackViewport {
   }
 
   private resetCameraGPU(resetPan, resetZoom): boolean {
-    // We do not know the ordering of various flips and rotations that have been applied, so just start like we were at the beginning.
-    this.setCamera({
-      flipHorizontal: false,
-      flipVertical: false,
-      viewUp: <Point3>[0, -1, 0],
-    });
+    // Todo: we need to make the rotation a camera properties so that
+    // we can reset it there, right now it is not possible to reset the rotation
+    // without this
+    if (this.initialViewUp) {
+      // We do not know the ordering of various flips and rotations that have been applied, so just start like we were at the beginning.
+      this.setCamera({
+        flipHorizontal: false,
+        flipVertical: false,
+        viewUp: this.initialViewUp,
+      });
+    }
 
     // For stack Viewport we since we have only one slice
     // it should be enough to reset the camera to the center of the image

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1880,10 +1880,12 @@ class StackViewport extends Viewport implements IStackViewport {
   }
 
   private resetCameraGPU(resetPan, resetZoom): boolean {
-    // Todo: we need to make the rotation a camera properties so that
-    // we can reset it there, right now it is not possible to reset the rotation
-    // without this
-    this.getVtkActiveCamera().roll(this.rotationCache);
+    // We do not know the ordering of various flips and rotations that have been applied, so just start like we were at the beginning.
+    this.setCamera({
+      flipHorizontal: false,
+      flipVertical: false,
+      viewUp: <Point3>[0, -1, 0],
+    });
 
     // For stack Viewport we since we have only one slice
     // it should be enough to reset the camera to the center of the image


### PR DESCRIPTION
For a GPU reset, start by resetting the flips and rotation (via viewUp) because the ordering of the various flips and rotations that have been applied is not known.