### PR TITLE
feat(ScaleOverlayTool): Add scale overlay tool

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -4038,6 +4038,7 @@ interface ScaleOverlayAnnotation extends Annotation {
         handles: {
             points: Types_2.Point3[];
         };
+        viewportId: string;
     };
 }
 
@@ -4052,7 +4053,7 @@ export class ScaleOverlayTool extends AnnotationDisplayTool {
         endTick2: any[][];
     };
     // (undocumented)
-    computeInnerScaleTicks: (scaleSize: any, location: any, annotationUID: any, leftTick: any, rightTick: any) => {
+    computeInnerScaleTicks: (scaleSize: number, location: string, annotationUID: string, leftTick: any[][], rightTick: any[][]) => {
         tickIds: any[];
         tickUIDs: any[];
         tickCoordinates: any[];
@@ -4065,7 +4066,7 @@ export class ScaleOverlayTool extends AnnotationDisplayTool {
     // (undocumented)
     computeScaleSize: (worldWidthViewport: number, worldHeightViewport: number, location: any) => any;
     // (undocumented)
-    computeWorldScaleCoordinates: (scaleSize: any, location: any, topRight: any, pointSet: any) => any;
+    computeWorldScaleCoordinates: (scaleSize: any, location: any, pointSet: any) => any;
     // (undocumented)
     editData: {
         renderingEngine: any;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -4032,6 +4032,71 @@ type RepresentationPublicInput = {
 function resetElementCursor(element: HTMLDivElement): void;
 
 // @public (undocumented)
+interface ScaleOverlayAnnotation extends Annotation {
+    // (undocumented)
+    data: {
+        handles: {
+            points: Types_2.Point3[];
+        };
+    };
+}
+
+// @public (undocumented)
+export class ScaleOverlayTool extends AnnotationDisplayTool {
+    constructor(toolProps?: PublicToolProps, defaultToolProps?: ToolProps);
+    // (undocumented)
+    computeCanvasScaleCoordinates: (canvasSize: any, canvasCoordinates: any, vscaleBounds: any, hscaleBounds: any, location: any) => any;
+    // (undocumented)
+    computeEndScaleTicks: (canvasCoordinates: any, location: any) => {
+        endTick1: any[][];
+        endTick2: any[][];
+    };
+    // (undocumented)
+    computeInnerScaleTicks: (scaleSize: any, location: any, annotationUID: any, leftTick: any, rightTick: any) => {
+        tickIds: any[];
+        tickUIDs: any[];
+        tickCoordinates: any[];
+    };
+    // (undocumented)
+    computeScaleBounds: (canvasSize: any, horizontalReduction: any, verticalReduction: any, location: any) => {
+        height: any;
+        width: any;
+    };
+    // (undocumented)
+    computeScaleSize: (worldWidthViewport: number, worldHeightViewport: number, location: any) => any;
+    // (undocumented)
+    computeWorldScaleCoordinates: (scaleSize: any, location: any, topRight: any, pointSet: any) => any;
+    // (undocumented)
+    editData: {
+        renderingEngine: any;
+        viewport: any;
+        annotation: ScaleOverlayAnnotation;
+    } | null;
+    // (undocumented)
+    _getTextLines(scaleSize: number): string[] | undefined;
+    // (undocumented)
+    _init: () => void;
+    // (undocumented)
+    isDrawing: boolean;
+    // (undocumented)
+    isHandleOutsideImage: boolean;
+    // (undocumented)
+    mouseDragCallback: any;
+    // (undocumented)
+    onCameraModified: (evt: Types_2.EventTypes.CameraModifiedEvent) => void;
+    // (undocumented)
+    onSetToolEnabled: () => void;
+    // (undocumented)
+    renderAnnotation(enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper): boolean;
+    // (undocumented)
+    _throttledCalculateCachedStats: any;
+    // (undocumented)
+    static toolName: any;
+    // (undocumented)
+    touchDragCallback: any;
+}
+
+// @public (undocumented)
 type Scaling = {
     PET?: PTScaling;
 };
@@ -4715,7 +4780,8 @@ declare namespace ToolSpecificAnnotationTypes {
         ArrowAnnotation,
         AngleAnnotation,
         ReferenceCursor,
-        ReferenceLineAnnotation
+        ReferenceLineAnnotation,
+        ScaleOverlayAnnotation
     }
 }
 

--- a/packages/tools/examples/scaleOverlayTool/index.ts
+++ b/packages/tools/examples/scaleOverlayTool/index.ts
@@ -45,7 +45,7 @@ content.appendChild(element);
 
 const instructions = document.createElement('p');
 instructions.innerText =
-  'Left Click: Window/Level\nRight Click: Zoom\n Mouse Wheel: Stack Scroll';
+  'Left Click: Length Tool\nRight Click: Zoom\n Mouse Wheel: Stack Scroll';
 
 content.append(instructions);
 // ============================= //
@@ -89,7 +89,6 @@ async function run() {
   cornerstoneTools.addTool(StackScrollMouseWheelTool);
 
   // Create a stack viewport
-  // const viewportId = 'CT_STACK';
   // Define a tool group, which defines how mouse events map to tool commands for
   // Any viewport using the group
   toolGroup = ToolGroupManager.createToolGroup(toolGroupId);

--- a/packages/tools/examples/scaleOverlayTool/index.ts
+++ b/packages/tools/examples/scaleOverlayTool/index.ts
@@ -1,0 +1,170 @@
+import { Types, Enums, RenderingEngine } from '@cornerstonejs/core';
+import {
+  initDemo,
+  createImageIdsAndCacheMetaData,
+  setTitleAndDescription,
+  addDropdownToToolbar,
+} from '../../../../utils/demo/helpers';
+import * as cornerstoneTools from '@cornerstonejs/tools';
+
+// This is for debugging purposes
+console.warn(
+  'Click on index.ts to open source code for this example --------->'
+);
+
+const {
+  PanTool,
+  ZoomTool,
+  ToolGroupManager,
+  ScaleOverlayTool,
+  LengthTool,
+  StackScrollMouseWheelTool,
+  Enums: csToolsEnums,
+} = cornerstoneTools;
+
+const { ViewportType } = Enums;
+const { MouseBindings } = csToolsEnums;
+
+// ======== Set up page ======== //
+setTitleAndDescription(
+  'Scale Overlay Tool',
+  'Set scale location using dropdown menu, zoom by holding right mouse down'
+);
+
+const content = document.getElementById('content');
+const element = document.createElement('div');
+
+// Disable right click context menu so we can have right click tools
+element.oncontextmenu = (e) => e.preventDefault();
+
+element.id = 'cornerstone-element';
+element.style.width = '500px';
+element.style.height = '500px';
+
+content.appendChild(element);
+
+const instructions = document.createElement('p');
+instructions.innerText =
+  'Left Click: Window/Level\nRight Click: Zoom\n Mouse Wheel: Stack Scroll';
+
+content.append(instructions);
+// ============================= //
+
+const toolGroupId = 'STACK_TOOL_GROUP_ID';
+
+// add dropdown tool bar to select scale location
+const scaleLocations = ['bottom', 'top', 'left', 'right'];
+let currentScaleLocation = scaleLocations[0];
+let toolGroup;
+
+addDropdownToToolbar({
+  options: { values: scaleLocations, defaultValue: scaleLocations[0] },
+  onSelectedValueChange: (newSelectedScaleLocation) => {
+    currentScaleLocation = newSelectedScaleLocation as string;
+
+    toolGroup.setToolConfiguration(
+      ScaleOverlayTool.toolName,
+      {
+        scaleLocation: currentScaleLocation,
+      },
+      true //overwrite
+    );
+
+    toolGroup.setToolEnabled(ScaleOverlayTool.toolName);
+  },
+});
+
+/**
+ * Runs the demo
+ */
+async function run() {
+  // Init Cornerstone and related libraries
+  await initDemo();
+
+  // Add tools to Cornerstone3D
+  cornerstoneTools.addTool(PanTool);
+  cornerstoneTools.addTool(ZoomTool);
+  cornerstoneTools.addTool(ScaleOverlayTool);
+  cornerstoneTools.addTool(LengthTool);
+  cornerstoneTools.addTool(StackScrollMouseWheelTool);
+
+  // Create a stack viewport
+  // const viewportId = 'CT_STACK';
+  // Define a tool group, which defines how mouse events map to tool commands for
+  // Any viewport using the group
+  toolGroup = ToolGroupManager.createToolGroup(toolGroupId);
+
+  // Add the tools to the tool group, TODO: add scaleOverlayTool
+  toolGroup.addTool(PanTool.toolName);
+  toolGroup.addTool(ZoomTool.toolName);
+  toolGroup.addTool(LengthTool.toolName);
+  toolGroup.addTool(StackScrollMouseWheelTool.toolName);
+  toolGroup.addTool(ScaleOverlayTool.toolName);
+
+  // Set the initial state of the tools, here we set one tool active on left click.
+  // This means left click will draw that tool.
+
+  toolGroup.setToolActive(LengthTool.toolName, {
+    bindings: [
+      {
+        mouseButton: MouseBindings.Primary, // Left click
+      },
+    ],
+  });
+
+  toolGroup.setToolActive(ZoomTool.toolName, {
+    bindings: [
+      {
+        mouseButton: MouseBindings.Secondary, //
+      },
+    ],
+  });
+
+  toolGroup.setToolActive(StackScrollMouseWheelTool.toolName);
+
+  toolGroup.setToolEnabled(ScaleOverlayTool.toolName);
+
+  // Get Cornerstone imageIds and fetch metadata into RAM
+  const imageIds = await createImageIdsAndCacheMetaData({
+    StudyInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7311.5101.158323547117540061132729905711',
+    SeriesInstanceUID:
+      '1.3.6.1.4.1.14519.5.2.1.7311.5101.250911858840767891342974687368',
+    wadoRsRoot: 'https://domvja9iplmyu.cloudfront.net/dicomweb',
+  });
+
+  // Instantiate a rendering engine
+  const renderingEngineId = 'myRenderingEngine';
+  const renderingEngine = new RenderingEngine(renderingEngineId);
+
+  const viewportId = 'CT_STACK';
+  const viewportInput = {
+    viewportId,
+    type: ViewportType.STACK,
+    element,
+    defaultOptions: {
+      background: <Types.Point3>[0.2, 0, 0.2],
+    },
+  };
+
+  renderingEngine.enableElement(viewportInput);
+
+  // Set the tool group on the viewport
+  toolGroup.addViewport(viewportId, renderingEngineId);
+
+  // Get the stack viewport that was created
+  const viewport = <Types.IStackViewport>(
+    renderingEngine.getViewport(viewportId)
+  );
+
+  // Define a stack containing a single image
+  const stack = [imageIds[0], imageIds[1], imageIds[2]];
+
+  // Set the stack on the viewport
+  viewport.setStack(stack);
+
+  // Render the image
+  viewport.render();
+}
+
+run();

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -54,6 +54,7 @@ import {
   ReferenceCursors,
   ReferenceLines,
   PaintFillTool,
+  ScaleOverlayTool,
 } from './tools';
 
 import * as Enums from './enums';
@@ -93,6 +94,7 @@ export {
   MagnifyTool,
   ReferenceCursors,
   ReferenceLines,
+  ScaleOverlayTool,
   // Segmentation Display
   SegmentationDisplayTool,
   // Segmentation Editing Tools

--- a/packages/tools/src/tools/ScaleOverlayTool.ts
+++ b/packages/tools/src/tools/ScaleOverlayTool.ts
@@ -126,7 +126,7 @@ class ScaleOverlayTool extends AnnotationDisplayTool {
   onCameraModified = (evt: Types.EventTypes.CameraModifiedEvent): void => {
     // If the camera is modified, we need to update the viewport
     // that the camera was modified on
-    this.configuration.viewportId = evt.target.dataset.viewportUid;
+    this.configuration.viewportId = evt.detail.viewportId;
     this._init();
   };
 

--- a/packages/tools/src/tools/ScaleOverlayTool.ts
+++ b/packages/tools/src/tools/ScaleOverlayTool.ts
@@ -148,8 +148,6 @@ class ScaleOverlayTool extends AnnotationDisplayTool {
     }
     const location = this.configuration.scaleLocation;
     const { annotation, viewport } = this.editData;
-    const image = viewport.getImageData();
-    const imageId = viewport.getCurrentImageId();
     const canvas = enabledElement.viewport.canvas;
 
     const renderStatus = false;
@@ -163,26 +161,6 @@ class ScaleOverlayTool extends AnnotationDisplayTool {
       toolName: this.getToolName(),
       viewportId: enabledElement.viewport.id,
     };
-
-    let rowPixelSpacing = image.spacing[0];
-    let colPixelSpacing = image.spacing[1];
-    const imagePlane = metaData.get('imagePlaneModule', imageId);
-
-    // if imagePlane exists, set row and col pixel spacing
-    if (imagePlane) {
-      rowPixelSpacing =
-        imagePlane.rowPixelSpacing || imagePlane.rowImagePixelSpacing;
-      colPixelSpacing =
-        imagePlane.columnPixelSpacing || imagePlane.colImagePixelSpacing;
-    }
-
-    // Check whether pixel spacing is defined
-    if (!rowPixelSpacing || !colPixelSpacing) {
-      console.warn(
-        `Unable to define rowPixelSpacing or colPixelSpacing from data on ScaleOverlayTool's renderAnnotation`
-      );
-      return;
-    }
 
     const canvasSize = {
       width: canvas.width,
@@ -458,11 +436,11 @@ class ScaleOverlayTool extends AnnotationDisplayTool {
   };
 
   computeInnerScaleTicks = (
-    scaleSize,
-    location,
-    annotationUID,
-    leftTick,
-    rightTick
+    scaleSize: number,
+    location: string,
+    annotationUID: string,
+    leftTick: any[][],
+    rightTick: any[][]
   ) => {
     let canvasScaleSize;
     if (location == 'bottom' || location == 'top') {

--- a/packages/tools/src/tools/ScaleOverlayTool.ts
+++ b/packages/tools/src/tools/ScaleOverlayTool.ts
@@ -384,7 +384,9 @@ class ScaleOverlayTool extends AnnotationDisplayTool {
     worldHeightViewport: number,
     location: any
   ) => {
-    const scaleSizes = [2000, 1000, 500, 250, 100, 50, 25, 10, 5];
+    const scaleSizes = [
+      16000, 8000, 4000, 2000, 1000, 500, 250, 100, 50, 25, 10, 5, 2,
+    ];
     let currentScaleSize;
     if (location == 'top' || location == 'bottom') {
       currentScaleSize = scaleSizes.filter(

--- a/packages/tools/src/tools/ScaleOverlayTool.ts
+++ b/packages/tools/src/tools/ScaleOverlayTool.ts
@@ -1,0 +1,664 @@
+import AnnotationDisplayTool from './base/AnnotationDisplayTool';
+import { vec3 } from 'gl-matrix';
+import {
+  metaData,
+  getRenderingEngines,
+  utilities as csUtils,
+} from '@cornerstonejs/core';
+import { ScaleOverlayAnnotation } from '../types/ToolSpecificAnnotationTypes';
+import type { Types } from '@cornerstonejs/core';
+import { filterViewportsWithToolEnabled } from '../utilities/viewportFilters';
+import { addAnnotation } from '../stateManagement/annotation/annotationState';
+import {
+  drawLine as drawLineSvg,
+  drawTextBox as drawTextBoxSvg,
+} from '../drawingSvg';
+import {
+  EventTypes,
+  PublicToolProps,
+  ToolProps,
+  SVGDrawingHelper,
+} from '../types';
+import { StyleSpecifier } from '../types/AnnotationStyle';
+
+const SCALEOVERLAYTOOL_ID = 'scaleoverlay-viewport';
+
+/**
+ * @public
+ * @class ScaleOverlayTool
+ * @memberof Tools
+ *
+ * @classdesc Tool for displaying a scale overlay on the image.
+ * @extends Tools.Base.BaseTool
+ */
+class ScaleOverlayTool extends AnnotationDisplayTool {
+  static toolName;
+
+  public touchDragCallback: any;
+  public mouseDragCallback: any;
+  _throttledCalculateCachedStats: any;
+  editData: {
+    renderingEngine: any;
+    viewport: any;
+    annotation: ScaleOverlayAnnotation;
+  } | null = {} as any;
+  isDrawing: boolean;
+  isHandleOutsideImage: boolean;
+
+  constructor(
+    toolProps: PublicToolProps = {},
+    defaultToolProps: ToolProps = {
+      configuration: {
+        viewportId: '',
+        scaleLocation: 'bottom',
+        scaleColor: 'yellow',
+      },
+    }
+  ) {
+    super(toolProps, defaultToolProps);
+  }
+
+  _init = (): void => {
+    const renderingEngines = getRenderingEngines();
+    const renderingEngine = renderingEngines[0];
+
+    if (!renderingEngine) {
+      return;
+    }
+
+    let viewports = renderingEngine.getViewports();
+    viewports = filterViewportsWithToolEnabled(viewports, this.getToolName());
+
+    let viewport = viewports[0];
+
+    if (this.configuration.viewportId) {
+      viewport = viewports.find(
+        (viewportId) => viewportId.id === this.configuration.viewportId
+      );
+    }
+
+    if (!viewport) {
+      return;
+    }
+
+    const { element } = viewport;
+    const { viewUp, viewPlaneNormal } = viewport.getCamera();
+
+    const viewportCanvasCornersInWorld =
+      csUtils.getViewportImageCornersInWorld(viewport);
+
+    let annotation = this.editData.annotation;
+
+    if (!annotation) {
+      const newAnnotation: ScaleOverlayAnnotation = {
+        metadata: {
+          toolName: this.getToolName(),
+          viewPlaneNormal: <Types.Point3>[...viewPlaneNormal],
+          viewUp: <Types.Point3>[...viewUp],
+          FrameOfReferenceUID: viewport.getFrameOfReferenceUID(),
+          referencedImageId: null,
+        },
+        data: {
+          handles: {
+            points: viewportCanvasCornersInWorld,
+          },
+        },
+      };
+
+      addAnnotation(element, newAnnotation);
+      annotation = newAnnotation;
+    } else {
+      this.editData.annotation.data.handles.points =
+        viewportCanvasCornersInWorld;
+    }
+
+    this.editData = {
+      viewport,
+      renderingEngine,
+      annotation,
+    };
+  };
+
+  onSetToolEnabled = (): void => {
+    this._init();
+  };
+
+  onCameraModified = (evt: Types.EventTypes.CameraModifiedEvent): void => {
+    // If the camera is modified, we need to update the viewport
+    // that the camera was modified on
+    this.configuration.viewportId = evt.target.dataset.viewportUid;
+    this._init();
+  };
+
+  /**
+   * Used to draw the scale annotation in each request animation
+   * frame.
+   *
+   * @param enabledElement - The Cornerstone's enabledElement.
+   * @param svgDrawingHelper - The svgDrawingHelper providing the context for drawing.
+   * @returns
+   */
+
+  renderAnnotation(
+    enabledElement: Types.IEnabledElement,
+    svgDrawingHelper: SVGDrawingHelper
+  ) {
+    if (!this.editData.viewport) {
+      return;
+    }
+    const location = this.configuration.scaleLocation;
+    const { annotation, viewport } = this.editData;
+    const image = viewport.getImageData();
+    const imageId = viewport.getCurrentImageId();
+    const canvas = enabledElement.viewport.canvas;
+
+    const renderStatus = false;
+
+    if (!viewport) {
+      return renderStatus;
+    }
+
+    const styleSpecifier: StyleSpecifier = {
+      toolGroupId: this.toolGroupId,
+      toolName: this.getToolName(),
+      viewportId: enabledElement.viewport.id,
+    };
+
+    let rowPixelSpacing = image.spacing[0];
+    let colPixelSpacing = image.spacing[1];
+    const imagePlane = metaData.get('imagePlaneModule', imageId);
+
+    // if imagePlane exists, set row and col pixel spacing
+    if (imagePlane) {
+      rowPixelSpacing =
+        imagePlane.rowPixelSpacing || imagePlane.rowImagePixelSpacing;
+      colPixelSpacing =
+        imagePlane.columnPixelSpacing || imagePlane.colImagePixelSpacing;
+    }
+
+    // Check whether pixel spacing is defined
+    if (!rowPixelSpacing || !colPixelSpacing) {
+      console.warn(
+        `Unable to define rowPixelSpacing or colPixelSpacing from data on ScaleOverlayTool's renderAnnotation`
+      );
+      return;
+    }
+
+    const canvasSize = {
+      width: canvas.width,
+      height: canvas.height,
+    };
+
+    const topLeft = annotation.data.handles.points[0];
+    const topRight = annotation.data.handles.points[1];
+    const bottomLeft = annotation.data.handles.points[2];
+    const bottomRight = annotation.data.handles.points[3];
+
+    const pointSet1 = [topLeft, bottomLeft, topRight, bottomRight];
+
+    const worldWidthViewport = vec3.distance(bottomLeft, bottomRight);
+    const worldHeightViewport = vec3.distance(topLeft, bottomLeft);
+
+    // 0.05 gives margin to horizontal and vertical lines
+    const hscaleBounds = this.computeScaleBounds(
+      canvasSize,
+      0.05,
+      0.05,
+      location
+    );
+
+    const vscaleBounds = this.computeScaleBounds(
+      canvasSize,
+      0.05,
+      0.05,
+      location
+    );
+
+    const scaleSize = this.computeScaleSize(
+      worldWidthViewport,
+      worldHeightViewport,
+      location
+    );
+
+    const canvasCoordinates = this.computeWorldScaleCoordinates(
+      scaleSize,
+      location,
+      topRight,
+      pointSet1
+    ).map((world) => viewport.worldToCanvas(world));
+
+    const scaleCanvasCoordinates = this.computeCanvasScaleCoordinates(
+      canvasSize,
+      canvasCoordinates,
+      vscaleBounds,
+      hscaleBounds,
+      location
+    );
+
+    const scaleTicks = this.computeEndScaleTicks(
+      scaleCanvasCoordinates,
+      location
+    );
+
+    const { annotationUID } = annotation;
+
+    styleSpecifier.annotationUID = annotationUID;
+    const lineWidth = this.getStyle('lineWidth', styleSpecifier, annotation);
+    const lineDash = this.getStyle('lineDash', styleSpecifier, annotation);
+    const color = this.getStyle('color', styleSpecifier, annotation);
+    const shadow = this.getStyle('shadow', styleSpecifier, annotation);
+
+    const scaleId = `${annotationUID}-scaleline`;
+    const scaleLineUID = '1';
+    drawLineSvg(
+      svgDrawingHelper,
+      annotationUID,
+      scaleLineUID,
+      scaleCanvasCoordinates[0],
+      scaleCanvasCoordinates[1],
+      {
+        color,
+        width: lineWidth,
+        lineDash,
+        shadow,
+      },
+      scaleId
+    );
+    const leftTickId = `${annotationUID}-left`;
+    const leftTickUID = '2';
+
+    drawLineSvg(
+      svgDrawingHelper,
+      annotationUID,
+      leftTickUID,
+      scaleTicks.endTick1[0] as Types.Point2,
+      scaleTicks.endTick1[1] as Types.Point2,
+      {
+        color,
+        width: lineWidth,
+        lineDash,
+        shadow,
+      },
+      leftTickId
+    );
+    const rightTickId = `${annotationUID}-right`;
+    const rightTickUID = '3';
+
+    drawLineSvg(
+      svgDrawingHelper,
+      annotationUID,
+      rightTickUID,
+      scaleTicks.endTick2[0] as Types.Point2,
+      scaleTicks.endTick2[1] as Types.Point2,
+      {
+        color,
+        width: lineWidth,
+        lineDash,
+        shadow,
+      },
+      rightTickId
+    );
+
+    const locationTextOffest = {
+      bottom: [-10, -42],
+      top: [-12, -35],
+      left: [-40, -20],
+      right: [-50, -20],
+    };
+
+    const textCanvasCoordinates = [
+      scaleCanvasCoordinates[0][0] + locationTextOffest[location][0],
+      scaleCanvasCoordinates[0][1] + locationTextOffest[location][1],
+    ];
+    const textBoxLines = this._getTextLines(scaleSize);
+
+    const { tickIds, tickUIDs, tickCoordinates } = this.computeInnerScaleTicks(
+      scaleSize,
+      location,
+      annotationUID,
+      scaleTicks.endTick1,
+      scaleTicks.endTick2
+    );
+
+    // draws inner ticks for scale
+    for (let i = 0; i < tickUIDs.length; i++) {
+      drawLineSvg(
+        svgDrawingHelper,
+        annotationUID,
+        tickUIDs[i],
+        tickCoordinates[i][0],
+        tickCoordinates[i][1],
+        {
+          color,
+          width: lineWidth,
+          lineDash,
+          shadow,
+        },
+        tickIds[i]
+      );
+    }
+
+    const textUID = 'text0';
+    drawTextBoxSvg(
+      svgDrawingHelper,
+      annotationUID,
+      textUID,
+      textBoxLines,
+      [textCanvasCoordinates[0], textCanvasCoordinates[1]],
+      {
+        fontFamily: 'Helvetica Neue, Helvetica, Arial, sans-serif',
+        fontSize: '14px',
+        lineDash: '2,3',
+        lineWidth: '1',
+        shadow: true,
+        color: color,
+      }
+    );
+
+    return renderStatus;
+  }
+
+  _getTextLines(scaleSize: number): string[] | undefined {
+    let scaleSizeDisplayValue;
+    let scaleSizeUnits;
+    if (scaleSize >= 50) {
+      scaleSizeDisplayValue = scaleSize / 10; //convert to cm
+      scaleSizeUnits = ' cm';
+    } else {
+      scaleSizeDisplayValue = scaleSize; //convert to cm
+      scaleSizeUnits = ' mm';
+    }
+
+    const textLines = [scaleSizeDisplayValue.toString().concat(scaleSizeUnits)];
+
+    return textLines;
+  }
+
+  /**
+   *
+   * @param worldWidthViewport
+   * @returns currentScaleSize
+   */
+  computeScaleSize = (
+    worldWidthViewport: number,
+    worldHeightViewport: number,
+    location: any
+  ) => {
+    const scaleSizes = [2000, 1000, 500, 250, 100, 50, 25, 10, 5];
+    let currentScaleSize;
+    if (location == 'top' || location == 'bottom') {
+      currentScaleSize = scaleSizes.filter(
+        (scaleSize) =>
+          scaleSize < worldWidthViewport * 0.6 &&
+          scaleSize > worldWidthViewport * 0.2
+      );
+    } else {
+      currentScaleSize = scaleSizes.filter(
+        (scaleSize) =>
+          scaleSize < worldHeightViewport * 0.6 &&
+          scaleSize > worldHeightViewport * 0.2
+      );
+    }
+
+    return currentScaleSize[0];
+  };
+
+  /**
+   *  calculates scale ticks for ends of the scale
+   * @param canvasCoordinates
+   * @returns leftTick, rightTick
+   */
+  computeEndScaleTicks = (canvasCoordinates, location) => {
+    const locationTickOffset = {
+      bottom: [
+        [0, -10],
+        [0, -10],
+      ],
+      top: [
+        [0, 10],
+        [0, 10],
+      ],
+      left: [
+        [0, 0],
+        [10, 0],
+      ],
+      right: [
+        [0, 0],
+        [-10, 0],
+      ],
+    };
+
+    const endTick1 = [
+      [
+        canvasCoordinates[1][0] + locationTickOffset[location][0][0],
+        canvasCoordinates[1][1] + locationTickOffset[location][0][0],
+      ],
+      [
+        canvasCoordinates[1][0] + locationTickOffset[location][1][0],
+        canvasCoordinates[1][1] + locationTickOffset[location][1][1],
+      ],
+    ];
+    const endTick2 = [
+      [
+        canvasCoordinates[0][0] + locationTickOffset[location][0][0],
+        canvasCoordinates[0][1] + locationTickOffset[location][0][0],
+      ],
+      [
+        canvasCoordinates[0][0] + locationTickOffset[location][1][0],
+        canvasCoordinates[0][1] + locationTickOffset[location][1][1],
+      ],
+    ];
+
+    return {
+      endTick1: endTick1,
+      endTick2: endTick2,
+    };
+  };
+
+  computeInnerScaleTicks = (
+    scaleSize,
+    location,
+    annotationUID,
+    leftTick,
+    rightTick
+  ) => {
+    let canvasScaleSize;
+    if (location == 'bottom' || location == 'top') {
+      canvasScaleSize = rightTick[0][0] - leftTick[0][0];
+    } else if (location == 'left' || location == 'right') {
+      canvasScaleSize = rightTick[0][1] - leftTick[0][1];
+    }
+    const tickIds = [];
+    const tickUIDs = [];
+    const tickCoordinates = [];
+    let numberSmallTicks = scaleSize;
+
+    if (scaleSize >= 50) {
+      numberSmallTicks = scaleSize / 10;
+    }
+
+    const tickSpacing = canvasScaleSize / numberSmallTicks;
+
+    for (let i = 0; i < numberSmallTicks - 1; i++) {
+      const locationOffset = {
+        bottom: [
+          [tickSpacing * (i + 1), 0],
+          [tickSpacing * (i + 1), 5],
+        ],
+        top: [
+          [tickSpacing * (i + 1), 0],
+          [tickSpacing * (i + 1), -5],
+        ],
+        left: [
+          [0, tickSpacing * (i + 1)],
+          [-5, tickSpacing * (i + 1)],
+        ],
+        right: [
+          [0, tickSpacing * (i + 1)],
+          [5, tickSpacing * (i + 1)],
+        ],
+      };
+      tickIds.push(`${annotationUID}-tick${i}`);
+      tickUIDs.push(`tick${i}`);
+      if ((i + 1) % 5 == 0) {
+        tickCoordinates.push([
+          [
+            leftTick[0][0] + locationOffset[location][0][0],
+            leftTick[0][1] + locationOffset[location][0][1],
+          ],
+          [
+            leftTick[1][0] + locationOffset[location][0][0],
+            leftTick[1][1] + locationOffset[location][0][1],
+          ],
+        ]);
+      } else {
+        tickCoordinates.push([
+          [
+            leftTick[0][0] + locationOffset[location][0][0],
+            leftTick[0][1] + locationOffset[location][0][1],
+          ],
+          [
+            leftTick[1][0] + locationOffset[location][1][0],
+            leftTick[1][1] + locationOffset[location][1][1],
+          ],
+        ]);
+      }
+    }
+
+    return { tickIds, tickUIDs, tickCoordinates };
+  };
+
+  computeWorldScaleCoordinates = (scaleSize, location, topRight, pointSet) => {
+    let worldCoordinates;
+    let topBottomVec = vec3.subtract(vec3.create(), pointSet[0], pointSet[1]);
+    topBottomVec = vec3.normalize(vec3.create(), topBottomVec) as Types.Point3;
+
+    let topRightVec = vec3.subtract(vec3.create(), pointSet[2], pointSet[0]);
+    topRightVec = vec3.normalize(vec3.create(), topRightVec);
+
+    const midpointLocation = {
+      bottom: [pointSet[1], pointSet[2]],
+      top: [pointSet[0], pointSet[3]],
+      right: [pointSet[2], pointSet[3]],
+      left: [pointSet[0], pointSet[1]],
+    };
+
+    const midpoint = vec3
+      .add(
+        vec3.create(),
+        midpointLocation[location][0],
+        midpointLocation[location][0]
+      )
+      .map((i) => i / 2) as Types.Point3;
+
+    const offset =
+      scaleSize /
+      2 /
+      Math.sqrt(
+        Math.pow(topBottomVec[0], 2) +
+          Math.pow(topBottomVec[1], 2) +
+          Math.pow(topBottomVec[2], 2)
+      );
+
+    if (location == 'top' || location == 'bottom') {
+      worldCoordinates = [
+        vec3.subtract(
+          vec3.create(),
+          midpoint,
+          topRightVec.map((i) => i * offset) as Types.Point3
+        ),
+        vec3.add(
+          vec3.create(),
+          midpoint,
+          topRightVec.map((i) => i * offset) as Types.Point3
+        ),
+      ];
+    } else if (location == 'left' || location == 'right') {
+      worldCoordinates = [
+        vec3.add(
+          vec3.create(),
+          midpoint,
+          topBottomVec.map((i) => i * offset) as Types.Point3
+        ),
+        vec3.subtract(
+          vec3.create(),
+          midpoint,
+          topBottomVec.map((i) => i * offset) as Types.Point3
+        ),
+      ];
+    }
+
+    return worldCoordinates;
+  };
+
+  /**
+   * Computes the centered canvas coordinates for scale
+   * @param canvasSize
+   * @param canvasCoordinates
+   * @param vscaleBounds
+   * @returns scaleCanvasCoordinates
+   */
+  computeCanvasScaleCoordinates = (
+    canvasSize,
+    canvasCoordinates,
+    vscaleBounds,
+    hscaleBounds,
+    location
+  ) => {
+    let scaleCanvasCoordinates;
+    if (location == 'top' || location == 'bottom') {
+      const worldDistanceOnCanvas =
+        canvasCoordinates[0][0] - canvasCoordinates[1][0];
+      scaleCanvasCoordinates = [
+        [canvasSize.width / 2 - worldDistanceOnCanvas / 2, vscaleBounds.height],
+        [canvasSize.width / 2 + worldDistanceOnCanvas / 2, vscaleBounds.height],
+      ];
+    } else if (location == 'left' || location == 'right') {
+      const worldDistanceOnCanvas =
+        canvasCoordinates[0][1] - canvasCoordinates[1][1];
+      scaleCanvasCoordinates = [
+        [hscaleBounds.width, canvasSize.height / 2 - worldDistanceOnCanvas / 2],
+        [hscaleBounds.width, canvasSize.height / 2 + worldDistanceOnCanvas / 2],
+      ];
+    }
+
+    return scaleCanvasCoordinates;
+  };
+
+  /**
+   * Computes the max bound for scales on the image
+   * @param  {{width: number, height: number}} canvasSize
+   * @param  {number} horizontalReduction
+   * @param  {number} verticalReduction
+   * @returns {Object.<string, { x:number, y:number }>}
+   */
+  computeScaleBounds = (
+    canvasSize,
+    horizontalReduction,
+    verticalReduction,
+    location
+  ) => {
+    const hReduction = horizontalReduction * Math.min(1000, canvasSize.width);
+    const vReduction = verticalReduction * Math.min(1000, canvasSize.height);
+    const locationBounds = {
+      bottom: [-vReduction, -hReduction],
+      top: [vReduction, hReduction],
+      left: [vReduction, hReduction],
+      right: [-vReduction, -hReduction],
+    };
+    const canvasBounds = {
+      bottom: [canvasSize.height, canvasSize.width],
+      top: [0, canvasSize.width],
+      left: [canvasSize.height, 0],
+      right: [canvasSize.height, canvasSize.width],
+    };
+
+    return {
+      height: canvasBounds[location][0] + locationBounds[location][0],
+      width: canvasBounds[location][1] + locationBounds[location][1],
+    };
+  };
+}
+
+ScaleOverlayTool.toolName = 'ScaleOverlay';
+export default ScaleOverlayTool;

--- a/packages/tools/src/tools/index.ts
+++ b/packages/tools/src/tools/index.ts
@@ -75,4 +75,5 @@ export {
   MagnifyTool,
   ReferenceLines,
   PaintFillTool,
+  ScaleOverlayTool,
 };

--- a/packages/tools/src/tools/index.ts
+++ b/packages/tools/src/tools/index.ts
@@ -23,6 +23,7 @@ import AngleTool from './annotation/AngleTool';
 import CobbAngleTool from './annotation/CobbAngleTool';
 import ReferenceCursors from './ReferenceCursors';
 import ReferenceLines from './ReferenceLinesTool';
+import ScaleOverlayTool from './ScaleOverlayTool';
 
 // Segmentation DisplayTool
 import SegmentationDisplayTool from './displayTools/SegmentationDisplayTool';

--- a/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
+++ b/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
@@ -278,5 +278,6 @@ export interface ScaleOverlayAnnotation extends Annotation {
     handles: {
       points: Types.Point3[];
     };
+    viewportId: string;
   };
 }

--- a/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
+++ b/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
@@ -272,3 +272,11 @@ export interface ReferenceLineAnnotation extends Annotation {
     };
   };
 }
+
+export interface ScaleOverlayAnnotation extends Annotation {
+  data: {
+    handles: {
+      points: Types.Point3[];
+    };
+  };
+}

--- a/utils/ExampleRunner/example-info.json
+++ b/utils/ExampleRunner/example-info.json
@@ -231,6 +231,10 @@
       "cancelAnnotationDrawing": {
         "name": "Cancel Annotation Drawing",
         "description": "Demonstrates how to use the keyboard (ESC) key to cancel annotation drawing."
+      },
+      "scaleOverlayTool": {
+        "name": "Scale Overlay Tool",
+        "description": "Demonstrates the scale overlay tool for rendering a scale on a viewport showing the real world size of the image."
       }
     }
   }


### PR DESCRIPTION
### Summary

Displays a scale overlay on images to show the real world size. Scale can be positioned at the bottom, top, left or right side of the canvas. Scale size has been verified by using the length tool.

### Screenshot

![scaleoverlaytool-demo](https://user-images.githubusercontent.com/9090600/214721718-dadfff48-590d-444d-90a4-50fc5a299616.gif)
