### PR TITLE
fix(segmentation): segmentation could not render segment while invisible

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -4473,6 +4473,12 @@ function setSegmentSpecificConfig(toolGroupId: string, segmentationRepresentatio
 function setSegmentSpecificRepresentationConfig(toolGroupId: string, segmentationRepresentationUID: string, config: SegmentSpecificRepresentationConfig, suppressEvents?: boolean): void;
 
 // @public (undocumented)
+function setSegmentsVisibility(toolGroupId: string, segmentationRepresentationUID: string, segmentIndices: number[], visibility: boolean): void;
+
+// @public (undocumented)
+function setSegmentVisibility(toolGroupId: string, segmentationRepresentationUID: string, segmentIndex: number, visibility: boolean): void;
+
+// @public (undocumented)
 type SetToolBindingsType = {
     bindings: IToolBinding[];
 };
@@ -4482,9 +4488,6 @@ function setToolGroupSpecificConfig(toolGroupId: string, config: SegmentationRep
 
 // @public (undocumented)
 function setToolGroupSpecificConfig_2(toolGroupId: string, segmentationRepresentationConfig: SegmentationRepresentationConfig): void;
-
-// @public (undocumented)
-function setVisibilityForSegmentIndex(toolGroupId: string, segmentationRepresentationUID: string, segmentIndex: number, visibility: boolean): void;
 
 // @public (undocumented)
 function showAllAnnotations(): void;
@@ -4861,7 +4864,6 @@ type ToolGroupSpecificRepresentationState = {
     type: Enums.SegmentationRepresentations;
     active: boolean;
     segmentsHidden: Set<number>;
-    visibility: boolean;
     colorLUTIndex: number;
 };
 
@@ -5213,7 +5215,8 @@ declare namespace visibility_2 {
     export {
         setSegmentationVisibility,
         getSegmentationVisibility,
-        setVisibilityForSegmentIndex
+        setSegmentVisibility,
+        setSegmentsVisibility
     }
 }
 

--- a/packages/tools/src/stateManagement/segmentation/config/segmentationVisibility.ts
+++ b/packages/tools/src/stateManagement/segmentation/config/segmentationVisibility.ts
@@ -15,10 +15,11 @@ function getSegmentationIndices(segmentationId) {
 
 /**
  * Set the visibility of a segmentation representation for a given tool group. It fires
- * a SEGMENTATION_REPRESENTATION_MODIFIED event. If the segmentation had some segments
- * hidden, it will remove them from the hidden set and make them all visible. On the
- * other hand, if the segmentation had all segments hidden, it will make all segments
- * visible.
+ * a SEGMENTATION_REPRESENTATION_MODIFIED event. If the visibility is set to true, and
+ * the segmentation representation had some segments hidden, it will show all the segments.
+ * And if the visibility is set to false, and it had some segments shown, it will hide all
+ * the segments.
+ *
  *
  * @triggers SEGMENTATION_REPRESENTATION_MODIFIED
  * @param toolGroupId - The Id of the tool group that contains the segmentation.

--- a/packages/tools/src/stateManagement/segmentation/config/segmentationVisibility.ts
+++ b/packages/tools/src/stateManagement/segmentation/config/segmentationVisibility.ts
@@ -1,11 +1,24 @@
-import { triggerSegmentationRepresentationModified } from '../triggerSegmentationEvents';
+import { cache } from '@cornerstonejs/core';
+import * as SegmentationState from '../../../stateManagement/segmentation/segmentationState';
 import { getSegmentationRepresentations } from '../../../stateManagement/segmentation/segmentationState';
 import { ToolGroupSpecificRepresentation } from '../../../types/SegmentationStateTypes';
-import * as SegmentationState from '../../../stateManagement/segmentation/segmentationState';
+import { triggerSegmentationRepresentationModified } from '../triggerSegmentationEvents';
+
+function getSegmentationIndices(segmentationId) {
+  const volume = cache.getVolume(segmentationId);
+  const scalarData = volume.getScalarData();
+
+  const keySet = {};
+  scalarData.forEach((it) => (keySet[it] = it));
+  return Object.keys(keySet).map((it) => parseInt(it, 10));
+}
 
 /**
  * Set the visibility of a segmentation representation for a given tool group. It fires
- * a SEGMENTATION_REPRESENTATION_MODIFIED event.
+ * a SEGMENTATION_REPRESENTATION_MODIFIED event. If the segmentation had some segments
+ * hidden, it will remove them from the hidden set and make them all visible. On the
+ * other hand, if the segmentation had all segments hidden, it will make all segments
+ * visible.
  *
  * @triggers SEGMENTATION_REPRESENTATION_MODIFIED
  * @param toolGroupId - The Id of the tool group that contains the segmentation.
@@ -24,19 +37,34 @@ function setSegmentationVisibility(
     return;
   }
 
-  toolGroupSegmentationRepresentations.forEach(
-    (representation: ToolGroupSpecificRepresentation) => {
-      if (
-        representation.segmentationRepresentationUID ===
-        segmentationRepresentationUID
-      ) {
-        representation.visibility = visibility;
-        triggerSegmentationRepresentationModified(
-          toolGroupId,
-          representation.segmentationRepresentationUID
-        );
-      }
-    }
+  const representation = toolGroupSegmentationRepresentations.find(
+    (representation: ToolGroupSpecificRepresentation) =>
+      representation.segmentationRepresentationUID ===
+      segmentationRepresentationUID
+  );
+
+  if (!representation) {
+    return;
+  }
+
+  const { segmentsHidden, segmentationId } = representation;
+
+  const indices = getSegmentationIndices(segmentationId);
+
+  // if visibility is set to be true, we need to remove all the segments
+  // from the segmentsHidden set, otherwise we need to add all the segments
+  // to the segmentsHidden set
+  if (visibility) {
+    segmentsHidden.clear();
+  } else {
+    indices.forEach((index) => {
+      segmentsHidden.add(index);
+    });
+  }
+
+  triggerSegmentationRepresentationModified(
+    toolGroupId,
+    representation.segmentationRepresentationUID
   );
 }
 
@@ -53,23 +81,65 @@ function getSegmentationVisibility(
   toolGroupId: string,
   segmentationRepresentationUID: string
 ): boolean | undefined {
-  const toolGroupSegRepresentations =
+  const toolGroupSegmentationRepresentations =
     getSegmentationRepresentations(toolGroupId);
 
-  const segmentationData = toolGroupSegRepresentations.find(
+  const representation = toolGroupSegmentationRepresentations.find(
     (representation: ToolGroupSpecificRepresentation) =>
       representation.segmentationRepresentationUID ===
       segmentationRepresentationUID
   );
 
-  if (!segmentationData) {
+  if (!representation) {
     return;
   }
 
-  return segmentationData.visibility;
+  const { segmentsHidden } = representation;
+
+  return segmentsHidden.size === 0;
 }
 
-function setVisibilityForSegmentIndex(
+/**
+ * Set the visibility of the given segment indices to the given visibility. This
+ * is a helper to set the visibility of multiple segments at once and reduces
+ * the number of events fired.
+ *
+ * @param toolGroupId -  The tool group id of the segmentation representation.
+ * @param segmentationRepresentationUID -  The UID of the segmentation
+ * representation.
+ * @param segmentIndices -  The indices of the segments to be hidden/shown.
+ * @param visibility -  The visibility to set the segments to.
+ *
+ */
+function setSegmentsVisibility(
+  toolGroupId: string,
+  segmentationRepresentationUID: string,
+  segmentIndices: number[],
+  visibility: boolean
+): void {
+  const segRepresentation =
+    SegmentationState.getSegmentationRepresentationByUID(
+      toolGroupId,
+      segmentationRepresentationUID
+    );
+
+  if (!segRepresentation) {
+    return;
+  }
+
+  segmentIndices.forEach((segmentIndex) => {
+    visibility
+      ? segRepresentation.segmentsHidden.delete(segmentIndex)
+      : segRepresentation.segmentsHidden.add(segmentIndex);
+  });
+
+  triggerSegmentationRepresentationModified(
+    toolGroupId,
+    segmentationRepresentationUID
+  );
+}
+
+function setSegmentVisibility(
   toolGroupId: string,
   segmentationRepresentationUID: string,
   segmentIndex: number,
@@ -85,11 +155,9 @@ function setVisibilityForSegmentIndex(
     return;
   }
 
-  if (visibility) {
-    segRepresentation.segmentsHidden.delete(segmentIndex);
-  } else {
-    segRepresentation.segmentsHidden.add(segmentIndex);
-  }
+  visibility
+    ? segRepresentation.segmentsHidden.delete(segmentIndex)
+    : segRepresentation.segmentsHidden.add(segmentIndex);
 
   triggerSegmentationRepresentationModified(
     toolGroupId,
@@ -100,5 +168,6 @@ function setVisibilityForSegmentIndex(
 export {
   setSegmentationVisibility,
   getSegmentationVisibility,
-  setVisibilityForSegmentIndex,
+  setSegmentVisibility,
+  setSegmentsVisibility,
 };

--- a/packages/tools/src/stateManagement/segmentation/config/segmentationVisibility.ts
+++ b/packages/tools/src/stateManagement/segmentation/config/segmentationVisibility.ts
@@ -15,11 +15,8 @@ function getSegmentationIndices(segmentationId) {
 
 /**
  * Set the visibility of a segmentation representation for a given tool group. It fires
- * a SEGMENTATION_REPRESENTATION_MODIFIED event. If the visibility is set to true, and
- * the segmentation representation had some segments hidden, it will show all the segments.
- * And if the visibility is set to false, and it had some segments shown, it will hide all
- * the segments.
- *
+ * a SEGMENTATION_REPRESENTATION_MODIFIED event. Visibility true will show all segments
+ * and visibility false will hide all segments"
  *
  * @triggers SEGMENTATION_REPRESENTATION_MODIFIED
  * @param toolGroupId - The Id of the tool group that contains the segmentation.

--- a/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
+++ b/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
@@ -1,15 +1,14 @@
 import {
   cache,
+  Enums,
   getEnabledElementByIds,
   Types,
-  utilities,
-  Enums,
   utilities as csUtils,
 } from '@cornerstonejs/core';
 
-import * as SegmentationState from '../../../stateManagement/segmentation/segmentationState';
-import * as SegmentationConfig from '../../../stateManagement/segmentation/config/segmentationConfig';
 import Representations from '../../../enums/SegmentationRepresentations';
+import * as SegmentationConfig from '../../../stateManagement/segmentation/config/segmentationConfig';
+import * as SegmentationState from '../../../stateManagement/segmentation/segmentationState';
 import { getToolGroup } from '../../../store/ToolGroupManager';
 import {
   RepresentationPublicInput,
@@ -17,11 +16,11 @@ import {
   ToolGroupSpecificRepresentation,
 } from '../../../types/SegmentationStateTypes';
 
-import removeContourFromElement from './removeContourFromElement';
 import {
-  addContourToElement,
   addContourSetToElement,
+  addContourToElement,
 } from './addContourToElement';
+import { default as removeContourFromElement } from './removeContourFromElement';
 
 /**
  * It adds a new segmentation representation to the segmentation state
@@ -48,7 +47,6 @@ async function addSegmentationRepresentation(
     segmentationRepresentationUID,
     type: Representations.Contour,
     segmentsHidden,
-    visibility,
     colorLUTIndex,
     active,
     segmentationRepresentationSpecificConfig: {},
@@ -133,7 +131,6 @@ async function render(
     active,
     segmentationId,
     segmentationRepresentationUID,
-    visibility,
     segmentsHidden,
   } = representation;
 

--- a/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
+++ b/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
@@ -36,7 +36,7 @@ async function addSegmentationRepresentation(
   toolGroupSpecificConfig?: SegmentationRepresentationConfig
 ): Promise<string> {
   const { segmentationId } = representationInput;
-  const segmentationRepresentationUID = utilities.uuidv4();
+  const segmentationRepresentationUID = csUtils.uuidv4();
   // Todo: make these configurable during representation input by user
   const segmentsHidden = new Set() as Set<number>;
   const visibility = true;

--- a/packages/tools/src/tools/displayTools/Labelmap/labelmapDisplay.ts
+++ b/packages/tools/src/tools/displayTools/Labelmap/labelmapDisplay.ts
@@ -1,5 +1,5 @@
-import vtkColorTransferFunction from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction';
 import vtkPiecewiseFunction from '@kitware/vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkColorTransferFunction from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction';
 
 import {
   cache,
@@ -8,9 +8,9 @@ import {
   utilities,
 } from '@cornerstonejs/core';
 
-import * as SegmentationState from '../../../stateManagement/segmentation/segmentationState';
-import * as SegmentationConfig from '../../../stateManagement/segmentation/config/segmentationConfig';
 import Representations from '../../../enums/SegmentationRepresentations';
+import * as SegmentationConfig from '../../../stateManagement/segmentation/config/segmentationConfig';
+import * as SegmentationState from '../../../stateManagement/segmentation/segmentationState';
 import { getToolGroup } from '../../../store/ToolGroupManager';
 import type { LabelmapConfig } from '../../../types/LabelmapTypes';
 import {
@@ -45,7 +45,6 @@ async function addSegmentationRepresentation(
 
   // Todo: make these configurable during representation input by user
   const segmentsHidden = new Set() as Set<number>;
-  const visibility = true;
   const colorLUTIndex = 0;
   const active = true;
   const cfun = vtkColorTransferFunction.newInstance();
@@ -58,7 +57,6 @@ async function addSegmentationRepresentation(
     segmentationRepresentationUID,
     type: Representations.Labelmap,
     segmentsHidden,
-    visibility,
     colorLUTIndex,
     active,
     segmentationRepresentationSpecificConfig: {},
@@ -150,7 +148,6 @@ async function render(
     active,
     segmentationId,
     segmentationRepresentationUID,
-    visibility,
     segmentsHidden,
     config: renderingConfig,
   } = representation;
@@ -197,8 +194,7 @@ async function render(
     representation,
     active,
     renderInactiveSegmentations,
-    segmentsHidden,
-    visibility
+    segmentsHidden
   );
 }
 
@@ -212,8 +208,7 @@ function _setLabelmapColorAndOpacity(
   segmentationRepresentation: ToolGroupSpecificRepresentation,
   isActiveLabelmap: boolean,
   renderInactiveSegmentations: boolean,
-  segmentsHidden: Set<number>,
-  visibility = true
+  segmentsHidden: Set<number>
 ): void {
   const { segmentSpecificConfig, segmentationRepresentationSpecificConfig } =
     segmentationRepresentation;
@@ -301,8 +296,7 @@ function _setLabelmapColorAndOpacity(
   // Set visibility based on whether actor visibility is specifically asked
   // to be turned on/off (on by default) AND whether is is in active but
   // we are rendering inactive labelmap
-  const visible =
-    visibility && (isActiveLabelmap || renderInactiveSegmentations);
+  const visible = isActiveLabelmap || renderInactiveSegmentations;
   volumeActor.setVisibility(visible);
 }
 

--- a/packages/tools/src/tools/displayTools/SegmentationDisplayTool.ts
+++ b/packages/tools/src/tools/displayTools/SegmentationDisplayTool.ts
@@ -63,7 +63,7 @@ class SegmentationDisplayTool extends BaseTool {
       return;
     }
 
-    // for each segmentationData, make the visibility false
+    // for each segmentationData, make the visibility true
     toolGroupSegmentationRepresentations.forEach(
       (segmentationRepresentation) => {
         setSegmentationVisibility(

--- a/packages/tools/src/tools/displayTools/SegmentationDisplayTool.ts
+++ b/packages/tools/src/tools/displayTools/SegmentationDisplayTool.ts
@@ -1,23 +1,22 @@
-import { BaseTool } from '../base';
 import {
   getEnabledElementByIds,
   Types,
   utilities as csUtils,
 } from '@cornerstonejs/core';
 import Representations from '../../enums/SegmentationRepresentations';
-import { getSegmentationRepresentations } from '../../stateManagement/segmentation/segmentationState';
-import { labelmapDisplay } from './Labelmap';
-import { contourDisplay } from './Contour';
 import { config as segmentationConfig } from '../../stateManagement/segmentation';
-import { triggerSegmentationRepresentationModified } from '../../stateManagement/segmentation/triggerSegmentationEvents';
+import { setSegmentationVisibility } from '../../stateManagement/segmentation/config/segmentationVisibility';
+import { getSegmentationRepresentations } from '../../stateManagement/segmentation/segmentationState';
 import { getToolGroup } from '../../store/ToolGroupManager';
-
 import { PublicToolProps, ToolProps } from '../../types';
+import { BaseTool } from '../base';
 
 import {
   SegmentationRepresentationConfig,
   ToolGroupSpecificRepresentation,
 } from '../../types/SegmentationStateTypes';
+import { contourDisplay } from './Contour';
+import { labelmapDisplay } from './Labelmap';
 
 /**
  * In Cornerstone3DTools, displaying of segmentations are handled by the SegmentationDisplayTool.
@@ -65,13 +64,15 @@ class SegmentationDisplayTool extends BaseTool {
     }
 
     // for each segmentationData, make the visibility false
-    for (const segmentationRepresentation of toolGroupSegmentationRepresentations) {
-      segmentationRepresentation.visibility = true;
-      triggerSegmentationRepresentationModified(
-        toolGroupId,
-        segmentationRepresentation.segmentationRepresentationUID
-      );
-    }
+    toolGroupSegmentationRepresentations.forEach(
+      (segmentationRepresentation) => {
+        setSegmentationVisibility(
+          toolGroupId,
+          segmentationRepresentation.segmentationRepresentationUID,
+          true
+        );
+      }
+    );
   }
 
   onSetToolDisabled(): void {
@@ -87,13 +88,15 @@ class SegmentationDisplayTool extends BaseTool {
     }
 
     // for each segmentationData, make the visibility false
-    for (const segmentationRepresentation of toolGroupSegmentationRepresentations) {
-      segmentationRepresentation.visibility = false;
-      triggerSegmentationRepresentationModified(
-        toolGroupId,
-        segmentationRepresentation.segmentationRepresentationUID
-      );
-    }
+    toolGroupSegmentationRepresentations.forEach(
+      (segmentationRepresentation) => {
+        setSegmentationVisibility(
+          toolGroupId,
+          segmentationRepresentation.segmentationRepresentationUID,
+          false
+        );
+      }
+    );
   }
 
   /**

--- a/packages/tools/src/types/SegmentationStateTypes.ts
+++ b/packages/tools/src/types/SegmentationStateTypes.ts
@@ -2,8 +2,8 @@ import * as Enums from '../enums';
 import { ContourConfig, ContourSegmentationData } from './ContourTypes';
 import type {
   LabelmapConfig,
-  LabelmapSegmentationData,
   LabelmapRenderingConfig,
+  LabelmapSegmentationData,
 } from './LabelmapTypes';
 
 /**
@@ -101,13 +101,11 @@ export type ToolGroupSpecificRepresentationState = {
    */
   active: boolean;
   /**
-   * Hidden segment indices in the segmentation
+   * Hidden segment indices in the segmentation, if it contains only -1
+   * then all segments are invisible, otherwise only the segments in this
+   * set are invisible
    */
   segmentsHidden: Set<number>;
-  /**
-   * Whether the segmentation is visible
-   */
-  visibility: boolean;
   /**
    * The index of the colorLUT from the state that this segmentationData is
    * using to render

--- a/packages/tools/src/types/SegmentationStateTypes.ts
+++ b/packages/tools/src/types/SegmentationStateTypes.ts
@@ -101,9 +101,7 @@ export type ToolGroupSpecificRepresentationState = {
    */
   active: boolean;
   /**
-   * Hidden segment indices in the segmentation, if it contains only -1
-   * then all segments are invisible, otherwise only the segments in this
-   * set are invisible
+   * Hidden segment indices in the segmentation
    */
   segmentsHidden: Set<number>;
   /**

--- a/packages/tools/test/segmentationState_test.js
+++ b/packages/tools/test/segmentationState_test.js
@@ -1,6 +1,6 @@
 import * as cornerstone3D from '@cornerstonejs/core';
-import * as csTools3d from '../src/index';
 import * as testUtils from '../../../utils/test/testUtils';
+import * as csTools3d from '../src/index';
 
 const {
   cache,
@@ -153,7 +153,6 @@ describe('Segmentation State -- ', () => {
           const segRepresentation = toolGroupSegRepresentations[0];
 
           expect(segRepresentation.active).toBe(true);
-          expect(segRepresentation.visibility).toBe(true);
           expect(segRepresentation.segmentationRepresentationUID).toBeDefined();
           expect(segRepresentation.segmentationId).toBe(segVolumeId);
           expect(segRepresentation.type).toBe(LABELMAP);

--- a/packages/tools/test/segmentationVisibilityController_test.js
+++ b/packages/tools/test/segmentationVisibilityController_test.js
@@ -1,6 +1,6 @@
 import * as cornerstone3D from '@cornerstonejs/core';
-import * as csTools3d from '../src/index';
 import * as testUtils from '../../../utils/test/testUtils';
+import * as csTools3d from '../src/index';
 
 import * as volumeURI_100_100_10_1_1_1_0_SEG_activeInactive from './groundTruth/volumeURI_100_100_10_1_1_1_0_SEG_activeInactive.png';
 import * as volumeURI_100_100_10_1_1_1_0_SEG_customColorLUT from './groundTruth/volumeURI_100_100_10_1_1_1_0_SEG_customColorLUT.png';
@@ -286,8 +286,6 @@ describe('Segmentation Controller --', () => {
     //       csTools3d.segmentation.state.getSegmentationRepresentations(toolGroupId)
 
     //     // expect(segmentationState.length).toBe(2)
-    //     // expect(segmentationState[0].visibility).toBe(true)
-    //     // expect(segmentationState[1].visibility).toBe(false)
     //     // expect(segmentationState[0].active).toBe(true)
     //     // expect(segmentationState[1].active).toBe(false)
 


### PR DESCRIPTION
Previously when segmentation was set as hidden the actor was set as hidden and as a result you could not do use cases such as hide all, then unhide one. 

The problem was as a result of having two states (visibility and segmentsHidden), this PR will make them as one (only segmentsHidden) and visibility becomes a getter only