### PR TITLE
feat(adapters): Add adapters for Rectangle, Angle and fix generate DICOM

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -42,8 +42,6 @@
         "gl-matrix": "^3.4.3",
         "dcmjs": "^0.29.4",
         "lodash.clonedeep": "^4.5.0",
-        "loglevelnext": "^3.0.1",
-        "ndarray": "^1.0.19",
-        "pako": "^2.0.4"
+        "ndarray": "^1.0.19"
     }
 }

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -37,11 +37,9 @@
         "url": "https://github.com/cornerstonejs/cornerstone3D-beta/issues"
     },
     "homepage": "https://github.com/cornerstonejs/cornerstone3D-beta/blob/main/packages/adapters/README.md",
-    "peerDependencies": {
-        "gl-matrix": "^3.4.3"
-    },
     "dependencies": {
         "@babel/runtime-corejs2": "^7.17.8",
+        "gl-matrix": "^3.4.3",
         "dcmjs": "^0.29.4",
         "lodash.clonedeep": "^4.5.0",
         "loglevelnext": "^3.0.1",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -37,10 +37,12 @@
         "url": "https://github.com/cornerstonejs/cornerstone3D-beta/issues"
     },
     "homepage": "https://github.com/cornerstonejs/cornerstone3D-beta/blob/main/packages/adapters/README.md",
+    "peerDependencies": {
+        "gl-matrix": "^3.4.3"
+    },
     "dependencies": {
         "@babel/runtime-corejs2": "^7.17.8",
         "dcmjs": "^0.29.4",
-        "gl-matrix": "^3.4.3",
         "lodash.clonedeep": "^4.5.0",
         "loglevelnext": "^3.0.1",
         "ndarray": "^1.0.19",

--- a/packages/adapters/rollup.config.mjs
+++ b/packages/adapters/rollup.config.mjs
@@ -8,10 +8,7 @@ import { readFileSync } from "fs";
 const pkg = JSON.parse(readFileSync("package.json", { encoding: "utf8" }));
 
 export default {
-    external: ["dcmjs"],
-    globals: {
-        dcmjs: "dcmjs"
-    },
+    external: ["dcmjs", "gl-matrix", "lodash.clonedeep", "ndarray"],
     input: pkg.src || "src/index.ts",
     output: [
         // {

--- a/packages/adapters/rollup.config.mjs
+++ b/packages/adapters/rollup.config.mjs
@@ -5,35 +5,38 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import { readFileSync } from "fs";
 
-const pkg = JSON.parse(readFileSync('package.json', {encoding: 'utf8'}));
-
+const pkg = JSON.parse(readFileSync("package.json", { encoding: "utf8" }));
 
 export default {
-  input: pkg.src || 'src/index.ts',
-  output: [
-    // {
-    //   file: `dist/${pkg.name}.js`,
-    //   format: "umd",
-    //   name: pkg.name,
-    //   sourcemap: true
-    // },
-    {
-      file: `dist/${pkg.name}.es.js`,
-      format: "es",
-      sourcemap: true
-    }
-  ],
-  plugins: [
-    resolve({
-      browser: true
-    }),
-    commonjs(),
-    typescript(),
-//    globals(),
-    // builtins(),
-    babel({
-      exclude: "node_modules/**"
-    }),
-    json()
-  ]
+    external: ["dcmjs"],
+    globals: {
+        dcmjs: "dcmjs"
+    },
+    input: pkg.src || "src/index.ts",
+    output: [
+        // {
+        //   file: `dist/${pkg.name}.js`,
+        //   format: "umd",
+        //   name: pkg.name,
+        //   sourcemap: true
+        // },
+        {
+            file: `dist/${pkg.name}.es.js`,
+            format: "es",
+            sourcemap: true
+        }
+    ],
+    plugins: [
+        resolve({
+            browser: true
+        }),
+        commonjs(),
+        typescript(),
+        //    globals(),
+        // builtins(),
+        babel({
+            exclude: "node_modules/**"
+        }),
+        json()
+    ]
 };

--- a/packages/adapters/src/adapters/Cornerstone/Angle.js
+++ b/packages/adapters/src/adapters/Cornerstone/Angle.js
@@ -3,13 +3,13 @@ import { utilities } from "dcmjs";
 import MeasurementReport from "./MeasurementReport";
 import CORNERSTONE_4_TAG from "./cornerstone4Tag";
 
-const { CobbAngle: TID300CobbAngle } = utilities.TID300;
+const { Angle: TID300Angle } = utilities.TID300;
 
 const ANGLE = "Angle";
 
 class Angle {
     /**
-     * Generate TID300 measurement data for a plane angle measurement - use a CobbAngle, but label it as Angle
+     * Generate TID300 measurement data for a plane angle measurement - use a Angle, but label it as Angle
      */
     static getMeasurementData(MeasurementGroup) {
         const { defaultState, NUMGroup, SCOORDGroup } =
@@ -72,7 +72,7 @@ class Angle {
 
 Angle.toolType = ANGLE;
 Angle.utilityToolType = ANGLE;
-Angle.TID300Representation = TID300CobbAngle;
+Angle.TID300Representation = TID300Angle;
 Angle.isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
     if (!TrackingIdentifier.includes(":")) {
         return false;

--- a/packages/adapters/src/adapters/Cornerstone3D/Angle.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Angle.ts
@@ -1,0 +1,119 @@
+import { utilities } from "dcmjs";
+import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
+import MeasurementReport from "./MeasurementReport";
+
+const { CobbAngle: TID300CobbAngle } = utilities.TID300;
+
+const MEASUREMENT_TYPE = "Angle";
+const trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${MEASUREMENT_TYPE}`;
+
+class Angle {
+    public static toolType = MEASUREMENT_TYPE;
+    public static utilityToolType = MEASUREMENT_TYPE;
+    public static TID300Representation = TID300CobbAngle;
+    public static isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
+        if (!TrackingIdentifier.includes(":")) {
+            return false;
+        }
+
+        const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
+
+        if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
+            return false;
+        }
+
+        return toolType === MEASUREMENT_TYPE;
+    };
+
+    // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
+    public static getMeasurementData(
+        MeasurementGroup,
+        sopInstanceUIDToImageIdMap,
+        imageToWorldCoords,
+        metadata
+    ) {
+        const { defaultState, NUMGroup, SCOORDGroup, ReferencedFrameNumber } =
+            MeasurementReport.getSetupMeasurementData(
+                MeasurementGroup,
+                sopInstanceUIDToImageIdMap,
+                metadata,
+                Angle.toolType
+            );
+
+        const referencedImageId =
+            defaultState.annotation.metadata.referencedImageId;
+
+        const { GraphicData } = SCOORDGroup;
+        const worldCoords = [];
+        for (let i = 0; i < GraphicData.length; i += 2) {
+            const point = imageToWorldCoords(referencedImageId, [
+                GraphicData[i],
+                GraphicData[i + 1]
+            ]);
+            worldCoords.push(point);
+        }
+
+        const state = defaultState;
+
+        state.annotation.data = {
+            handles: {
+                points: [worldCoords[0], worldCoords[1], worldCoords[3]],
+                activeHandleIndex: 0,
+                textBox: {
+                    hasMoved: false
+                }
+            },
+            cachedStats: {
+                [`imageId:${referencedImageId}`]: {
+                    angle: NUMGroup
+                        ? NUMGroup.MeasuredValueSequence.NumericValue
+                        : null
+                }
+            },
+            frameNumber: ReferencedFrameNumber
+        };
+
+        return state;
+    }
+
+    public static getTID300RepresentationArguments(tool, worldToImageCoords) {
+        const { data, finding, findingSites, metadata } = tool;
+        const { cachedStats = {}, handles } = data;
+
+        const { referencedImageId } = metadata;
+
+        if (!referencedImageId) {
+            throw new Error(
+                "Angle.getTID300RepresentationArguments: referencedImageId is not defined"
+            );
+        }
+
+        const start1 = worldToImageCoords(referencedImageId, handles.points[0]);
+        const middle = worldToImageCoords(referencedImageId, handles.points[1]);
+
+        const end = worldToImageCoords(referencedImageId, handles.points[2]);
+
+        const point1 = { x: start1[0], y: start1[1] };
+        const point2 = { x: middle[0], y: middle[1] };
+        const point3 = point2;
+        const point4 = { x: end[0], y: end[1] };
+
+        const { angle } = cachedStats[`imageId:${referencedImageId}`] || {};
+
+        // Represented as a cobb angle
+        return {
+            point1,
+            point2,
+            point3,
+            point4,
+            rAngle: angle,
+            trackingIdentifierTextValue,
+            finding,
+            findingSites: findingSites || []
+        };
+    }
+}
+
+MeasurementReport.registerTool(Angle);
+
+export default Angle;

--- a/packages/adapters/src/adapters/Cornerstone3D/Bidirectional.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Bidirectional.ts
@@ -11,7 +11,24 @@ const SHORT_AXIS = "Short Axis";
 const trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${BIDIRECTIONAL}`;
 
 class Bidirectional {
-    static getMeasurementData(
+    public static toolType = BIDIRECTIONAL;
+    public static utilityToolType = BIDIRECTIONAL;
+    public static TID300Representation = TID300Bidirectional;
+    public static isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
+        if (!TrackingIdentifier.includes(":")) {
+            return false;
+        }
+
+        const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
+
+        if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
+            return false;
+        }
+
+        return toolType === BIDIRECTIONAL;
+    };
+
+    public static getMeasurementData(
         MeasurementGroup,
         sopInstanceUIDToImageIdMap,
         imageToWorldCoords,
@@ -102,16 +119,16 @@ class Bidirectional {
         const { points } = handles;
 
         // Find the length and width point pairs by comparing the distances of the points at 0,1 to points at 2,3
-        let firstPointPairs = [points[0], points[1]];
-        let secondPointPairs = [points[2], points[3]];
+        const firstPointPairs = [points[0], points[1]];
+        const secondPointPairs = [points[2], points[3]];
 
-        let firstPointPairsDistance = Math.sqrt(
+        const firstPointPairsDistance = Math.sqrt(
             Math.pow(firstPointPairs[0][0] - firstPointPairs[1][0], 2) +
                 Math.pow(firstPointPairs[0][1] - firstPointPairs[1][1], 2) +
                 Math.pow(firstPointPairs[0][2] - firstPointPairs[1][2], 2)
         );
 
-        let secondPointPairsDistance = Math.sqrt(
+        const secondPointPairsDistance = Math.sqrt(
             Math.pow(secondPointPairs[0][0] - secondPointPairs[1][0], 2) +
                 Math.pow(secondPointPairs[0][1] - secondPointPairs[1][1], 2) +
                 Math.pow(secondPointPairs[0][2] - secondPointPairs[1][2], 2)
@@ -173,23 +190,6 @@ class Bidirectional {
         };
     }
 }
-
-Bidirectional.toolType = BIDIRECTIONAL;
-Bidirectional.utilityToolType = BIDIRECTIONAL;
-Bidirectional.TID300Representation = TID300Bidirectional;
-Bidirectional.isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
-    if (!TrackingIdentifier.includes(":")) {
-        return false;
-    }
-
-    const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
-
-    if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
-        return false;
-    }
-
-    return toolType === BIDIRECTIONAL;
-};
 
 MeasurementReport.registerTool(Bidirectional);
 

--- a/packages/adapters/src/adapters/Cornerstone3D/CobbAngle.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/CobbAngle.ts
@@ -8,8 +8,25 @@ const MEASUREMENT_TYPE = "CobbAngle";
 const trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${MEASUREMENT_TYPE}`;
 
 class CobbAngle {
+    public static toolType = MEASUREMENT_TYPE;
+    public static utilityToolType = MEASUREMENT_TYPE;
+    public static TID300Representation = TID300CobbAngle;
+    public static isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
+        if (!TrackingIdentifier.includes(":")) {
+            return false;
+        }
+
+        const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
+
+        if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
+            return false;
+        }
+
+        return toolType === MEASUREMENT_TYPE;
+    };
+
     // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
-    static getMeasurementData(
+    public static getMeasurementData(
         MeasurementGroup,
         sopInstanceUIDToImageIdMap,
         imageToWorldCoords,
@@ -64,7 +81,7 @@ class CobbAngle {
         return state;
     }
 
-    static getTID300RepresentationArguments(tool, worldToImageCoords) {
+    public static getTID300RepresentationArguments(tool, worldToImageCoords) {
         const { data, finding, findingSites, metadata } = tool;
         const { cachedStats = {}, handles } = data;
 
@@ -101,24 +118,6 @@ class CobbAngle {
         };
     }
 }
-
-CobbAngle.toolType = MEASUREMENT_TYPE;
-CobbAngle.utilityToolType = MEASUREMENT_TYPE;
-console.log("TID300CobbAngle=", TID300CobbAngle);
-CobbAngle.TID300Representation = TID300CobbAngle;
-CobbAngle.isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
-    if (!TrackingIdentifier.includes(":")) {
-        return false;
-    }
-
-    const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
-
-    if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
-        return false;
-    }
-
-    return toolType === MEASUREMENT_TYPE;
-};
 
 MeasurementReport.registerTool(CobbAngle);
 

--- a/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
@@ -255,7 +255,7 @@ export default class MeasurementReport {
             const instance = metadataProvider.getInstance(imageId);
 
             const { sopInstanceUID, sopClassUID } = sopCommonModule;
-            const { seriesInstanceUID } = instance;
+            const { SeriesInstanceUID: seriesInstanceUID } = instance;
 
             sopInstanceUIDsToSeriesInstanceUIDMap[sopInstanceUID] =
                 seriesInstanceUID;
@@ -319,7 +319,7 @@ export default class MeasurementReport {
 
         const contentItem = tid1500MeasurementReport.contentItem(
             derivationSourceDatasets,
-            { sopInstanceUIDsToSeriesInstanceUIDMap }
+            { ...options, sopInstanceUIDsToSeriesInstanceUIDMap }
         );
 
         // Merge the derived dataset with the content from the Measurement Report

--- a/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
@@ -17,7 +17,7 @@ const FINDING = { CodingSchemeDesignator: "DCM", CodeValue: "121071" };
 const FINDING_SITE = { CodingSchemeDesignator: "SCT", CodeValue: "363698007" };
 const FINDING_SITE_OLD = { CodingSchemeDesignator: "SRT", CodeValue: "G-C0E3" };
 
-const codeValueMatch = (group, code, oldCode) => {
+const codeValueMatch = (group, code, oldCode?) => {
     const { ConceptNameCodeSequence } = group;
     if (!ConceptNameCodeSequence) return;
     const { CodingSchemeDesignator, CodeValue } = ConceptNameCodeSequence;
@@ -82,13 +82,17 @@ function getMeasurementGroup(
 }
 
 export default class MeasurementReport {
+    public static MEASUREMENT_BY_TOOLTYPE = {};
+    public static CORNERSTONE_TOOL_CLASSES_BY_UTILITY_TYPE = {};
+    public static CORNERSTONE_TOOL_CLASSES_BY_TOOL_TYPE = {};
+
     static getCornerstoneLabelFromDefaultState(defaultState) {
         const { findingSites = [], finding } = defaultState;
 
         const cornersoneFreeTextCodingValue =
             Cornerstone3DCodingScheme.codeValues.CORNERSTONEFREETEXT;
 
-        let freeTextLabel = findingSites.find(
+        const freeTextLabel = findingSites.find(
             fs => fs.CodeValue === cornersoneFreeTextCodingValue
         );
 
@@ -132,10 +136,7 @@ export default class MeasurementReport {
         return _meta;
     }
 
-    static generateDerivationSourceDataset(
-        StudyInstanceUID,
-        SeriesInstanceUID
-    ) {
+    static generateDerivationSourceDataset = instance => {
         const _vrMap = {
             PixelData: "OW"
         };
@@ -143,14 +144,13 @@ export default class MeasurementReport {
         const _meta = MeasurementReport.generateDatasetMeta();
 
         const derivationSourceDataset = {
-            StudyInstanceUID,
-            SeriesInstanceUID,
+            ...instance,
             _meta: _meta,
             _vrMap: _vrMap
         };
 
         return derivationSourceDataset;
-    }
+    };
 
     static getSetupMeasurementData(
         MeasurementGroup,
@@ -193,6 +193,7 @@ export default class MeasurementReport {
         });
 
         const defaultState = {
+            description: undefined,
             sopInstanceUid: ReferencedSOPInstanceUID,
             annotation: {
                 annotationUID: DicomMetaDictionary.uid(),
@@ -251,13 +252,10 @@ export default class MeasurementReport {
                 "sopCommonModule",
                 imageId
             );
-            const generalSeriesModule = metadataProvider.get(
-                "generalSeriesModule",
-                imageId
-            );
+            const instance = metadataProvider.getInstance(imageId);
 
             const { sopInstanceUID, sopClassUID } = sopCommonModule;
-            const { studyInstanceUID, seriesInstanceUID } = generalSeriesModule;
+            const { seriesInstanceUID } = instance;
 
             sopInstanceUIDsToSeriesInstanceUIDMap[sopInstanceUID] =
                 seriesInstanceUID;
@@ -269,10 +267,7 @@ export default class MeasurementReport {
             ) {
                 // Entry not present for series, create one.
                 const derivationSourceDataset =
-                    MeasurementReport.generateDerivationSourceDataset(
-                        studyInstanceUID,
-                        seriesInstanceUID
-                    );
+                    MeasurementReport.generateDerivationSourceDataset(instance);
 
                 derivationSourceDatasets.push(derivationSourceDataset);
             }
@@ -283,10 +278,10 @@ export default class MeasurementReport {
 
             const ReferencedSOPSequence = {
                 ReferencedSOPClassUID: sopClassUID,
-                ReferencedSOPInstanceUID: sopInstanceUID
+                ReferencedSOPInstanceUID: sopInstanceUID,
+                ReferencedFrameNumber: undefined
             };
 
-            const instance = metadataProvider.get("instance", imageId);
             if (
                 (instance &&
                     instance.NumberOfFrames &&
@@ -320,7 +315,7 @@ export default class MeasurementReport {
             options
         );
 
-        const report = new StructuredReport(derivationSourceDatasets);
+        const report = new StructuredReport(derivationSourceDatasets, options);
 
         const contentItem = tid1500MeasurementReport.contentItem(
             derivationSourceDatasets,
@@ -336,17 +331,13 @@ export default class MeasurementReport {
 
     /**
      * Generate Cornerstone tool state from dataset
-     * @param {object} dataset dataset
-     * @param {object} hooks
-     * @param {function} hooks.getToolClass Function to map dataset to a tool class
-     * @returns
      */
     static generateToolState(
         dataset,
         sopInstanceUIDToImageIdMap,
         imageToWorldCoords,
         metadata,
-        hooks = {}
+        hooks
     ) {
         // For now, bail out if the dataset is not a TID1500 SR with length measurements
         if (dataset.ContentTemplateSequence.TemplateIdentifier !== "1500") {
@@ -396,17 +387,17 @@ export default class MeasurementReport {
 
             const TrackingIdentifierValue = TrackingIdentifierGroup.TextValue;
 
-            const toolClass = hooks.getToolClass
-                ? hooks.getToolClass(
-                      measurementGroup,
-                      dataset,
-                      registeredToolClasses
-                  )
-                : registeredToolClasses.find(tc =>
-                      tc.isValidCornerstoneTrackingIdentifier(
-                          TrackingIdentifierValue
-                      )
-                  );
+            const toolClass =
+                hooks?.getToolClass?.(
+                    measurementGroup,
+                    dataset,
+                    registeredToolClasses
+                ) ||
+                registeredToolClasses.find(tc =>
+                    tc.isValidCornerstoneTrackingIdentifier(
+                        TrackingIdentifierValue
+                    )
+                );
 
             if (toolClass) {
                 const measurement = toolClass.getMeasurementData(
@@ -439,7 +430,3 @@ export default class MeasurementReport {
             toolClass.utilityToolType;
     }
 }
-
-MeasurementReport.MEASUREMENT_BY_TOOLTYPE = {};
-MeasurementReport.CORNERSTONE_TOOL_CLASSES_BY_UTILITY_TYPE = {};
-MeasurementReport.CORNERSTONE_TOOL_CLASSES_BY_TOOL_TYPE = {};

--- a/packages/adapters/src/adapters/Cornerstone3D/PlanarFreehandROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/PlanarFreehandROI.ts
@@ -10,6 +10,23 @@ const trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${PLANARFREEHANDROI}`
 const closedContourThreshold = 1e-5;
 
 class PlanarFreehandROI {
+    public static toolType = PLANARFREEHANDROI;
+    public static utilityToolType = PLANARFREEHANDROI;
+    public static TID300Representation = TID300Polyline;
+    public static isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
+        if (!TrackingIdentifier.includes(":")) {
+            return false;
+        }
+
+        const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
+
+        if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
+            return false;
+        }
+
+        return toolType === PLANARFREEHANDROI;
+    };
+
     static getMeasurementData(
         MeasurementGroup,
         sopInstanceUIDToImageIdMap,
@@ -53,7 +70,7 @@ class PlanarFreehandROI {
             isOpenContour = false;
         }
 
-        let points = [];
+        const points = [];
 
         if (isOpenContour) {
             points.push(worldCoords[0], worldCoords[worldCoords.length - 1]);
@@ -114,23 +131,6 @@ class PlanarFreehandROI {
         };
     }
 }
-
-PlanarFreehandROI.toolType = PLANARFREEHANDROI;
-PlanarFreehandROI.utilityToolType = PLANARFREEHANDROI;
-PlanarFreehandROI.TID300Representation = TID300Polyline;
-PlanarFreehandROI.isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
-    if (!TrackingIdentifier.includes(":")) {
-        return false;
-    }
-
-    const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
-
-    if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
-        return false;
-    }
-
-    return toolType === PLANARFREEHANDROI;
-};
 
 MeasurementReport.registerTool(PlanarFreehandROI);
 

--- a/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
@@ -1,0 +1,115 @@
+import { utilities } from "dcmjs";
+import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
+import MeasurementReport from "./MeasurementReport";
+
+const { Polyline: TID300Polyline } = utilities.TID300;
+
+const TOOLTYPE = "RectangleROI";
+const trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${TOOLTYPE}`;
+
+class RectangleROI {
+    public static toolType = TOOLTYPE;
+    public static utilityToolType = TOOLTYPE;
+    public static TID300Representation = TID300Polyline;
+
+    public static isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
+        if (!TrackingIdentifier.includes(":")) {
+            return false;
+        }
+
+        const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
+
+        if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
+            return false;
+        }
+
+        return toolType === TOOLTYPE;
+    };
+
+    public static getMeasurementData(
+        MeasurementGroup,
+        sopInstanceUIDToImageIdMap,
+        imageToWorldCoords,
+        metadata
+    ) {
+        const { defaultState, NUMGroup, SCOORDGroup, ReferencedFrameNumber } =
+            MeasurementReport.getSetupMeasurementData(
+                MeasurementGroup,
+                sopInstanceUIDToImageIdMap,
+                metadata,
+                RectangleROI.toolType
+            );
+
+        const referencedImageId =
+            defaultState.annotation.metadata.referencedImageId;
+
+        const { GraphicData } = SCOORDGroup;
+        const worldCoords = [];
+        for (let i = 0; i < GraphicData.length; i += 2) {
+            const point = imageToWorldCoords(referencedImageId, [
+                GraphicData[i],
+                GraphicData[i + 1]
+            ]);
+            worldCoords.push(point);
+        }
+
+        const state = defaultState;
+
+        state.annotation.data = {
+            handles: {
+                points: [
+                    worldCoords[0],
+                    worldCoords[1],
+                    worldCoords[2],
+                    worldCoords[3]
+                ],
+                activeHandleIndex: 0,
+                textBox: {
+                    hasMoved: false
+                }
+            },
+            cachedStats: {
+                [`imageId:${referencedImageId}`]: {
+                    area: NUMGroup
+                        ? NUMGroup.MeasuredValueSequence.NumericValue
+                        : null
+                }
+            },
+            frameNumber: ReferencedFrameNumber
+        };
+
+        return state;
+    }
+
+    static getTID300RepresentationArguments(tool, worldToImageCoords) {
+        const { data, finding, findingSites, metadata } = tool;
+        const { cachedStats = {}, handles } = data;
+
+        const { referencedImageId } = metadata;
+
+        if (!referencedImageId) {
+            throw new Error(
+                "CobbAngle.getTID300RepresentationArguments: referencedImageId is not defined"
+            );
+        }
+
+        const corners = handles.points.map(point =>
+            worldToImageCoords(referencedImageId, point)
+        );
+
+        const { area, perimeter } = cachedStats;
+
+        return {
+            points: corners,
+            area,
+            perimeter,
+            trackingIdentifierTextValue,
+            finding,
+            findingSites: findingSites || []
+        };
+    }
+}
+
+MeasurementReport.registerTool(RectangleROI);
+
+export default RectangleROI;

--- a/packages/adapters/src/adapters/Cornerstone3D/index.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/index.ts
@@ -4,8 +4,10 @@ import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
 
 import ArrowAnnotate from "./ArrowAnnotate";
 import Bidirectional from "./Bidirectional";
+import Angle from "./Angle";
 import CobbAngle from "./CobbAngle";
 import EllipticalROI from "./EllipticalROI";
+import RectangleROI from "./RectangleROI";
 import Length from "./Length";
 import PlanarFreehandROI from "./PlanarFreehandROI";
 import Probe from "./Probe";
@@ -13,8 +15,10 @@ import Probe from "./Probe";
 const Cornerstone3D = {
     Bidirectional,
     CobbAngle,
+    Angle,
     Length,
     EllipticalROI,
+    RectangleROI,
     ArrowAnnotate,
     Probe,
     PlanarFreehandROI,

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -582,9 +582,11 @@ class PlanarFreehandROITool extends AnnotationTool {
     if (!(isDrawing || isEditingOpen || isEditingClosed)) {
       // No annotations are currently being modified, so we can just use the
       // render contour method to render all of them
-      annotations.forEach((annotation) =>
-        this.renderContour(enabledElement, svgDrawingHelper, annotation)
-      );
+      annotations.forEach((annotation) => {
+        console.log('annotation render', annotation);
+        if (!annotation) return;
+        this.renderContour(enabledElement, svgDrawingHelper, annotation);
+      });
 
       return renderStatus;
     }

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -583,7 +583,6 @@ class PlanarFreehandROITool extends AnnotationTool {
       // No annotations are currently being modified, so we can just use the
       // render contour method to render all of them
       annotations.forEach((annotation) => {
-        console.log('annotation render', annotation);
         if (!annotation) return;
         this.renderContour(enabledElement, svgDrawingHelper, annotation);
       });


### PR DESCRIPTION
Add additional adapters for Rectangle, Angle, PlanarFreehand
Fix the generated DICOM so it included all the patient/study attributes so it doesn't fail to send against a validating PACS.  This is a critical bug in that the generated DICOM was missing the Patient ID attribute, and thus would fail to store on any DICOM compliant PACS back end.