### PR TITLE
fix(voi): PET linear transfer function

### DIFF
--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -214,11 +214,7 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     let volumeActor;
 
     if (volumeId) {
-      const actorEntry = actorEntries.find((entry: ActorEntry) => {
-        return entry.uid === volumeId;
-      });
-
-      volumeActor = actorEntry?.actor as vtkVolume;
+      volumeActor = this.getActor(volumeId)?.actor as vtkVolume;
     }
 
     // // set it for the first volume (if there are more than one - fusion)
@@ -241,8 +237,18 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
       const cfun = createSigmoidRGBTransferFunction(voiRangeToUse);
       volumeActor.getProperty().setRGBTransferFunction(0, cfun);
     } else {
-      const cfun = createLinearRGBTransferFunction(voiRangeToUse);
-      volumeActor.getProperty().setRGBTransferFunction(0, cfun);
+      // TODO: refactor and make it work for PET series (inverted/colormap)
+      // const cfun = createLinearRGBTransferFunction(voiRangeToUse);
+      // volumeActor.getProperty().setRGBTransferFunction(0, cfun);
+
+      // Moving from LINEAR to SIGMOID and back to LINEAR will not
+      // work until we implement it in a different way because the
+      // LINEAR transfer function is not recreated.
+      const { lower, upper } = voiRangeToUse;
+      volumeActor
+        .getProperty()
+        .getRGBTransferFunction(0)
+        .setRange(lower, upper);
     }
 
     if (!suppressEvents) {


### PR DESCRIPTION
Reverted the changes that recreates the linear transfer function every time `setVOI` is called because that breaks PET series. PET series must have an inverted transfer function or the colormap applied on PET Fusion series must be preserved.

A new change is required to fix how SIGMOID/LINEAR transfer functions work.