### PR TITLE
fix(StackViewport): float number comparison to use epsilon when StackViewport is abou…

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1466,7 +1466,7 @@ interface IRenderingEngine {
 export function isCornerstoneInitialized(): boolean;
 
 // @public (undocumented)
-function isEqual(v1: number[] | Float32Array, v2: number[] | Float32Array, tolerance?: number): boolean;
+function isEqual<ValueType>(v1: ValueType, v2: ValueType, tolerance?: number): boolean;
 
 // @public (undocumented)
 function isImageActor(actorEntry: Types.ActorEntry): boolean;

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1536,11 +1536,15 @@ class StackViewport extends Viewport implements IStackViewport {
     const columnCosines = direction.slice(3, 6);
     const dataType = imageData.getPointData().getScalars().getDataType();
 
+    // using epsilon comparison for float numbers comparison.
+    const isSameXSpacing = isEqual(xSpacing, image.rowPixelSpacing);
+    const isSameYSpacing = isEqual(ySpacing, image.columnPixelSpacing);
+
     // using spacing, size, and direction only for now
     return (
-      (xSpacing === image.rowPixelSpacing ||
+      (isSameXSpacing ||
         (image.rowPixelSpacing === null && xSpacing === 1.0)) &&
-      (ySpacing === image.columnPixelSpacing ||
+      (isSameYSpacing ||
         (image.columnPixelSpacing === null && ySpacing === 1.0)) &&
       xVoxels === image.columns &&
       yVoxels === image.rows &&

--- a/packages/core/src/utilities/isEqual.ts
+++ b/packages/core/src/utilities/isEqual.ts
@@ -1,27 +1,72 @@
-/**
- * returns equal if the two arrays are identical within the
- * given tolerance.
- *
- * @param v1 - The first array of values
- * @param v2 - The second array of values.
- * @param tolerance - The acceptable tolerance, the default is 0.00001
- *
- * @returns True if the two values are within the tolerance levels.
- */
-export default function isEqual(
-  v1: number[] | Float32Array,
-  v2: number[] | Float32Array,
+function areNumbersEqualWithTolerance(
+  num1: number,
+  num2: number,
+  tolerance: number
+): boolean {
+  return Math.abs(num1 - num2) <= tolerance;
+}
+
+function areArraysEqual(
+  arr1: number[] | Float32Array | Float64Array,
+  arr2: number[] | Float32Array | Float64Array,
   tolerance = 1e-5
 ): boolean {
-  if (v1.length !== v2.length) {
+  if (arr1.length !== arr2.length) {
     return false;
   }
 
-  for (let i = 0; i < v1.length; i++) {
-    if (Math.abs(v1[i] - v2[i]) > tolerance) {
+  for (let i = 0; i < arr1.length; i++) {
+    if (!areNumbersEqualWithTolerance(arr1[i], arr2[i], tolerance)) {
       return false;
     }
   }
 
   return true;
+}
+
+function isNumberType(value: any): value is number {
+  return typeof value === 'number';
+}
+
+function isFloatArrayLike(
+  value: any
+): value is number[] | Float32Array | Float64Array {
+  const isArrayLike = typeof value === 'object' || 'length' in value;
+  const floatTypedArrayLike =
+    value instanceof Float32Array || value instanceof Float64Array;
+
+  return isArrayLike || floatTypedArrayLike;
+}
+
+/**
+ * Returns whether two values are equal or not based on epsilon comparison.
+ * For array comparison, it does NOT strictly compare them but only compare its values.
+ * Typed Array comparison is valid for Float32Array and Float16Array only.
+ *
+ * @param v1 - The first value to compare
+ * @param v2 - The second value to compare
+ * @param tolerance - The acceptable tolerance, the default is 0.00001
+ *
+ * @returns True if the two values are within the tolerance levels.
+ */
+export default function isEqual<ValueType>(
+  v1: ValueType,
+  v2: ValueType,
+  tolerance = 1e-5
+): boolean {
+  // values must be the same type
+  if (typeof v1 !== typeof v2) {
+    return false;
+  }
+
+  if (isNumberType(v1) && isNumberType(v2)) {
+    return areNumbersEqualWithTolerance(v1, v2, tolerance);
+  }
+
+  // if not a number comparison fallback to array comparison
+  if (isFloatArrayLike(v1) && isFloatArrayLike(v2)) {
+    return areArraysEqual(v1, v2, tolerance);
+  }
+
+  return false;
 }

--- a/packages/core/src/utilities/isEqual.ts
+++ b/packages/core/src/utilities/isEqual.ts
@@ -7,8 +7,8 @@ function areNumbersEqualWithTolerance(
 }
 
 function areArraysEqual(
-  arr1: number[] | Float32Array | Float64Array,
-  arr2: number[] | Float32Array | Float64Array,
+  arr1: ArrayLike<number>,
+  arr2: ArrayLike<number>,
   tolerance = 1e-5
 ): boolean {
   if (arr1.length !== arr2.length) {
@@ -28,20 +28,14 @@ function isNumberType(value: any): value is number {
   return typeof value === 'number';
 }
 
-function isFloatArrayLike(
-  value: any
-): value is number[] | Float32Array | Float64Array {
-  const isArrayLike = typeof value === 'object' || 'length' in value;
-  const floatTypedArrayLike =
-    value instanceof Float32Array || value instanceof Float64Array;
-
-  return isArrayLike || floatTypedArrayLike;
+function isNumberArrayLike(value: any): value is ArrayLike<number> {
+  return 'length' in value && typeof value[0] === 'number';
 }
 
 /**
- * Returns whether two values are equal or not based on epsilon comparison.
+ * Returns whether two values are equal or not, based on epsilon comparison.
  * For array comparison, it does NOT strictly compare them but only compare its values.
- * Typed Array comparison is valid for Float32Array and Float16Array only.
+ * It can compare array of numbers and also typed array. Otherwise it will just return false.
  *
  * @param v1 - The first value to compare
  * @param v2 - The second value to compare
@@ -54,8 +48,17 @@ export default function isEqual<ValueType>(
   v2: ValueType,
   tolerance = 1e-5
 ): boolean {
-  // values must be the same type
-  if (typeof v1 !== typeof v2) {
+  // values must be the same type or not null
+  if (typeof v1 !== typeof v2 || v1 === null || v2 === null) {
+    return false;
+  }
+
+  // typeof object must have same constructor
+  if (
+    typeof v1 === 'object' &&
+    typeof v2 === 'object' &&
+    v1.constructor !== v2.constructor
+  ) {
     return false;
   }
 
@@ -63,8 +66,7 @@ export default function isEqual<ValueType>(
     return areNumbersEqualWithTolerance(v1, v2, tolerance);
   }
 
-  // if not a number comparison fallback to array comparison
-  if (isFloatArrayLike(v1) && isFloatArrayLike(v2)) {
+  if (isNumberArrayLike(v1) && isNumberArrayLike(v2)) {
     return areArraysEqual(v1, v2, tolerance);
   }
 

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -18,6 +18,18 @@ describe('Cornerstone-render Utilities:', function () {
     expect(isEqual(0.2 + 0.1, 0.3, 0.01)).toBe(true);
     expect(isEqual(Infinity, Infinity, 0.0001)).toBe(false);
     expect(isEqual(NaN, NaN, 0.0001)).toBe(false);
+
+    const typedArray1 = new Float32Array([1.0, 1.2]);
+    const typedArray2 = new Float32Array([1.0, 1.2]);
+    const typedArray3 = new Float64Array([1.0, 1.2]);
+    const typedArray4 = new Float64Array([1.01, 1.202]);
+    const typedArray5 = new Int16Array([1, 2]);
+    const typedArray6 = new Int16Array([1, 2]);
+
+    expect(isEqual(typedArray1, typedArray2, 0.0001)).toBe(true);
+    expect(isEqual(typedArray3, typedArray4, 0.0001)).toBe(true);
+    expect(isEqual(typedArray5, typedArray6, 0.0001)).toBe(true);
+    expect(isEqual(typedArray1, typedArray3, 0.1)).toBe(false);
   });
 
   it('Should correctly calculate line and plane intersection', () => {

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -10,6 +10,14 @@ describe('Cornerstone-render Utilities:', function () {
     expect(isEqual([0, 0, 0], [1, 1, 1])).toBe(false);
     expect(isEqual([0, 0, 0], [0, 0, 0])).toBe(true);
     expect(isEqual([0, 0, 0], [0.0000000001, 0, 0])).toBe(true);
+    expect(isEqual(1, 1)).toBe(true);
+    expect(isEqual(0.1, 0.1)).toBe(true);
+    expect(isEqual(0.1, [0.1])).toBe(false);
+    expect(isEqual([1], 1)).toBe(false);
+    expect(isEqual(0.00001, 0.00002, 0.00001)).toBe(true);
+    expect(isEqual(0.2 + 0.1, 0.3, 0.01)).toBe(true);
+    expect(isEqual(Infinity, Infinity, 0.0001)).toBe(false);
+    expect(isEqual(NaN, NaN, 0.0001)).toBe(false);
   });
 
   it('Should correctly calculate line and plane intersection', () => {

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -27,7 +27,7 @@ describe('Cornerstone-render Utilities:', function () {
     const typedArray6 = new Int16Array([1, 2]);
 
     expect(isEqual(typedArray1, typedArray2, 0.0001)).toBe(true);
-    expect(isEqual(typedArray3, typedArray4, 0.0001)).toBe(true);
+    expect(isEqual(typedArray3, typedArray4, 0.1)).toBe(true);
     expect(isEqual(typedArray5, typedArray6, 0.0001)).toBe(true);
     expect(isEqual(typedArray1, typedArray3, 0.1)).toBe(false);
   });


### PR DESCRIPTION
…t to be updated

fixes #516 

Adding epsilon comparison when StackViewport is about to be update.

Changed isEqual method to also consider number type of params. Backward compatibility is preserved (no loss to api)

Tech note: comparing float number in JS should be always using this approach.
Added some unit tests to validate new changes

Later on we can explore more the tolerances values for different situation and maybe include it as configuration within the lib