### PR TITLE
fix(doubleClick): mouseDoubleClickIgnoreListener is now added to each viewport element instead of the document element

### DIFF
--- a/packages/tools/examples/doubleClickWithStackAnnotationTools/index.ts
+++ b/packages/tools/examples/doubleClickWithStackAnnotationTools/index.ts
@@ -45,7 +45,12 @@ setTitleAndDescription(
 );
 
 const content = document.getElementById('content');
+content.style.display = 'flex';
+content.style.flexDirection = 'column';
+content.style.alignItems = 'flex-start';
+
 const element = document.createElement('div');
+const elementWrapper = document.createElement('div');
 
 // Disable right click context menu so we can have right click tools
 element.oncontextmenu = (e) => e.preventDefault();
@@ -55,7 +60,7 @@ element.id = 'cornerstone-element';
 // It is best to listen for the browser double click event on an ancestor of the viewport
 // element instead of the viewport element itself. This is so that in case CS3D needs to
 // handle the double click first (e.g. edit arrow annotation) and stop its propagation.
-content.addEventListener('dblclick', () => {
+elementWrapper.addEventListener('dblclick', () => {
   toggleCanvasSize();
 
   browserDoubleClickEventStatus.style.visibility = '';
@@ -86,15 +91,17 @@ element.addEventListener(Events.MOUSE_CLICK, () => {
   statusDiv.style.backgroundColor = '#00ff00';
 });
 
-content.appendChild(element);
+elementWrapper.appendChild(element);
+content.appendChild(elementWrapper);
 
 // double click status info elements
 const statusDiv = document.createElement('div');
 statusDiv.style.width = element.style.width;
+statusDiv.style.marginTop = '16px';
 
 content.append(statusDiv);
 
-const browserDoubleClickEventStatus = document.createElement('p');
+const browserDoubleClickEventStatus = document.createElement('span');
 browserDoubleClickEventStatus.style.visibility = 'hidden';
 statusDiv.append(browserDoubleClickEventStatus);
 

--- a/packages/tools/src/eventListeners/mouse/index.ts
+++ b/packages/tools/src/eventListeners/mouse/index.ts
@@ -1,5 +1,7 @@
 import mouseDoubleClickListener from './mouseDoubleClickListener';
-import mouseDownListener from './mouseDownListener';
+import mouseDownListener, {
+  mouseDoubleClickIgnoreListener,
+} from './mouseDownListener';
 import mouseMoveListener from './mouseMoveListener';
 
 /**
@@ -14,6 +16,13 @@ function disable(element: HTMLDivElement): void {
   element.removeEventListener('dblclick', mouseDoubleClickListener);
   element.removeEventListener('mousedown', mouseDownListener);
   element.removeEventListener('mousemove', mouseMoveListener);
+  // The mouseDoubleClickIgnoreListener prevents those browser 'dblclick'
+  // events that cornerstone has determined are single clicks from propagating
+  // to other (3rd party) listeners. A capture phase listener is used so that
+  // the 'dblclick' event can be ignored and not propagated ASAP.
+  element.removeEventListener('dblclick', mouseDoubleClickIgnoreListener, {
+    capture: true,
+  });
 }
 
 /**
@@ -31,6 +40,13 @@ function enable(element: HTMLDivElement): void {
   element.addEventListener('dblclick', mouseDoubleClickListener);
   element.addEventListener('mousedown', mouseDownListener);
   element.addEventListener('mousemove', mouseMoveListener);
+  // The mouseDoubleClickIgnoreListener prevents those browser 'dblclick'
+  // events that cornerstone has determined are single clicks from propagating
+  // to other (3rd party) listeners. A capture phase listener is used so that
+  // the 'dblclick' event can be ignored and not propagated ASAP.
+  element.addEventListener('dblclick', mouseDoubleClickIgnoreListener, {
+    capture: true,
+  });
 }
 
 export default {

--- a/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
+++ b/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
@@ -138,6 +138,7 @@ function mouseDownListener(evt: MouseEvent) {
   // First mouse down of a potential double click. So save it and start
   // a timeout to determine a double click.
   doubleClickState.mouseDownEvent = evt;
+  doubleClickState.ignoreDoubleClick = false;
 
   state.element = <HTMLDivElement>evt.currentTarget;
 
@@ -222,10 +223,8 @@ function _onMouseDrag(evt: MouseEvent) {
 
   if (doubleClickState.doubleClickTimeout) {
     if (_isDragPastDoubleClickTolerance(deltaPoints.canvas)) {
-      _doStateMouseDownAndUp();
-
       // Dragging past the tolerance means no double click should occur.
-      doubleClickState.ignoreDoubleClick = true;
+      _doStateMouseDownAndUp();
     } else {
       return;
     }
@@ -280,19 +279,7 @@ function _onMouseUp(evt: MouseEvent): void {
       state.element.addEventListener('mousemove', _onMouseMove);
     } else {
       // this is the second mouse up of a double click!
-
-      document.removeEventListener('mouseup', _onMouseUp);
-      state.element.removeEventListener('mousemove', _onMouseMove);
-
-      // Restore our global mousemove listener
-      state.element.addEventListener('mousemove', mouseMoveListener);
-
-      // ignore any mouse down and up events captured and let the double click happen
-      _clearDoubleClickTimeoutAndEvents();
-
-      doubleClickState.ignoreDoubleClick = false;
-
-      state = JSON.parse(JSON.stringify(defaultState));
+      _cleanUp();
     }
   } else {
     // Handle the actual mouse up. Note that it may have occurred during the double click timeout or
@@ -321,15 +308,7 @@ function _onMouseUp(evt: MouseEvent): void {
 
     triggerEvent(eventDetail.element, eventName, eventDetail);
 
-    document.removeEventListener('mouseup', _onMouseUp);
-
-    state.element.removeEventListener('mousemove', _onMouseMove);
-
-    // Restore our global mousemove listener
-    state.element.addEventListener('mousemove', mouseMoveListener);
-
-    // Restore `state` to `defaultState`
-    state = JSON.parse(JSON.stringify(defaultState));
+    _cleanUp();
   }
 
   // Remove the drag as soon as we get the mouse up because either we have executed
@@ -358,9 +337,6 @@ function _onMouseMove(evt: MouseEvent) {
   }
 
   _doStateMouseDownAndUp();
-
-  // Moving past the tolerance means no double click should occur.
-  doubleClickState.ignoreDoubleClick = true;
 
   // Do the move again because during the timeout the global mouse move listener was removed.
   // Now it is back.
@@ -394,8 +370,8 @@ function _preventClickHandler() {
  * or mouse move/drag tolerance is inaccurate and we do indeed get a double click event from
  * the browser later. The flag will be cleared in the mouseDoubleClickIgnoreListener should a
  * double click event get fired. If there is no eventual double click for the latest sequence,
- * the flag spills into the next sequence where it will either get set again (here) or cleared in
- * _onMouseUp if an actual double click is detected. It is perfectly safe for the flag to be
+ * the flag spills into the next sequence where it will get cleared at the beginning of that next
+ * sequence in mouseDownListener. It is perfectly safe for the flag to be
  * left true when no double click actually occurs because any future double click must start with
  * a mouse down that is handled in this module.
  *
@@ -421,11 +397,25 @@ function _doStateMouseDownAndUp() {
  * The timeout itself is also cleared so that no callback is invoked.
  */
 function _clearDoubleClickTimeoutAndEvents() {
-  clearTimeout(doubleClickState.doubleClickTimeout);
-  doubleClickState.doubleClickTimeout = null;
+  if (doubleClickState.doubleClickTimeout) {
+    clearTimeout(doubleClickState.doubleClickTimeout);
+    doubleClickState.doubleClickTimeout = null;
+  }
 
   doubleClickState.mouseDownEvent = null;
   doubleClickState.mouseUpEvent = null;
+}
+
+function _cleanUp() {
+  document.removeEventListener('mouseup', _onMouseUp);
+  state.element?.removeEventListener('mousemove', _onMouseMove);
+
+  // Restore our global mousemove listener
+  state.element?.addEventListener('mousemove', mouseMoveListener);
+
+  _clearDoubleClickTimeoutAndEvents();
+
+  state = JSON.parse(JSON.stringify(defaultState));
 }
 
 /**
@@ -517,6 +507,12 @@ export function mouseDoubleClickIgnoreListener(evt: MouseEvent) {
     // that any third party listener has not already handled the event.
     evt.stopImmediatePropagation();
     evt.preventDefault();
+  } else {
+    // If the embedding application blocked the first mouse down and up
+    // of a double click sequence from reaching this module, then this module
+    // has handled the second mouse down and up and thus needs to clean them up.
+    // Doing a clean up here for the typical double click case is harmless.
+    _cleanUp();
   }
 }
 

--- a/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
+++ b/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
@@ -503,32 +503,12 @@ export function getMouseButton(): number {
 }
 
 /**
- * Adds a capture phase double click listener to the document that ignores double
- * click events as determined by this module.
- */
-export function addIgnoreDoubleClickCaptureListener() {
-  document.addEventListener('dblclick', _mouseDoubleClickIgnoreListener, {
-    capture: true,
-  });
-}
-
-/**
- * Removes a capture phase double click listener from the document that ignores double
- * click events as determined by this module.
- */
-export function removeIgnoreDoubleClickCaptureListener() {
-  document.removeEventListener('dblclick', _mouseDoubleClickIgnoreListener, {
-    capture: true,
-  });
-}
-
-/**
  * Handles a dblclick event to determine if it should be ignored based on the
  * double click state's ignoreDoubleClick flag. stopImmediatePropagation and
- * preventDefault are used to ingore the event.
+ * preventDefault are used to ignore the event.
  * @param evt browser dblclick event
  */
-function _mouseDoubleClickIgnoreListener(evt: MouseEvent) {
+export function mouseDoubleClickIgnoreListener(evt: MouseEvent) {
   if (doubleClickState.ignoreDoubleClick) {
     doubleClickState.ignoreDoubleClick = false;
 

--- a/packages/tools/src/init.ts
+++ b/packages/tools/src/init.ts
@@ -14,10 +14,6 @@ import {
 } from './eventListeners';
 
 import * as ToolGroupManager from './store/ToolGroupManager';
-import {
-  addIgnoreDoubleClickCaptureListener,
-  removeIgnoreDoubleClickCaptureListener,
-} from './eventListeners/mouse/mouseDownListener';
 
 let csToolsInitialized = false;
 
@@ -35,12 +31,6 @@ export function init(defaultConfiguration = {}): void {
   _addCornerstoneEventListeners();
   _addCornerstoneToolsEventListeners();
 
-  // A separate double click listener at the document root. Separate
-  // from the {@link mouseDoubleClickListener} because...
-  // - it listens on the capture phase (and not the typical bubble phase)
-  // - the data used to ignore the double click is private to the mouseDownListener module
-  addIgnoreDoubleClickCaptureListener();
-
   csToolsInitialized = true;
 }
 
@@ -52,8 +42,6 @@ export function init(defaultConfiguration = {}): void {
 export function destroy(): void {
   _removeCornerstoneEventListeners();
   _removeCornerstoneToolsEventListeners();
-
-  removeIgnoreDoubleClickCaptureListener();
 
   // Important: destroy ToolGroups first, in order for cleanup to work correctly for the
   // added tools.


### PR DESCRIPTION
CS3D issue #375

Testing notes...
1. Run the `doubleclickwithstackannotationtools` example.
2. Open the browser dev tools.
3. In the Sources' tab of the browser dev tool, Ctrl+P to open the mouseDownListener.ts file.
4. Place a break point in the `mouseDoubleClickIgnoreListener` function inside the `if (doubleClickState.ignoreDoubleClick) {` block (see below).
```
export function mouseDoubleClickIgnoreListener(evt: MouseEvent) {
  if (doubleClickState.ignoreDoubleClick) {
    // breakpoint/debugger here
    doubleClickState.ignoreDoubleClick = false;
  ...
```
5. Single click on the viewport element image (i.e. to start a markup).
6. Now move the mouse to the right, outside of the viewport element and double click.
7. The breakpoint added should NOT be hit.

The same test should be tried with the `stackbasic` example.
