### PR TITLE
fix(trackball): rotate was wrong on mouse drag

### DIFF
--- a/packages/tools/src/tools/TrackballRotateTool.ts
+++ b/packages/tools/src/tools/TrackballRotateTool.ts
@@ -120,8 +120,6 @@ class TrackballRotateTool extends BaseTool {
       vtkMath.cross(leftV, upVec, forwardV);
       vtkMath.normalize(forwardV);
 
-      vtkMath.normalize(upVec);
-
       this.rotateCamera(viewport, centerWorld, forwardV, angleX);
 
       const angleY =

--- a/packages/tools/src/tools/TrackballRotateTool.ts
+++ b/packages/tools/src/tools/TrackballRotateTool.ts
@@ -120,8 +120,9 @@ class TrackballRotateTool extends BaseTool {
       vtkMath.cross(upVec, atV, rightV);
       vtkMath.normalize(rightV);
 
-      vtkMath.cross(rightV, upVec, forwardV);
+      vtkMath.cross(atV, rightV, forwardV);
       vtkMath.normalize(forwardV);
+      vtkMath.normalize(upVec);
 
       this.rotateCamera(viewport, centerWorld, forwardV, angleX);
 

--- a/packages/tools/src/tools/TrackballRotateTool.ts
+++ b/packages/tools/src/tools/TrackballRotateTool.ts
@@ -54,8 +54,6 @@ class TrackballRotateTool extends BaseTool {
     mat4.rotate(transform, transform, angle, axis);
     vec3.transformMat4(newViewUp, viewUp, transform);
 
-    // console.log(newPosition);
-
     viewport.setCamera({
       position: newPosition,
       viewUp: newViewUp,
@@ -86,15 +84,10 @@ class TrackballRotateTool extends BaseTool {
       lastPointsCanvas[1] / height,
     ];
 
-    // console.log(normalizedPosition[0] - normalizedPreviousPosition[0]);
-
     const center: Types.Point2 = [width * 0.5, height * 0.5];
     // NOTE: centerWorld corresponds to the focal point in cornerstone3D
     const centerWorld = viewport.canvasToWorld(center);
     const normalizedCenter = [0.5, 0.5];
-    // const normalizedCenter = center;
-    // console.log(centerWorld);
-
 
     const radsq = (1.0 + Math.abs(normalizedCenter[0])) ** 2.0;
     const op = [normalizedPreviousPosition[0], 0, 0];

--- a/packages/tools/src/tools/TrackballRotateTool.ts
+++ b/packages/tools/src/tools/TrackballRotateTool.ts
@@ -114,10 +114,13 @@ class TrackballRotateTool extends BaseTool {
 
       const upVec = camera.viewUp;
       const atV = camera.viewPlaneNormal;
-      const leftV: Types.Point3 = [0, 0, 0];
+      const rightV: Types.Point3 = [0, 0, 0];
       const forwardV: Types.Point3 = [0, 0, 0];
-      vtkMath.cross(upVec, atV, leftV);
-      vtkMath.cross(leftV, upVec, forwardV);
+
+      vtkMath.cross(upVec, atV, rightV);
+      vtkMath.normalize(rightV);
+
+      vtkMath.cross(rightV, upVec, forwardV);
       vtkMath.normalize(forwardV);
 
       this.rotateCamera(viewport, centerWorld, forwardV, angleX);
@@ -125,10 +128,6 @@ class TrackballRotateTool extends BaseTool {
       const angleY =
         (normalizedPreviousPosition[1] - normalizedPosition[1]) *
         rotateIncrementDegrees;
-
-      const rightV: Types.Point3 = [0, 0, 0];
-      vtkMath.cross(upVec, atV, rightV);
-      vtkMath.normalize(rightV);
 
       this.rotateCamera(viewport, centerWorld, rightV, angleY);
 

--- a/packages/tools/src/tools/TrackballRotateTool.ts
+++ b/packages/tools/src/tools/TrackballRotateTool.ts
@@ -1,6 +1,6 @@
 import vtkMath from '@kitware/vtk.js/Common/Core/Math';
 
-import { getEnabledElement, utilities as csUtils } from '@cornerstonejs/core';
+import { getEnabledElement } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 import { mat4, vec3 } from 'gl-matrix';
 import { EventTypes, PublicToolProps, ToolProps } from '../types';


### PR DESCRIPTION
### Summary

Fixed issue with TrackballRotateTool on 3D viewports where the image was being rotated about the incorrect axis when dragging the cursor along the x-axis of the canvas.

### Screenshots

**Old TrackballRotateTool**
![OLDtrackball](https://user-images.githubusercontent.com/9090600/217363895-c4b14fa0-d7b5-488c-a552-cb9f662a1c4e.gif)

**Fixed TrackballRotateTool**
![NEWtrackball](https://user-images.githubusercontent.com/9090600/217363958-faef69d4-eccd-4ae6-bfb0-53a37d4266b3.gif)
