### PR TITLE
fix for elliptical roi

### DIFF
--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -214,6 +214,7 @@ class EllipticalROITool extends AnnotationTool {
           activeHandleIndex: null,
         },
         cachedStats: {},
+        initialRotation: viewport.getRotation(),
       },
     };
 
@@ -765,9 +766,22 @@ class EllipticalROITool extends AnnotationTool {
       const canvasCoordinates = points.map((p) =>
         viewport.worldToCanvas(p)
       ) as [Types.Point2, Types.Point2, Types.Point2, Types.Point2];
-      const canvasCorners = <Array<Types.Point2>>(
-        getCanvasEllipseCorners(canvasCoordinates)
-      );
+
+      const rotation = Math.abs(viewport.getRotation() - data.initialRotation);
+      let canvasCorners;
+
+      if (rotation == 90 || rotation == 270) {
+        canvasCorners = <Array<Types.Point2>>getCanvasEllipseCorners([
+          canvasCoordinates[2], // bottom
+          canvasCoordinates[3], // top
+          canvasCoordinates[0], // left
+          canvasCoordinates[1], // right
+        ]);
+      } else {
+        canvasCorners = <Array<Types.Point2>>(
+          getCanvasEllipseCorners(canvasCoordinates) // bottom, top, left, right, keep as is
+        );
+      }
 
       const { centerPointRadius } = this.configuration;
 


### PR DESCRIPTION
This fixes the elliptical roi tool not rendering properly when rotation happens, I added an initial rotation attribute to help determine where the bottom/left/top/right attributes are located in the canvasCoordinates array.

[bottom, top, left, right] would become [left, right, bottom, top] when rotated

```JS
function getCanvasEllipseCorners(ellipseCanvasPoints) {
    const [bottom, top, left, right] = ellipseCanvasPoints;
    const topLeft = [left[0], top[1]];
    const bottomRight = [right[0], bottom[1]];
    return [topLeft, bottomRight];
}
```
this function expects the order to be [bottom. top, left. right], so we need to re-order the canvas coordinates for it if there's a rotation,  we can't pass it the array as it is when it's rotated.

```JS
getCanvasEllipseCorners([
          canvasCoordinates[2], // bottom
          canvasCoordinates[3], // top
          canvasCoordinates[0], // left
          canvasCoordinates[1], // right
        ]);
```


this is a more simple fix than the one I proposed previously in my other pull request, let me know if there's a better approach of doing this.