### PR TITLE
fix(doubleClick): mouse up events are not being propagated at all

### DIFF
--- a/packages/tools/examples/doubleClickWithStackAnnotationTools/index.ts
+++ b/packages/tools/examples/doubleClickWithStackAnnotationTools/index.ts
@@ -62,12 +62,28 @@ content.addEventListener('dblclick', () => {
   const renderEngine = getRenderingEngine(renderingEngineId);
   renderEngine.resize(true);
 
+  browserDoubleClickEventStatus.innerText =
+    "Browser 'dblclick' event detected on a viewport element ancestor.";
   statusDiv.style.backgroundColor = '#00ff00';
 });
 
 element.addEventListener(Events.MOUSE_DOWN, () => {
   browserDoubleClickEventStatus.style.visibility = 'hidden';
   statusDiv.style.backgroundColor = null;
+});
+
+element.addEventListener(Events.MOUSE_UP, () => {
+  browserDoubleClickEventStatus.style.visibility = '';
+  browserDoubleClickEventStatus.innerText =
+    "Cornerstone 'MOUSE_UP' event detected on the viewport element.";
+  statusDiv.style.backgroundColor = '#00ff00';
+});
+
+element.addEventListener(Events.MOUSE_CLICK, () => {
+  browserDoubleClickEventStatus.style.visibility = '';
+  browserDoubleClickEventStatus.innerText =
+    "Cornerstone 'MOUSE_CLICK' event detected on the viewport element.";
+  statusDiv.style.backgroundColor = '#00ff00';
 });
 
 content.appendChild(element);
@@ -80,8 +96,6 @@ content.append(statusDiv);
 
 const browserDoubleClickEventStatus = document.createElement('p');
 browserDoubleClickEventStatus.style.visibility = 'hidden';
-browserDoubleClickEventStatus.innerText =
-  "Browser 'dblclick' event detected on a viewport element ancestor.";
 statusDiv.append(browserDoubleClickEventStatus);
 
 // instruction elements

--- a/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
+++ b/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
@@ -149,6 +149,11 @@ function mouseDownListener(evt: MouseEvent) {
   state.renderingEngineId = renderingEngineId;
   state.viewportId = viewportId;
 
+  state.preventClickTimeout = setTimeout(
+    _preventClickHandler,
+    state.clickDelay
+  );
+
   // Prevent CornerstoneToolsMouseMove while mouse is down
   state.element.removeEventListener('mousemove', mouseMoveListener);
 
@@ -167,11 +172,6 @@ function mouseDownListener(evt: MouseEvent) {
  * @private
  */
 function _doMouseDown(evt: MouseEvent) {
-  state.preventClickTimeout = setTimeout(
-    _preventClickHandler,
-    state.clickDelay
-  );
-
   const deltaPoints = _getDeltaPoints(state.startPoints, state.startPoints);
 
   const eventDetail: EventTypes.MouseDownEventDetail = {
@@ -267,6 +267,9 @@ function _onMouseDrag(evt: MouseEvent) {
  * @param evt - The mouse event.
  */
 function _onMouseUp(evt: MouseEvent): void {
+  // Cancel the timeout preventing the click event from triggering
+  clearTimeout(state.preventClickTimeout);
+
   if (doubleClickState.doubleClickTimeout) {
     // received a mouse up while waiting for a double click (via a timeout)
 
@@ -295,9 +298,6 @@ function _onMouseUp(evt: MouseEvent): void {
     // Handle the actual mouse up. Note that it may have occurred during the double click timeout or
     // after it expired. In either case this block is being executed after the time out has expired
     // or after a drag started.
-
-    // Cancel the timeout preventing the click event from triggering
-    clearTimeout(state.preventClickTimeout);
 
     const eventName = state.isClickEvent ? MOUSE_CLICK : MOUSE_UP;
 


### PR DESCRIPTION
moved the mouse click/down timeout detection back into mouseDownListener and the timeout is now cleared on the subsequent 'mouseup' event.
