### PR TITLE
fix: Preserve the voi lut set attribute in properties

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -2160,6 +2160,7 @@ type StackViewportProperties = {
     interpolationType?: InterpolationType;
     rotation?: number;
     suppressEvents?: boolean;
+    isComputedVOI?: boolean;
 };
 
 // @public (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1355,6 +1355,7 @@ type StackViewportProperties = {
     interpolationType?: InterpolationType;
     rotation?: number;
     suppressEvents?: boolean;
+    isComputedVOI?: boolean;
 };
 
 // @public (undocumented)

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -4608,6 +4608,7 @@ type StackViewportProperties = {
     interpolationType?: InterpolationType;
     rotation?: number;
     suppressEvents?: boolean;
+    isComputedVOI?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -708,7 +708,13 @@ class StackViewport extends Viewport implements IStackViewport {
    * @returns viewport properties including voi, invert, interpolation type, rotation, flip
    */
   public getProperties = (): StackViewportProperties => {
-    const { voiRange, VOILUTFunction, interpolationType, invert } = this;
+    const {
+      voiRange,
+      VOILUTFunction,
+      interpolationType,
+      invert,
+      voiUpdatedWithSetProperties,
+    } = this;
     const rotation = this.getRotation();
 
     return {
@@ -717,6 +723,7 @@ class StackViewport extends Viewport implements IStackViewport {
       interpolationType,
       invert,
       rotation,
+      isComputedVOI: !voiUpdatedWithSetProperties,
     };
   };
 

--- a/packages/core/src/types/StackViewportProperties.ts
+++ b/packages/core/src/types/StackViewportProperties.ts
@@ -18,6 +18,8 @@ type StackViewportProperties = {
   rotation?: number;
   /** suppress events (optional) */
   suppressEvents?: boolean;
+  /** Indicates if the voi is a computed VOI (not user set) */
+  isComputedVOI?: boolean;
 };
 
 export default StackViewportProperties;


### PR DESCRIPTION
The voiUpdatedWithSetProperties value was getting lost if you did a get/set properties, causing some series to display weirdly afterwards.  This change preserves the value in the get/set properties.