### PR TITLE
fix(volumeLoad): should still update texture when loading

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1526,6 +1526,7 @@ interface IStreamingVolumeProperties {
     loadStatus: {
         loaded: boolean;
         loading: boolean;
+        cancelled: boolean;
         cachedFrames: Array<boolean>;
         callbacks: Array<() => void>;
     };

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1038,6 +1038,7 @@ interface IStreamingVolumeProperties {
     loadStatus: {
         loaded: boolean;
         loading: boolean;
+        cancelled: boolean;
         cachedFrames: Array<boolean>;
         callbacks: Array<() => void>;
     };

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2794,6 +2794,7 @@ interface IStreamingVolumeProperties {
     loadStatus: {
         loaded: boolean;
         loading: boolean;
+        cancelled: boolean;
         cachedFrames: Array<boolean>;
         callbacks: Array<() => void>;
     };

--- a/packages/core/src/types/IStreamingVolumeProperties.ts
+++ b/packages/core/src/types/IStreamingVolumeProperties.ts
@@ -6,6 +6,7 @@ interface IStreamingVolumeProperties {
   loadStatus: {
     loaded: boolean;
     loading: boolean;
+    cancelled: boolean;
     cachedFrames: Array<boolean>;
     callbacks: Array<() => void>;
   };

--- a/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
@@ -317,7 +317,8 @@ export default class BaseStreamingImageVolume extends ImageVolume {
       // data loader scheme)
       const cachedImage = cache.getCachedImageBasedOnImageURI(imageId);
 
-      // check if we are still loading the volume and we have not canceled loading
+      // check if the load was cancelled while we were waiting for the image
+      // if so we don't want to do anything
       if (loadStatus.cancelled) {
         console.warn(
           'volume load cancelled, returning for imageIdIndex: ',

--- a/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
@@ -29,6 +29,7 @@ export default class BaseStreamingImageVolume extends ImageVolume {
   loadStatus: {
     loaded: boolean;
     loading: boolean;
+    cancelled: boolean;
     cachedFrames: Array<boolean>;
     callbacks: Array<(...args: unknown[]) => void>;
   };
@@ -175,6 +176,7 @@ export default class BaseStreamingImageVolume extends ImageVolume {
 
     // Set to not loading.
     loadStatus.loading = false;
+    loadStatus.cancelled = true;
 
     // Remove all the callback listeners
     this.clearLoadCallbacks();
@@ -251,8 +253,6 @@ export default class BaseStreamingImageVolume extends ImageVolume {
     const { vtkOpenGLTexture, imageData, metadata, volumeId } = this;
     const { FrameOfReferenceUID } = metadata;
 
-    loadStatus.loading = true;
-
     // SharedArrayBuffer
     const arrayBuffer = scalarData.buffer;
     const numFrames = imageIds.length;
@@ -318,7 +318,11 @@ export default class BaseStreamingImageVolume extends ImageVolume {
       const cachedImage = cache.getCachedImageBasedOnImageURI(imageId);
 
       // check if we are still loading the volume and we have not canceled loading
-      if (!loadStatus.loading) {
+      if (loadStatus.cancelled) {
+        console.warn(
+          'volume load cancelled, returning for imageIdIndex: ',
+          imageIdIndex
+        );
         return;
       }
 
@@ -613,6 +617,11 @@ export default class BaseStreamingImageVolume extends ImageVolume {
   }
 
   private _prefetchImageIds(priority: number): void {
+    // Note: here is the correct location to set the loading flag
+    // since getImageIdsRequest is just grabbing and building requests
+    // and not actually executing them
+    this.loadStatus.loading = true;
+
     const requests = this.getImageLoadRequests(priority);
 
     requests.reverse().forEach((request) => {

--- a/packages/streaming-image-volume-loader/src/cornerstoneStreamingDynamicImageVolumeLoader.ts
+++ b/packages/streaming-image-volume-loader/src/cornerstoneStreamingDynamicImageVolumeLoader.ts
@@ -75,6 +75,7 @@ function cornerstoneStreamingDynamicImageVolumeLoader(
         // todo: loading and loaded should be on ImageVolume
         loaded: false,
         loading: false,
+        cancelled: false,
         cachedFrames: [],
         callbacks: [],
       },

--- a/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
+++ b/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
@@ -244,6 +244,7 @@ function cornerstoneStreamingImageVolumeLoader(
           // todo: loading and loaded should be on ImageVolume
           loaded: false,
           loading: false,
+          cancelled: false,
           cachedFrames: [],
           callbacks: [],
         },


### PR DESCRIPTION
we shouldn't hold texture update from happening in load, just in cancel