### PR TITLE
fix(doubleClick): click events are not being propagated at all

### DIFF
--- a/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
+++ b/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
@@ -149,11 +149,6 @@ function mouseDownListener(evt: MouseEvent) {
   state.renderingEngineId = renderingEngineId;
   state.viewportId = viewportId;
 
-  state.preventClickTimeout = setTimeout(
-    _preventClickHandler,
-    state.clickDelay
-  );
-
   // Prevent CornerstoneToolsMouseMove while mouse is down
   state.element.removeEventListener('mousemove', mouseMoveListener);
 
@@ -172,6 +167,11 @@ function mouseDownListener(evt: MouseEvent) {
  * @private
  */
 function _doMouseDown(evt: MouseEvent) {
+  state.preventClickTimeout = setTimeout(
+    _preventClickHandler,
+    state.clickDelay
+  );
+
   const deltaPoints = _getDeltaPoints(state.startPoints, state.startPoints);
 
   const eventDetail: EventTypes.MouseDownEventDetail = {


### PR DESCRIPTION
moved the mouse click/down timeout detection into _doMouseDown where the actual mouse down event is fired.