### PR TITLE
feat(StackViewport): rework rotation for stack viewport

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1478,6 +1478,8 @@ interface IViewport {
     // (undocumented)
     getRenderingEngine(): any;
     // (undocumented)
+    getRotation: () => number;
+    // (undocumented)
     getZoom(): number;
     // (undocumented)
     id: string;
@@ -2001,6 +2003,8 @@ export class StackViewport extends Viewport implements IStackViewport {
     // (undocumented)
     getRenderer(): any;
     // (undocumented)
+    getRotation: () => number;
+    // (undocumented)
     getTargetImageIdIndex: () => number;
     // (undocumented)
     hasImageId: (imageId: string) => boolean;
@@ -2278,6 +2282,8 @@ export class Viewport implements IViewport {
     // (undocumented)
     getRenderingEngine(): IRenderingEngine;
     // (undocumented)
+    getRotation: () => number;
+    // (undocumented)
     protected getVtkActiveCamera(): vtkCamera | vtkSlabCamera;
     // (undocumented)
     getZoom(): number;
@@ -2311,8 +2317,6 @@ export class Viewport implements IViewport {
     protected resetCameraNoEvent(): void;
     // (undocumented)
     resize: () => void;
-    // (undocumented)
-    protected rotation: number;
     // (undocumented)
     setActors(actors: Array<ActorEntry>): void;
     // (undocumented)
@@ -2500,6 +2504,8 @@ export class VolumeViewport extends BaseVolumeViewport {
     getCurrentImageIdIndex: () => number | undefined;
     // (undocumented)
     getIntensityFromWorld(point: Point3): number;
+    // (undocumented)
+    getRotation: () => number;
     // (undocumented)
     getSlabThickness(): number;
     // (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1015,6 +1015,7 @@ interface IViewport {
     getPan(): Point2;
     getRenderer(): void;
     getRenderingEngine(): any;
+    getRotation: () => number;
     getZoom(): number;
     id: string;
     isDisabled: boolean;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2744,6 +2744,7 @@ interface IViewport {
     getPan(): Point2;
     getRenderer(): void;
     getRenderingEngine(): any;
+    getRotation: () => number;
     getZoom(): number;
     id: string;
     isDisabled: boolean;

--- a/packages/core/examples/stackAPI/index.ts
+++ b/packages/core/examples/stackAPI/index.ts
@@ -18,7 +18,7 @@ console.warn(
   'Click on index.ts to open source code for this example --------->'
 );
 
-const { ViewportType } = Enums;
+const { ViewportType, Events } = Enums;
 
 // ======== Constants ======= //
 const renderingEngineId = 'myRenderingEngine';
@@ -37,6 +37,35 @@ element.style.width = '500px';
 element.style.height = '500px';
 
 content.appendChild(element);
+
+const info = document.createElement('div');
+content.appendChild(info);
+
+const rotationInfo = document.createElement('div');
+info.appendChild(rotationInfo);
+
+const flipHorizontalInfo = document.createElement('div');
+info.appendChild(flipHorizontalInfo);
+
+const flipVerticalInfo = document.createElement('div');
+info.appendChild(flipVerticalInfo);
+
+element.addEventListener(Events.CAMERA_MODIFIED, (_) => {
+  // Get the rendering engine
+  const renderingEngine = getRenderingEngine(renderingEngineId);
+
+  // Get the stack viewport
+  const viewport = <Types.IStackViewport>(
+    renderingEngine.getViewport(viewportId)
+  );
+
+  const { flipHorizontal, flipVertical } = viewport.getCamera();
+  const { rotation } = viewport.getProperties();
+
+  rotationInfo.innerText = `Rotation: ${rotation}`;
+  flipHorizontalInfo.innerText = `Flip horizontal: ${flipHorizontal}`;
+  flipVerticalInfo.innerText = `Flip vertical: ${flipVertical}`;
+});
 
 addButtonToToolbar({
   title: 'Set VOI Range',
@@ -143,7 +172,7 @@ addButtonToToolbar({
 });
 
 addButtonToToolbar({
-  title: 'Rotate',
+  title: 'Rotate Random',
   onClick: () => {
     // Get the rendering engine
     const renderingEngine = getRenderingEngine(renderingEngineId);
@@ -156,6 +185,41 @@ addButtonToToolbar({
     const rotation = Math.random() * 360;
 
     viewport.setProperties({ rotation });
+
+    viewport.render();
+  },
+});
+
+addButtonToToolbar({
+  title: 'Rotate Absolute 150',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IStackViewport>(
+      renderingEngine.getViewport(viewportId)
+    );
+
+    viewport.setProperties({ rotation: 150 });
+
+    viewport.render();
+  },
+});
+
+addButtonToToolbar({
+  title: 'Rotate Delta 30',
+  onClick: () => {
+    // Get the rendering engine
+    const renderingEngine = getRenderingEngine(renderingEngineId);
+
+    // Get the stack viewport
+    const viewport = <Types.IStackViewport>(
+      renderingEngine.getViewport(viewportId)
+    );
+
+    const { rotation } = viewport.getProperties();
+    viewport.setProperties({ rotation: rotation + 30 });
 
     viewport.render();
   },

--- a/packages/core/examples/stackAPI/index.ts
+++ b/packages/core/examples/stackAPI/index.ts
@@ -59,10 +59,14 @@ element.addEventListener(Events.CAMERA_MODIFIED, (_) => {
     renderingEngine.getViewport(viewportId)
   );
 
+  if (!viewport) {
+    return;
+  }
+
   const { flipHorizontal, flipVertical } = viewport.getCamera();
   const { rotation } = viewport.getProperties();
 
-  rotationInfo.innerText = `Rotation: ${rotation}`;
+  rotationInfo.innerText = `Rotation: ${Math.round(rotation)}`;
   flipHorizontalInfo.innerText = `Flip horizontal: ${flipHorizontal}`;
   flipVerticalInfo.innerText = `Flip vertical: ${flipVertical}`;
 });

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -142,7 +142,6 @@ class StackViewport extends Viewport implements IStackViewport {
   private cameraFocalPointOnRender: Point3; // we use focalPoint since flip manipulates the position and makes it useless to track
   private stackInvalidated = false; // if true -> new actor is forced to be created for the stack
   private voiApplied = false;
-  private rotationCache = 0;
   private _publishCalibratedEvent = false;
   private _calibrationEvent: CalibrationEvent;
   private _cpuFallbackEnabledElement?: CPUFallbackEnabledElement;
@@ -174,7 +173,7 @@ class StackViewport extends Viewport implements IStackViewport {
         canvas: this.canvas,
         renderingTools: {},
         transform: new Transform(),
-        viewport: {},
+        viewport: { rotation: 0 },
       };
     } else {
       const renderer = this.getRenderer();
@@ -568,8 +567,8 @@ class StackViewport extends Viewport implements IStackViewport {
     }
 
     if (typeof rotation !== 'undefined') {
-      if (this.rotationCache !== rotation) {
-        this.setRotation(this.rotationCache, rotation);
+      if (this.getRotation() !== rotation) {
+        this.setRotation(rotation);
       }
     }
   }
@@ -581,7 +580,7 @@ class StackViewport extends Viewport implements IStackViewport {
   public getProperties = (): StackViewportProperties => {
     return {
       voiRange: this.voiRange,
-      rotation: this.rotationCache,
+      rotation: this.getRotation(),
       interpolationType: this.interpolationType,
       invert: this.invert,
     };
@@ -650,7 +649,6 @@ class StackViewport extends Viewport implements IStackViewport {
     this.setProperties(
       {
         voiRange: this.voiRange,
-        rotation: this.rotation,
         interpolationType: this.interpolationType,
         invert: this.invert,
       },
@@ -669,10 +667,10 @@ class StackViewport extends Viewport implements IStackViewport {
 
     // If camera is rotated, we need the correct rotated viewUp along the
     // viewPlaneNormal vector
-    if (this.rotation) {
+    if (viewport.rotation) {
       const rotationMatrix = mat4.fromRotation(
         mat4.create(),
-        (this.rotation * Math.PI) / 180,
+        (viewport.rotation * Math.PI) / 180,
         viewPlaneNormal
       );
       viewUp = vec3.transformMat4(
@@ -788,7 +786,7 @@ class StackViewport extends Viewport implements IStackViewport {
       element: this.element,
       viewportId: this.id,
       renderingEngineId: this.renderingEngineId,
-      rotation: this.rotation,
+      rotation: this.getRotation(),
     };
 
     triggerEvent(this.element, Events.CAMERA_MODIFIED, eventDetail);
@@ -817,13 +815,69 @@ class StackViewport extends Viewport implements IStackViewport {
     this.setVOIGPU(voiRange, suppressEvents);
   }
 
-  private setRotation(rotationCache: number, rotation: number): void {
+  getRotation = (): number => {
+    if (this.useCPURendering) {
+      return this.getRotationCPU();
+    } else {
+      return this.getRotationGPU();
+    }
+  };
+
+  private getRotationCPU = (): number => {
+    const { viewport } = this._cpuFallbackEnabledElement;
+    return viewport.rotation;
+  };
+
+  /**
+   * Gets the rotation resulting from the value set in setRotation AND taking into
+   * account any flips that occurred subsequently.
+   *
+   * @returns the rotation resulting from the value set in setRotation AND taking into
+   * account any flips that occurred subsequently.
+   */
+  private getRotationGPU = (): number => {
+    const {
+      viewUp: endViewUp,
+      viewPlaneNormal,
+      flipVertical,
+    } = this.getCamera();
+
+    // The start view up vector without any rotation, but incorporating any vertical flip.
+    const startViewUp = flipVertical
+      ? vec3.negate(vec3.create(), this.initialViewUp)
+      : this.initialViewUp;
+
+    // The dot product of the start and end view up vectors.
+    const startToEndViewUpDot = vec3.dot(startViewUp, endViewUp);
+
+    // The angle between the start and end view up vectors.
+    const startToEndViewUpAngle =
+      (Math.acos(startToEndViewUpDot) * 180) / Math.PI;
+
+    // Now determine if startToEndViewUpAngle is positive or negative by comparing
+    // the direction of the start/end view up cross product with the current
+    // viewPlaneNormal.
+
+    const startToEndViewUpCross = vec3.cross(
+      vec3.create(),
+      startViewUp,
+      endViewUp
+    );
+
+    // The sign of the dot product of the start/end view up cross product and
+    // the viewPlaneNormal indicates a positive or negative rotation respectively.
+    const normalDot = vec3.dot(startToEndViewUpCross, viewPlaneNormal);
+
+    return normalDot >= 0 ? startToEndViewUpAngle : 360 - startToEndViewUpAngle;
+  };
+
+  private setRotation(rotation: number): void {
     const previousCamera = this.getCamera();
 
     if (this.useCPURendering) {
-      this.setRotationCPU(rotationCache, rotation);
+      this.setRotationCPU(rotation);
     } else {
-      this.setRotationGPU(rotationCache, rotation);
+      this.setRotationGPU(rotation);
     }
 
     // New camera after rotation
@@ -835,7 +889,7 @@ class StackViewport extends Viewport implements IStackViewport {
       element: this.element,
       viewportId: this.id,
       renderingEngineId: this.renderingEngineId,
-      rotation: this.rotation,
+      rotation,
     };
 
     triggerEvent(this.element, Events.CAMERA_MODIFIED, eventDetail);
@@ -859,22 +913,26 @@ class StackViewport extends Viewport implements IStackViewport {
     this.setInvertColorGPU(invert);
   }
 
-  private setRotationCPU(rotationCache: number, rotation: number): void {
+  private setRotationCPU(rotation: number): void {
     const { viewport } = this._cpuFallbackEnabledElement;
 
     viewport.rotation = rotation;
-    this.rotationCache = rotation;
-    this.rotation = rotation;
   }
 
-  private setRotationGPU(rotationCache: number, rotation: number): void {
+  private setRotationGPU(rotation: number): void {
+    const { flipVertical } = this.getCamera();
+
     // Moving back to zero rotation, for new scrolled slice rotation is 0 after camera reset
-    this.getVtkActiveCamera().roll(rotationCache);
+    const initialViewUp = flipVertical
+      ? vec3.negate(vec3.create(), this.initialViewUp)
+      : this.initialViewUp;
+
+    this.setCamera({
+      viewUp: initialViewUp as Point3,
+    });
 
     // rotating camera to the new value
     this.getVtkActiveCamera().roll(-rotation);
-    this.rotationCache = rotation;
-    this.rotation = rotation;
   }
 
   private setInterpolationTypeGPU(interpolationType: InterpolationType): void {
@@ -1256,7 +1314,6 @@ class StackViewport extends Viewport implements IStackViewport {
     this.currentImageIdIndex = currentImageIdIndex;
     this.targetImageIdIndex = currentImageIdIndex;
     this.stackInvalidated = true;
-    this.rotationCache = 0;
     this.flipVertical = false;
     this.flipHorizontal = false;
     this.voiApplied = false;
@@ -1671,21 +1728,16 @@ class StackViewport extends Viewport implements IStackViewport {
         cameraProps.focalPoint
       );
 
-      // store rotation cache since reset camera will reset it
-      const rotationCache = this.rotationCache;
-
       // Reset the camera to point to the new slice location, reset camera doesn't
       // modify the direction of projection and viewUp
       this.resetCameraNoEvent();
 
-      // restore the rotation cache for the new slice
-      this.setRotation(rotationCache, rotationCache);
-
-      // set the flip back to the previous value since the restore camera props
+      // set the flip and view up back to the previous value since the restore camera props
       // rely on the correct flip value
       this.setCameraNoEvent({
         flipHorizontal: previousCameraProps.flipHorizontal,
         flipVertical: previousCameraProps.flipVertical,
+        viewUp: previousCameraProps.viewUp,
       });
 
       const { focalPoint } = this.getCamera();
@@ -1704,8 +1756,6 @@ class StackViewport extends Viewport implements IStackViewport {
         panCache as Point3
       );
 
-      // Restore rotation for the new slice of the image
-      this.rotationCache = 0;
       this._setPropertiesFromCache();
 
       return;
@@ -1862,8 +1912,6 @@ class StackViewport extends Viewport implements IStackViewport {
       this.resetCameraGPU(resetPan, resetZoom);
     }
 
-    this.rotation = 0;
-    this.rotationCache = 0;
     return true;
   }
 
@@ -1895,7 +1943,8 @@ class StackViewport extends Viewport implements IStackViewport {
     // we can reset it there, right now it is not possible to reset the rotation
     // without this
 
-    // We do not know the ordering of various flips and rotations that have been applied, so just start like we were at the beginning.
+    // We do not know the ordering of various flips and rotations that have been applied,
+    // so the rotation and flip must be reset together.
     this.setCamera({
       flipHorizontal: false,
       flipVertical: false,

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -47,7 +47,6 @@ class Viewport implements IViewport {
   readonly type: ViewportType;
   protected flipHorizontal = false;
   protected flipVertical = false;
-  protected rotation = 0;
   public isDisabled: boolean;
 
   /** sx of viewport on the offscreen canvas */
@@ -99,6 +98,7 @@ class Viewport implements IViewport {
     this.isDisabled = false;
   }
 
+  getRotation: () => number;
   getFrameOfReferenceUID: () => string;
   canvasToWorld: (canvasPos: Point2) => Point3;
   worldToCanvas: (worldPos: Point3) => Point2;
@@ -995,7 +995,7 @@ class Viewport implements IViewport {
         element: this.element,
         viewportId: this.id,
         renderingEngineId: this.renderingEngineId,
-        rotation: this.rotation,
+        rotation: this.getRotation(),
       };
 
       triggerEvent(this.element, Events.CAMERA_MODIFIED, eventDetail);

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -448,6 +448,8 @@ class VolumeViewport extends BaseVolumeViewport {
     // number of steps, and subtract 1 to get the index
     return Math.round(Math.abs(distance) / spacingInNormal);
   };
+
+  getRotation = (): number => 0;
 }
 
 export default VolumeViewport;

--- a/packages/core/src/RenderingEngine/VolumeViewport3D.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport3D.ts
@@ -31,6 +31,8 @@ class VolumeViewport3D extends BaseVolumeViewport {
     this.resetVolumeViewportClippingRange();
     return;
   }
+
+  getRotation = (): number => 0;
 }
 
 export default VolumeViewport3D;

--- a/packages/core/src/types/IViewport.ts
+++ b/packages/core/src/types/IViewport.ts
@@ -37,6 +37,8 @@ interface IViewport {
   suppressEvents: boolean;
   /** if the viewport has been disabled */
   isDisabled: boolean;
+  /** the rotation applied to the view */
+  getRotation: () => number;
   /** frameOfReferenceUID the viewport's default actor is rendering */
   getFrameOfReferenceUID: () => string;
   /** method to convert canvas to world coordinates */


### PR DESCRIPTION
    fix(StackViewport): #372 Removed both the Viewport.rotation and StackViewport.rotationCache properties.
    Introduced an IViewport.getRotation for those viewports supporting rotation.
    StackViewport.getRotation calculates the rotation from the camera properties.
    Changed the StackAPI example to add buttons for constant absolute and delta rotations.
    The StackAPI example now reports the current rotation and flips.

Various scenarios to test - also try permutations of each:

- rotation + flip + next image
- rotation + flip + reset
- rotation + flip + next image + absolute rotation
- rotation + flip + next image + delta rotation
- rotation + flip + delta rotation