### PR TITLE
fix: Segmentation slice range is wrong when nearly orthonormal as well as for segmentation volumes

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -762,6 +762,9 @@ function getVoiFromSigmoidRGBTransferFunction(cfun: vtkColorTransferFunction): [
 function getVolumeActorCorners(volumeActor: any): Array<Point3>;
 
 // @public (undocumented)
+function getVolumeLoaderSchemes(): string[];
+
+// @public (undocumented)
 function getVolumeSliceRangeInfo(viewport: IVolumeViewport, volumeId: string): {
     sliceRange: ActorSliceRange;
     spacingInNormalDirection: number;
@@ -2595,6 +2598,7 @@ declare namespace volumeLoader {
         createAndCacheDerivedVolume,
         createLocalVolume,
         registerVolumeLoader,
+        getVolumeLoaderSchemes,
         registerUnknownVolumeLoader
     }
 }

--- a/packages/core/src/loaders/volumeLoader.ts
+++ b/packages/core/src/loaders/volumeLoader.ts
@@ -454,6 +454,11 @@ export function registerVolumeLoader(
   volumeLoaders[scheme] = volumeLoader;
 }
 
+/** Gets the array of volume loader schemes */
+export function getVolumeLoaderSchemes(): string[] {
+  return Object.keys(volumeLoaders);
+}
+
 /**
  * Registers a new unknownVolumeLoader and returns the previous one
  *

--- a/packages/core/src/utilities/getSliceRange.ts
+++ b/packages/core/src/utilities/getSliceRange.ts
@@ -1,8 +1,9 @@
 import vtkMatrixBuilder from '@kitware/vtk.js/Common/Core/MatrixBuilder';
 import getVolumeActorCorners from './getVolumeActorCorners';
 import type { VolumeActor, Point3, ActorSliceRange } from '../types';
+import { EPSILON } from '../constants';
 
-const isOne = (v) => Math.abs(v) > 0.99 && Math.abs(v) < 1.01;
+const isOne = (v) => Math.abs(Math.abs(v) - 1) < EPSILON;
 const isUnit = (v, off) =>
   isOne(v[off]) || isOne(v[off + 1]) || isOne(v[off + 2]);
 

--- a/packages/core/src/utilities/getTargetVolumeAndSpacingInNormalDir.ts
+++ b/packages/core/src/utilities/getTargetVolumeAndSpacingInNormalDir.ts
@@ -3,15 +3,21 @@ import { EPSILON } from '../constants';
 // import type { VolumeViewport } from '../RenderingEngine'
 import { ICamera, IImageVolume, IVolumeViewport } from '../types';
 import getSpacingInNormalDirection from './getSpacingInNormalDirection';
+import { getVolumeLoaderSchemes } from '../loaders/volumeLoader';
 
 // One EPSILON part larger multiplier
 const EPSILON_PART = 1 + EPSILON;
+
+const startsWith = (str, starts) =>
+  starts === str.substring(0, Math.min(str.length, starts.length));
 
 // Check if this is a primary volume
 // For now, that means it came from some sort of image loader, but
 // should be specifically designated.
 const isPrimaryVolume = (volume): boolean =>
-  volume.volumeId.indexOf(':') !== -1;
+  !!getVolumeLoaderSchemes().find((scheme) =>
+    startsWith(volume.volumeId, scheme)
+  );
 
 /**
  * Given a volume viewport and camera, find the target volume.

--- a/packages/core/src/utilities/getTargetVolumeAndSpacingInNormalDir.ts
+++ b/packages/core/src/utilities/getTargetVolumeAndSpacingInNormalDir.ts
@@ -7,6 +7,12 @@ import getSpacingInNormalDirection from './getSpacingInNormalDirection';
 // One EPSILON part larger multiplier
 const EPSILON_PART = 1 + EPSILON;
 
+// Check if this is a primary volume
+// For now, that means it came from some sort of image loader, but
+// should be specifically designated.
+const isPrimaryVolume = (volume): boolean =>
+  volume.volumeId.indexOf(':') !== -1;
+
 /**
  * Given a volume viewport and camera, find the target volume.
  * The imageVolume is retrieved from cache for the specified targetVolumeId or
@@ -82,8 +88,15 @@ export default function getTargetVolumeAndSpacingInNormalDir(
     actorUID: null,
   };
 
+  const hasPrimaryVolume = imageVolumes.find(isPrimaryVolume);
+
   for (let i = 0; i < imageVolumes.length; i++) {
     const imageVolume = imageVolumes[i];
+
+    if (hasPrimaryVolume && !isPrimaryVolume(imageVolume)) {
+      // Secondary volumes like segmentation don't count towards spacing
+      continue;
+    }
 
     const spacingInNormalDirection = getSpacingInNormalDirection(
       imageVolume,


### PR DESCRIPTION
If a segmentation is created with a much larger range than one of the display sets it applies to, then that display set is shown with large swathes of black, and the scrolling can be wrong because it uses the finer of the two scrolls, which can end up duplicating base images.

This change uses primary volumes, which it determines by those having a volume image loader prefix, for slice range, and only uses secondary volumes when there are no primaries.