### PR TITLE
fix: elliptical ROI, issue #324

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1375,7 +1375,7 @@ function drawArrow(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, ar
 function drawCircle(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, circleUID: string, center: Types_2.Point2, radius: number, options?: {}): void;
 
 // @public (undocumented)
-function drawEllipse(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, ellipseUID: string, corner1: Types_2.Point2, corner2: Types_2.Point2, options?: {}, dataId?: string): void;
+function drawEllipse(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, ellipseUID: string, corner1: Types_2.Point2, corner2: Types_2.Point2, options?: {}, dataId?: string, rotation: any): void;
 
 // @public (undocumented)
 function drawHandles(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, handleGroupUID: string, handlePoints: Array<Types_2.Point2>, options?: {}): void;
@@ -1479,6 +1479,7 @@ interface EllipticalROIAnnotation extends Annotation {
         };
         label: string;
         cachedStats?: ROICachedStats;
+        intialRotation?: any;
     };
 }
 
@@ -1540,6 +1541,8 @@ export class EllipticalROITool extends AnnotationTool {
     _pointInEllipseCanvas(ellipse: any, location: Types_2.Point2): boolean;
     // (undocumented)
     renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
+    // (undocumented)
+    _rotatePoint: (point: any, center: any, angle: any) => any;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1375,7 +1375,7 @@ function drawArrow(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, ar
 function drawCircle(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, circleUID: string, center: Types_2.Point2, radius: number, options?: {}): void;
 
 // @public (undocumented)
-function drawEllipse(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, ellipseUID: string, corner1: Types_2.Point2, corner2: Types_2.Point2, options?: {}, dataId?: string, rotation: any): void;
+function drawEllipse(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, ellipseUID: string, corner1: Types_2.Point2, corner2: Types_2.Point2, options?: {}, dataId?: string, rotation?: number): void;
 
 // @public (undocumented)
 function drawHandles(svgDrawingHelper: SVGDrawingHelper, annotationUID: string, handleGroupUID: string, handlePoints: Array<Types_2.Point2>, options?: {}): void;
@@ -1479,7 +1479,7 @@ interface EllipticalROIAnnotation extends Annotation {
         };
         label: string;
         cachedStats?: ROICachedStats;
-        intialRotation?: any;
+        initialRotation: number;
     };
 }
 
@@ -1542,7 +1542,7 @@ export class EllipticalROITool extends AnnotationTool {
     // (undocumented)
     renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
-    _rotatePoint: (point: any, center: any, angle: any) => any;
+    _rotatePoint: (point: any, center: any, angle: any) => Types_2.Point2;
     // (undocumented)
     _throttledCalculateCachedStats: any;
     // (undocumented)

--- a/packages/tools/src/drawingSvg/drawEllipse.ts
+++ b/packages/tools/src/drawingSvg/drawEllipse.ts
@@ -12,7 +12,8 @@ function drawEllipse(
   corner1: Types.Point2,
   corner2: Types.Point2,
   options = {},
-  dataId = ''
+  dataId = '',
+  rotation = 0
 ): void {
   const { color, width, lineWidth, lineDash } = Object.assign(
     {
@@ -30,15 +31,21 @@ function drawEllipse(
   const svgns = 'http://www.w3.org/2000/svg';
   const svgNodeHash = _getHash(annotationUID, 'ellipse', ellipseUID);
   const existingEllipse = svgDrawingHelper.getSvgNode(svgNodeHash);
-
+  let radiusX, radiusY;
   const w = Math.abs(corner1[0] - corner2[0]);
   const h = Math.abs(corner1[1] - corner2[1]);
   const xMin = Math.min(corner1[0], corner2[0]);
   const yMin = Math.min(corner1[1], corner2[1]);
 
   const center = [xMin + w / 2, yMin + h / 2];
-  const radiusX = w / 2;
-  const radiusY = h / 2;
+
+  if (rotation == 90 || rotation == 270) {
+    radiusX = h / 2;
+    radiusY = w / 2;
+  } else {
+    radiusX = w / 2;
+    radiusY = h / 2;
+  }
 
   const attributes = {
     cx: `${center[0]}`,

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -775,7 +775,12 @@ class EllipticalROITool extends AnnotationTool {
 
         canvasCoordinates = canvasCoordinates.map((p) =>
           this._rotatePoint(p, center, -rotation)
-        );
+        ) as [
+          Types.Point2,
+          Types.Point2,
+          Types.Point2,
+          Types.Point2
+        ];
       }
       const canvasCorners = <Array<Types.Point2>>(
         getCanvasEllipseCorners(canvasCoordinates)
@@ -974,7 +979,7 @@ class EllipticalROITool extends AnnotationTool {
     const sin = Math.sin(angleRadians);
     const x = point[0] - center[0];
     const y = point[1] - center[1];
-    return [x * cos - y * sin + center[0], x * sin + y * cos + center[1]];
+    return [x * cos - y * sin + center[0], x * sin + y * cos + center[1]] as Types.Point2;
   };
 
   _getTextLines = (data, targetId: string, isPreScaled: boolean): string[] => {

--- a/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
+++ b/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
@@ -96,6 +96,7 @@ export interface EllipticalROIAnnotation extends Annotation {
     };
     label: string;
     cachedStats?: ROICachedStats;
+    initialRotation: number;
   };
 }
 


### PR DESCRIPTION
[Issue#324](https://github.com/cornerstonejs/cornerstone3D-beta/issues/324)

Hi,

This is a fix for the EllipticalROITool not rendering correctly when rotation happens. I added a few attributes to account for the rotation, and also stored the initial rotation of the viewport as a reference for calculations.

I also added a new method called rotate point to help with the rotation of the coordinates.

This is the rotation issue that was happening:-

![GIF 5](https://user-images.githubusercontent.com/93064150/224839171-c32ef9d4-f81e-4351-ba53-c8820801e2aa.gif)

If the rotation was 90 / 270 it wouldn't render properly (the bug also occurs if the canvas is already rotated, ex 90 degrees, then you rotate again to 180, it will not render right)

The issue is still on : https://v3-demo.ohif.org if you would like to test it

This is after the fix has been added :-

![GIF 6](https://user-images.githubusercontent.com/93064150/224839181-48df5629-1fe4-4c62-9160-5498e511b1e4.gif)

Thanks.
