### PR TITLE
fix(svg): find and reset svg-layer within the correct element

### DIFF
--- a/packages/tools/src/store/removeEnabledElement.ts
+++ b/packages/tools/src/store/removeEnabledElement.ts
@@ -32,13 +32,7 @@ function removeEnabledElement(
   const { element, viewportId } = elementDisabledEvt.detail;
 
   _resetSvgNodeCache(element);
-
-  const viewportNode = element;
-  const svgLayer = viewportNode.querySelector('svg');
-  const internalViewportNode = element.querySelector(`div.${VIEWPORT_ELEMENT}`);
-  if (svgLayer) {
-    internalViewportNode.removeChild(svgLayer);
-  }
+  _removeSvgNode(element);
 
   // Remove this element from the annotation rendering engine
   annotationRenderingEngine.removeViewportElement(viewportId, element);
@@ -109,6 +103,14 @@ function _resetSvgNodeCache(element: HTMLDivElement) {
   const elementHash = `${viewportId}:${renderingEngineId}`;
 
   delete state.svgNodeCache[elementHash];
+}
+
+function _removeSvgNode(element: HTMLDivElement) {
+  const internalViewportNode = element.querySelector(`div.${VIEWPORT_ELEMENT}`);
+  const svgLayer = internalViewportNode.querySelector('svg');
+  if (svgLayer) {
+    internalViewportNode.removeChild(svgLayer);
+  }
 }
 
 /**


### PR DESCRIPTION
We use nativeElement for rendering an element (enabledElement) that contains overlayboxes as well as some other components. While querying for the svg-layer during the remove element, we are having problems using these properties because it searches under the wrong element. I investigated our repository issues and found it looks like #252.

![removeChild](https://user-images.githubusercontent.com/36845173/214840550-401e6aa0-86d8-4bbd-96d2-b28b19fec5c2.PNG)

