### PR TITLE
fix(adapters): Update the build a little to allow debugging into typescript

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -3,7 +3,8 @@
     "version": "0.3.1",
     "description": "Adapters for Cornerstone3D to/from formats including DICOM SR and others",
     "src": "src/index.ts",
-    "main": "src/index.ts",
+    "main": "./dist/@cornerstonejs/adapters.es.js",
+    "module": "src/index.ts",
     "files": [
         "dist"
     ],

--- a/packages/adapters/src/adapters/Cornerstone3D/EllipticalROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/EllipticalROI.ts
@@ -2,6 +2,7 @@ import { vec3 } from "gl-matrix";
 import { utilities } from "dcmjs";
 import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
 import MeasurementReport from "./MeasurementReport";
+import isValidCornerstoneTrackingIdentifier from "./isValidCornerstoneTrackingIdentifier";
 
 const { Ellipse: TID300Ellipse } = utilities.TID300;
 
@@ -11,6 +12,12 @@ const EPSILON = 1e-4;
 const trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${ELLIPTICALROI}`;
 
 class EllipticalROI {
+    static toolType = ELLIPTICALROI;
+    static utilityToolType = ELLIPTICALROI;
+    static TID300Representation = TID300Ellipse;
+    static isValidCornerstoneTrackingIdentifier =
+        isValidCornerstoneTrackingIdentifier.bind(EllipticalROI);
+
     static getMeasurementData(
         MeasurementGroup,
         sopInstanceUIDToImageIdMap,
@@ -149,7 +156,7 @@ class EllipticalROI {
         const topBottomLength = Math.abs(top[1] - bottom[1]);
         const leftRightLength = Math.abs(left[0] - right[0]);
 
-        let points = [];
+        const points = [];
         if (topBottomLength > leftRightLength) {
             // major axis is bottom to top
             points.push({ x: top[0], y: top[1] });
@@ -179,25 +186,6 @@ class EllipticalROI {
         };
     }
 }
-
-EllipticalROI.toolType = ELLIPTICALROI;
-EllipticalROI.utilityToolType = ELLIPTICALROI;
-EllipticalROI.TID300Representation = TID300Ellipse;
-EllipticalROI.isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
-    if (!TrackingIdentifier.includes(":")) {
-        return false;
-    }
-
-    const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
-
-    if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
-        return false;
-    }
-
-    // The following is needed since the new cornerstone3D has changed
-    // the EllipticalRoi toolName (which was in the old cornerstone) to EllipticalROI
-    return toolType.toLowerCase() === ELLIPTICALROI.toLowerCase();
-};
 
 MeasurementReport.registerTool(EllipticalROI);
 

--- a/packages/adapters/src/adapters/Cornerstone3D/EllipticalROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/EllipticalROI.ts
@@ -9,14 +9,13 @@ const { Ellipse: TID300Ellipse } = utilities.TID300;
 const ELLIPTICALROI = "EllipticalROI";
 const EPSILON = 1e-4;
 
-const trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${ELLIPTICALROI}`;
-
 class EllipticalROI {
+    static trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${ELLIPTICALROI}`;
     static toolType = ELLIPTICALROI;
     static utilityToolType = ELLIPTICALROI;
     static TID300Representation = TID300Ellipse;
     static isValidCornerstoneTrackingIdentifier =
-        isValidCornerstoneTrackingIdentifier.bind(EllipticalROI);
+        isValidCornerstoneTrackingIdentifier;
 
     static getMeasurementData(
         MeasurementGroup,
@@ -180,7 +179,7 @@ class EllipticalROI {
         return {
             area,
             points,
-            trackingIdentifierTextValue,
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
             findingSites: findingSites || []
         };

--- a/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
@@ -1,5 +1,6 @@
 import { normalizers, data, utilities, derivations } from "dcmjs";
 
+import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
 import { toArray, codeMeaningEquals } from "../helpers";
 import Cornerstone3DCodingScheme from "./CodingScheme";
 
@@ -82,6 +83,7 @@ function getMeasurementGroup(
 }
 
 export default class MeasurementReport {
+    public static CORNERSTONE_3D_TAG = CORNERSTONE_3D_TAG;
     public static MEASUREMENT_BY_TOOLTYPE = {};
     public static CORNERSTONE_TOOL_CLASSES_BY_UTILITY_TYPE = {};
     public static CORNERSTONE_TOOL_CLASSES_BY_TOOL_TYPE = {};
@@ -419,7 +421,11 @@ export default class MeasurementReport {
         return measurementData;
     }
 
-    static registerTool(toolClass) {
+    /**
+     * Register a new tool type.
+     * @param toolClass to perform I/O to DICOM for this tool
+     */
+    public static registerTool(toolClass) {
         MeasurementReport.CORNERSTONE_TOOL_CLASSES_BY_UTILITY_TYPE[
             toolClass.utilityToolType
         ] = toolClass;

--- a/packages/adapters/src/adapters/Cornerstone3D/isValidCornerstoneTrackingIdentifier.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/isValidCornerstoneTrackingIdentifier.ts
@@ -1,0 +1,19 @@
+import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
+
+export default function isValidCornerstoneTrackingIdentifier(
+    trackingIdentifier: string
+): boolean {
+    if (!trackingIdentifier.includes(":")) {
+        return false;
+    }
+
+    const [cornerstone3DTag, toolType] = trackingIdentifier.split(":");
+
+    if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
+        return false;
+    }
+
+    // The following is needed since the new cornerstone3D has changed
+    // the EllipticalRoi toolName (which was in the old cornerstone) to EllipticalROI
+    return toolType.toLowerCase() === this.toolType;
+}

--- a/packages/adapters/src/adapters/Cornerstone3D/isValidCornerstoneTrackingIdentifier.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/isValidCornerstoneTrackingIdentifier.ts
@@ -14,6 +14,6 @@ export default function isValidCornerstoneTrackingIdentifier(
     }
 
     // The following is needed since the new cornerstone3D has changed
-    // the EllipticalRoi toolName (which was in the old cornerstone) to EllipticalROI
-    return toolType.toLowerCase() === this.toolType;
+    // case names such as EllipticalRoi to EllipticalROI
+    return toolType.toLowerCase() === this.toolType.toLowerCase();
 }


### PR DESCRIPTION
This changes the release module just a tiny bit, with the impact that with yarn link, the typescript files are directly debugged, while with regular yarn install, the es module is used.