### PR TITLE
fix(suv display): fix scaling of non-SUV PT images

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -696,7 +696,7 @@ export class CircleROITool extends AnnotationTool {
     // (undocumented)
     _endCallback: (evt: EventTypes_2.InteractionEventType) => void;
     // (undocumented)
-    _getTextLines: (data: any, targetId: string, isPreScaled: boolean) => string[];
+    _getTextLines: (data: any, targetId: string, isPreScaled: boolean, suvbw?: number) => string[];
     // (undocumented)
     handleSelectedCallback: (evt: EventTypes_2.InteractionEventType, annotation: CircleROIAnnotation, handle: ToolHandle) => void;
     // (undocumented)
@@ -1664,7 +1664,7 @@ export class EllipticalROITool extends AnnotationTool {
     // (undocumented)
     _getCanvasEllipseCenter(ellipseCanvasPoints: Types_2.Point2[]): Types_2.Point2;
     // (undocumented)
-    _getTextLines: (data: any, targetId: string, isPreScaled: boolean) => string[];
+    _getTextLines: (data: any, targetId: string, isPreScaled: boolean, suvbw?: number) => string[];
     // (undocumented)
     handleSelectedCallback: (evt: EventTypes_2.InteractionEventType, annotation: EllipticalROIAnnotation, handle: ToolHandle) => void;
     // (undocumented)
@@ -3741,7 +3741,7 @@ export class ProbeTool extends AnnotationTool {
     // (undocumented)
     getHandleNearImagePoint(element: HTMLDivElement, annotation: ProbeAnnotation, canvasCoords: Types_2.Point2, proximity: number): ToolHandle | undefined;
     // (undocumented)
-    _getTextLines(data: any, targetId: string, isPreScaled: boolean): string[] | undefined;
+    _getTextLines(data: any, targetId: string, isPreScaled: boolean, suvbwScalingFactor?: number): string[] | undefined;
     // (undocumented)
     _getValueForModality(value: any, imageVolume: any, modality: any): {};
     // (undocumented)
@@ -4029,7 +4029,7 @@ export class RectangleROITool extends AnnotationTool {
         height: number;
     };
     // (undocumented)
-    _getTextLines: (data: any, targetId: string, isPreScaled: boolean) => string[] | undefined;
+    _getTextLines: (data: any, targetId: string, isPreScaled: boolean, suvbw?: number) => string[] | undefined;
     // (undocumented)
     handleSelectedCallback: (evt: EventTypes_2.InteractionEventType, annotation: RectangleROIAnnotation, handle: ToolHandle) => void;
     // (undocumented)

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -325,6 +325,8 @@ export abstract class AnnotationTool extends AnnotationDisplayTool {
     // (undocumented)
     abstract isPointNearTool(element: HTMLDivElement, annotation: Annotation, canvasCoords: Types_2.Point2, proximity: number, interactionType: string): boolean;
     // (undocumented)
+    isSuvScaled(viewport: Types_2.IStackViewport | Types_2.IVolumeViewport, targetId: string, imageId?: string): boolean;
+    // (undocumented)
     mouseMoveCallback: (evt: EventTypes_2.MouseMoveEventType, filteredAnnotations?: Annotations) => boolean;
     // (undocumented)
     static toolName: any;
@@ -696,7 +698,7 @@ export class CircleROITool extends AnnotationTool {
     // (undocumented)
     _endCallback: (evt: EventTypes_2.InteractionEventType) => void;
     // (undocumented)
-    _getTextLines: (data: any, targetId: string, isPreScaled: boolean, suvbw?: number) => string[];
+    _getTextLines: (data: any, targetId: string, isPreScaled: boolean, isSuvScaled: boolean) => string[];
     // (undocumented)
     handleSelectedCallback: (evt: EventTypes_2.InteractionEventType, annotation: CircleROIAnnotation, handle: ToolHandle) => void;
     // (undocumented)
@@ -1664,7 +1666,7 @@ export class EllipticalROITool extends AnnotationTool {
     // (undocumented)
     _getCanvasEllipseCenter(ellipseCanvasPoints: Types_2.Point2[]): Types_2.Point2;
     // (undocumented)
-    _getTextLines: (data: any, targetId: string, isPreScaled: boolean, suvbw?: number) => string[];
+    _getTextLines: (data: any, targetId: string, isPreScaled: boolean, isSuvScaled: boolean) => string[];
     // (undocumented)
     handleSelectedCallback: (evt: EventTypes_2.InteractionEventType, annotation: EllipticalROIAnnotation, handle: ToolHandle) => void;
     // (undocumented)
@@ -3741,7 +3743,7 @@ export class ProbeTool extends AnnotationTool {
     // (undocumented)
     getHandleNearImagePoint(element: HTMLDivElement, annotation: ProbeAnnotation, canvasCoords: Types_2.Point2, proximity: number): ToolHandle | undefined;
     // (undocumented)
-    _getTextLines(data: any, targetId: string, isPreScaled: boolean, suvbwScalingFactor?: number): string[] | undefined;
+    _getTextLines(data: any, targetId: string, isPreScaled: boolean, isSuvScaled: boolean): string[] | undefined;
     // (undocumented)
     _getValueForModality(value: any, imageVolume: any, modality: any): {};
     // (undocumented)
@@ -4029,7 +4031,7 @@ export class RectangleROITool extends AnnotationTool {
         height: number;
     };
     // (undocumented)
-    _getTextLines: (data: any, targetId: string, isPreScaled: boolean, suvbw?: number) => string[] | undefined;
+    _getTextLines: (data: any, targetId: string, isPreScaled: boolean, isSuvScaled: boolean) => string[] | undefined;
     // (undocumented)
     handleSelectedCallback: (evt: EventTypes_2.InteractionEventType, annotation: RectangleROIAnnotation, handle: ToolHandle) => void;
     // (undocumented)

--- a/packages/dicomImageLoader/src/shared/scaling/scaleArray.ts
+++ b/packages/dicomImageLoader/src/shared/scaling/scaleArray.ts
@@ -5,11 +5,7 @@ export default function scaleArray(
   const arrayLength = array.length;
   const { rescaleSlope, rescaleIntercept, suvbw } = scalingParameters;
 
-  if (scalingParameters.modality === 'PT') {
-    if (typeof suvbw !== 'number') {
-      return;
-    }
-
+  if (scalingParameters.modality === 'PT' && typeof suvbw === 'number') {
     for (let i = 0; i < arrayLength; i++) {
       array[i] = suvbw * (array[i] * rescaleSlope + rescaleIntercept);
     }

--- a/packages/streaming-image-volume-loader/src/helpers/scaleArray.ts
+++ b/packages/streaming-image-volume-loader/src/helpers/scaleArray.ts
@@ -14,11 +14,7 @@ export default function scaleArray(
   const arrayLength = array.length;
   const { rescaleSlope, rescaleIntercept, suvbw } = scalingParameters;
 
-  if (scalingParameters.modality === 'PT') {
-    if (typeof suvbw !== 'number') {
-      return array;
-    }
-
+  if (scalingParameters.modality === 'PT' && typeof suvbw === 'number') {
     for (let i = 0; i < arrayLength; i++) {
       array[i] = suvbw * (array[i] * rescaleSlope + rescaleIntercept);
     }

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -6,6 +6,7 @@ import {
   eventTarget,
   triggerEvent,
   utilities as csUtils,
+  metaData,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -855,10 +856,11 @@ class CircleROITool extends AnnotationTool {
       isEmptyArea,
       Modality,
       areaUnit,
+      suvbw,
     } = cachedVolumeStats;
 
     const textLines: string[] = [];
-    const unit = getModalityUnit(Modality, isPreScaled);
+    const unit = getModalityUnit(Modality, isPreScaled, suvbw);
 
     if (radius) {
       const radiusLine = isEmptyArea
@@ -1021,8 +1023,15 @@ class CircleROITool extends AnnotationTool {
         stdDev /= count;
         stdDev = Math.sqrt(stdDev);
 
+        const { suvbw } =
+          metaData.get(
+            'scalingModule',
+            annotation.metadata.referencedImageId
+          ) || {};
+
         cachedStats[targetId] = {
           Modality: metadata.Modality,
+          suvbw,
           area,
           mean,
           max,

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -800,7 +800,11 @@ class CircleROITool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const textLines = this._getTextLines(data, targetId, isPreScaled);
+      const { suvbw } =
+        metaData.get('scalingModule', annotation.metadata.referencedImageId) ||
+        {};
+
+      const textLines = this._getTextLines(data, targetId, isPreScaled, suvbw);
       if (!textLines || textLines.length === 0) {
         continue;
       }
@@ -844,7 +848,12 @@ class CircleROITool extends AnnotationTool {
     return renderStatus;
   };
 
-  _getTextLines = (data, targetId: string, isPreScaled: boolean): string[] => {
+  _getTextLines = (
+    data,
+    targetId: string,
+    isPreScaled: boolean,
+    suvbw?: number
+  ): string[] => {
     const cachedVolumeStats = data.cachedStats[targetId];
     const {
       radius,
@@ -856,7 +865,6 @@ class CircleROITool extends AnnotationTool {
       isEmptyArea,
       Modality,
       areaUnit,
-      suvbw,
     } = cachedVolumeStats;
 
     const textLines: string[] = [];
@@ -1023,15 +1031,8 @@ class CircleROITool extends AnnotationTool {
         stdDev /= count;
         stdDev = Math.sqrt(stdDev);
 
-        const { suvbw } =
-          metaData.get(
-            'scalingModule',
-            annotation.metadata.referencedImageId
-          ) || {};
-
         cachedStats[targetId] = {
           Modality: metadata.Modality,
-          suvbw,
           area,
           mean,
           max,

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -800,11 +800,16 @@ class CircleROITool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const { suvbw } =
-        metaData.get('scalingModule', annotation.metadata.referencedImageId) ||
-        {};
+      const scalingModule: Types.ScalingParameters | undefined =
+        annotation.metadata.referencedImageId &&
+        metaData.get('scalingModule', annotation.metadata.referencedImageId);
 
-      const textLines = this._getTextLines(data, targetId, isPreScaled, suvbw);
+      const textLines = this._getTextLines(
+        data,
+        targetId,
+        isPreScaled,
+        scalingModule?.suvbw
+      );
       if (!textLines || textLines.length === 0) {
         continue;
       }

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -6,7 +6,6 @@ import {
   eventTarget,
   triggerEvent,
   utilities as csUtils,
-  metaData,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -800,15 +799,17 @@ class CircleROITool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const scalingModule: Types.ScalingParameters | undefined =
-        annotation.metadata.referencedImageId &&
-        metaData.get('scalingModule', annotation.metadata.referencedImageId);
+      const isSuvScaled = this.isSuvScaled(
+        viewport,
+        targetId,
+        annotation.metadata.referencedImageId
+      );
 
       const textLines = this._getTextLines(
         data,
         targetId,
         isPreScaled,
-        scalingModule?.suvbw
+        isSuvScaled
       );
       if (!textLines || textLines.length === 0) {
         continue;
@@ -857,7 +858,7 @@ class CircleROITool extends AnnotationTool {
     data,
     targetId: string,
     isPreScaled: boolean,
-    suvbw?: number
+    isSuvScaled: boolean
   ): string[] => {
     const cachedVolumeStats = data.cachedStats[targetId];
     const {
@@ -873,7 +874,7 @@ class CircleROITool extends AnnotationTool {
     } = cachedVolumeStats;
 
     const textLines: string[] = [];
-    const unit = getModalityUnit(Modality, isPreScaled, suvbw);
+    const unit = getModalityUnit(Modality, isPreScaled, isSuvScaled);
 
     if (radius) {
       const radiusLine = isEmptyArea

--- a/packages/tools/src/tools/annotation/DragProbeTool.ts
+++ b/packages/tools/src/tools/annotation/DragProbeTool.ts
@@ -187,7 +187,18 @@ class DragProbeTool extends ProbeTool {
 
     const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-    const textLines = this._getTextLines(data, targetId, isPreScaled);
+    const isSuvScaled = this.isSuvScaled(
+      viewport,
+      targetId,
+      annotation.metadata.referencedImageId
+    );
+
+    const textLines = this._getTextLines(
+      data,
+      targetId,
+      isPreScaled,
+      isSuvScaled
+    );
     if (textLines) {
       const textCanvasCoordinates = [
         canvasCoordinates[0] + 6,

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -6,7 +6,6 @@ import {
   eventTarget,
   triggerEvent,
   utilities as csUtils,
-  metaData,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -928,15 +927,17 @@ class EllipticalROITool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const scalingModule: Types.ScalingParameters | undefined =
-        annotation.metadata.referencedImageId &&
-        metaData.get('scalingModule', annotation.metadata.referencedImageId);
+      const isSuvScaled = this.isSuvScaled(
+        viewport,
+        targetId,
+        annotation.metadata.referencedImageId
+      );
 
       const textLines = this._getTextLines(
         data,
         targetId,
         isPreScaled,
-        scalingModule?.suvbw
+        isSuvScaled
       );
       if (!textLines || textLines.length === 0) {
         continue;
@@ -985,14 +986,14 @@ class EllipticalROITool extends AnnotationTool {
     data,
     targetId: string,
     isPreScaled: boolean,
-    suvbw?: number
+    isSuvScaled: boolean
   ): string[] => {
     const cachedVolumeStats = data.cachedStats[targetId];
     const { area, mean, stdDev, max, isEmptyArea, Modality, areaUnit } =
       cachedVolumeStats;
 
     const textLines: string[] = [];
-    const unit = getModalityUnit(Modality, isPreScaled, suvbw);
+    const unit = getModalityUnit(Modality, isPreScaled, isSuvScaled);
 
     if (area) {
       const areaLine = isEmptyArea

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -928,7 +928,11 @@ class EllipticalROITool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const textLines = this._getTextLines(data, targetId, isPreScaled);
+      const { suvbw } =
+        metaData.get('scalingModule', annotation.metadata.referencedImageId) ||
+        {};
+
+      const textLines = this._getTextLines(data, targetId, isPreScaled, suvbw);
       if (!textLines || textLines.length === 0) {
         continue;
       }
@@ -972,9 +976,14 @@ class EllipticalROITool extends AnnotationTool {
     return renderStatus;
   };
 
-  _getTextLines = (data, targetId: string, isPreScaled: boolean): string[] => {
+  _getTextLines = (
+    data,
+    targetId: string,
+    isPreScaled: boolean,
+    suvbw?: number
+  ): string[] => {
     const cachedVolumeStats = data.cachedStats[targetId];
-    const { area, mean, stdDev, max, isEmptyArea, Modality, areaUnit, suvbw } =
+    const { area, mean, stdDev, max, isEmptyArea, Modality, areaUnit } =
       cachedVolumeStats;
 
     const textLines: string[] = [];
@@ -1134,15 +1143,8 @@ class EllipticalROITool extends AnnotationTool {
         stdDev /= count;
         stdDev = Math.sqrt(stdDev);
 
-        const { suvbw } =
-          metaData.get(
-            'scalingModule',
-            annotation.metadata.referencedImageId
-          ) || {};
-
         cachedStats[targetId] = {
           Modality: metadata.Modality,
-          suvbw,
           area,
           mean,
           max,

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -6,6 +6,7 @@ import {
   eventTarget,
   triggerEvent,
   utilities as csUtils,
+  metaData,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -973,11 +974,11 @@ class EllipticalROITool extends AnnotationTool {
 
   _getTextLines = (data, targetId: string, isPreScaled: boolean): string[] => {
     const cachedVolumeStats = data.cachedStats[targetId];
-    const { area, mean, stdDev, max, isEmptyArea, Modality, areaUnit } =
+    const { area, mean, stdDev, max, isEmptyArea, Modality, areaUnit, suvbw } =
       cachedVolumeStats;
 
     const textLines: string[] = [];
-    const unit = getModalityUnit(Modality, isPreScaled);
+    const unit = getModalityUnit(Modality, isPreScaled, suvbw);
 
     if (area) {
       const areaLine = isEmptyArea
@@ -1133,8 +1134,15 @@ class EllipticalROITool extends AnnotationTool {
         stdDev /= count;
         stdDev = Math.sqrt(stdDev);
 
+        const { suvbw } =
+          metaData.get(
+            'scalingModule',
+            annotation.metadata.referencedImageId
+          ) || {};
+
         cachedStats[targetId] = {
           Modality: metadata.Modality,
+          suvbw,
           area,
           mean,
           max,

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -928,11 +928,16 @@ class EllipticalROITool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const { suvbw } =
-        metaData.get('scalingModule', annotation.metadata.referencedImageId) ||
-        {};
+      const scalingModule: Types.ScalingParameters | undefined =
+        annotation.metadata.referencedImageId &&
+        metaData.get('scalingModule', annotation.metadata.referencedImageId);
 
-      const textLines = this._getTextLines(data, targetId, isPreScaled, suvbw);
+      const textLines = this._getTextLines(
+        data,
+        targetId,
+        isPreScaled,
+        scalingModule?.suvbw
+      );
       if (!textLines || textLines.length === 0) {
         continue;
       }

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -8,7 +8,6 @@ import {
   eventTarget,
   utilities as csUtils,
   utilities,
-  metaData,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -505,15 +504,17 @@ class ProbeTool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const scalingModule: Types.ScalingParameters | undefined =
-        annotation.metadata.referencedImageId &&
-        metaData.get('scalingModule', annotation.metadata.referencedImageId);
+      const isSuvScaled = this.isSuvScaled(
+        viewport,
+        targetId,
+        annotation.metadata.referencedImageId
+      );
 
       const textLines = this._getTextLines(
         data,
         targetId,
         isPreScaled,
-        scalingModule?.suvbw
+        isSuvScaled
       );
       if (textLines) {
         const textCanvasCoordinates = [
@@ -540,7 +541,7 @@ class ProbeTool extends AnnotationTool {
     data,
     targetId: string,
     isPreScaled: boolean,
-    suvbwScalingFactor?: number
+    isSuvScaled: boolean
   ): string[] | undefined {
     const cachedVolumeStats = data.cachedStats[targetId];
     const { index, Modality, value, SUVBw, SUVLbm, SUVBsa } = cachedVolumeStats;
@@ -550,7 +551,7 @@ class ProbeTool extends AnnotationTool {
     }
 
     const textLines = [];
-    const unit = getModalityUnit(Modality, isPreScaled, suvbwScalingFactor);
+    const unit = getModalityUnit(Modality, isPreScaled, isSuvScaled);
 
     textLines.push(`(${index[0]}, ${index[1]}, ${index[2]})`);
 

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -8,6 +8,7 @@ import {
   eventTarget,
   utilities as csUtils,
   utilities,
+  metaData,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -532,14 +533,22 @@ class ProbeTool extends AnnotationTool {
     isPreScaled: boolean
   ): string[] | undefined {
     const cachedVolumeStats = data.cachedStats[targetId];
-    const { index, Modality, value, SUVBw, SUVLbm, SUVBsa } = cachedVolumeStats;
+    const {
+      index,
+      Modality,
+      value,
+      SUVBw,
+      SUVLbm,
+      SUVBsa,
+      suvbw: suvbwScalingFactor,
+    } = cachedVolumeStats;
 
     if (value === undefined && SUVBw === undefined) {
       return;
     }
 
     const textLines = [];
-    const unit = getModalityUnit(Modality, isPreScaled);
+    const unit = getModalityUnit(Modality, isPreScaled, suvbwScalingFactor);
 
     textLines.push(`(${index[0]}, ${index[1]}, ${index[2]})`);
 
@@ -646,10 +655,17 @@ class ProbeTool extends AnnotationTool {
 
         const values = this._getValueForModality(value, image, modality);
 
+        const { suvbw } =
+          metaData.get(
+            'scalingModule',
+            annotation.metadata.referencedImageId
+          ) || {};
+
         cachedStats[targetId] = {
           index,
           ...values,
           Modality: modality,
+          suvbw,
         };
       } else {
         this.isHandleOutsideImage = true;

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -505,11 +505,16 @@ class ProbeTool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const { suvbw } =
-        metaData.get('scalingModule', annotation.metadata.referencedImageId) ||
-        {};
+      const scalingModule: Types.ScalingParameters | undefined =
+        annotation.metadata.referencedImageId &&
+        metaData.get('scalingModule', annotation.metadata.referencedImageId);
 
-      const textLines = this._getTextLines(data, targetId, isPreScaled, suvbw);
+      const textLines = this._getTextLines(
+        data,
+        targetId,
+        isPreScaled,
+        scalingModule?.suvbw
+      );
       if (textLines) {
         const textCanvasCoordinates = [
           canvasCoordinates[0] + 6,
@@ -573,7 +578,7 @@ class ProbeTool extends AnnotationTool {
     // Check if we have scaling for the other 2 SUV types for the PET.
     if (
       modality === 'PT' &&
-      imageVolume.scaling.PET &&
+      imageVolume.scaling?.PET &&
       (imageVolume.scaling.PET.suvbwToSuvbsa ||
         imageVolume.scaling.PET.suvbwToSuvlbm)
     ) {

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -505,7 +505,11 @@ class ProbeTool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const textLines = this._getTextLines(data, targetId, isPreScaled);
+      const { suvbw } =
+        metaData.get('scalingModule', annotation.metadata.referencedImageId) ||
+        {};
+
+      const textLines = this._getTextLines(data, targetId, isPreScaled, suvbw);
       if (textLines) {
         const textCanvasCoordinates = [
           canvasCoordinates[0] + 6,
@@ -530,18 +534,11 @@ class ProbeTool extends AnnotationTool {
   _getTextLines(
     data,
     targetId: string,
-    isPreScaled: boolean
+    isPreScaled: boolean,
+    suvbwScalingFactor?: number
   ): string[] | undefined {
     const cachedVolumeStats = data.cachedStats[targetId];
-    const {
-      index,
-      Modality,
-      value,
-      SUVBw,
-      SUVLbm,
-      SUVBsa,
-      suvbw: suvbwScalingFactor,
-    } = cachedVolumeStats;
+    const { index, Modality, value, SUVBw, SUVLbm, SUVBsa } = cachedVolumeStats;
 
     if (value === undefined && SUVBw === undefined) {
       return;
@@ -655,17 +652,10 @@ class ProbeTool extends AnnotationTool {
 
         const values = this._getValueForModality(value, image, modality);
 
-        const { suvbw } =
-          metaData.get(
-            'scalingModule',
-            annotation.metadata.referencedImageId
-          ) || {};
-
         cachedStats[targetId] = {
           index,
           ...values,
           Modality: modality,
-          suvbw,
         };
       } else {
         this.isHandleOutsideImage = true;

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -6,6 +6,7 @@ import {
   triggerEvent,
   eventTarget,
   utilities as csUtils,
+  metaData,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -844,14 +845,15 @@ class RectangleROITool extends AnnotationTool {
     isPreScaled: boolean
   ): string[] | undefined => {
     const cachedVolumeStats = data.cachedStats[targetId];
-    const { area, mean, max, stdDev, Modality, areaUnit } = cachedVolumeStats;
+    const { area, mean, max, stdDev, Modality, areaUnit, suvbw } =
+      cachedVolumeStats;
 
     if (mean === undefined) {
       return;
     }
 
     const textLines: string[] = [];
-    const unit = getModalityUnit(Modality, isPreScaled);
+    const unit = getModalityUnit(Modality, isPreScaled, suvbw);
 
     textLines.push(`Area: ${area.toFixed(2)} ${areaUnit}\xb2`);
     textLines.push(`Mean: ${mean.toFixed(2)} ${unit}`);
@@ -985,8 +987,15 @@ class RectangleROITool extends AnnotationTool {
         stdDev /= count;
         stdDev = Math.sqrt(stdDev);
 
+        const { suvbw } =
+          metaData.get(
+            'scalingModule',
+            annotation.metadata.referencedImageId
+          ) || {};
+
         cachedStats[targetId] = {
           Modality: metadata.Modality,
+          suvbw,
           area,
           mean,
           stdDev,

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -6,7 +6,6 @@ import {
   triggerEvent,
   eventTarget,
   utilities as csUtils,
-  metaData,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -772,15 +771,17 @@ class RectangleROITool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const scalingModule: Types.ScalingParameters | undefined =
-        annotation.metadata.referencedImageId &&
-        metaData.get('scalingModule', annotation.metadata.referencedImageId);
+      const isSuvScaled = this.isSuvScaled(
+        viewport,
+        targetId,
+        annotation.metadata.referencedImageId
+      );
 
       const textLines = this._getTextLines(
         data,
         targetId,
         isPreScaled,
-        scalingModule?.suvbw
+        isSuvScaled
       );
       if (!textLines || textLines.length === 0) {
         continue;
@@ -852,7 +853,7 @@ class RectangleROITool extends AnnotationTool {
     data,
     targetId: string,
     isPreScaled: boolean,
-    suvbw?: number
+    isSuvScaled: boolean
   ): string[] | undefined => {
     const cachedVolumeStats = data.cachedStats[targetId];
     const { area, mean, max, stdDev, Modality, areaUnit } = cachedVolumeStats;
@@ -862,7 +863,7 @@ class RectangleROITool extends AnnotationTool {
     }
 
     const textLines: string[] = [];
-    const unit = getModalityUnit(Modality, isPreScaled, suvbw);
+    const unit = getModalityUnit(Modality, isPreScaled, isSuvScaled);
 
     textLines.push(`Area: ${area.toFixed(2)} ${areaUnit}\xb2`);
     textLines.push(`Mean: ${mean.toFixed(2)} ${unit}`);

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -772,7 +772,11 @@ class RectangleROITool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const textLines = this._getTextLines(data, targetId, isPreScaled);
+      const { suvbw } =
+        metaData.get('scalingModule', annotation.metadata.referencedImageId) ||
+        {};
+
+      const textLines = this._getTextLines(data, targetId, isPreScaled, suvbw);
       if (!textLines || textLines.length === 0) {
         continue;
       }
@@ -842,11 +846,11 @@ class RectangleROITool extends AnnotationTool {
   _getTextLines = (
     data,
     targetId: string,
-    isPreScaled: boolean
+    isPreScaled: boolean,
+    suvbw?: number
   ): string[] | undefined => {
     const cachedVolumeStats = data.cachedStats[targetId];
-    const { area, mean, max, stdDev, Modality, areaUnit, suvbw } =
-      cachedVolumeStats;
+    const { area, mean, max, stdDev, Modality, areaUnit } = cachedVolumeStats;
 
     if (mean === undefined) {
       return;
@@ -987,15 +991,8 @@ class RectangleROITool extends AnnotationTool {
         stdDev /= count;
         stdDev = Math.sqrt(stdDev);
 
-        const { suvbw } =
-          metaData.get(
-            'scalingModule',
-            annotation.metadata.referencedImageId
-          ) || {};
-
         cachedStats[targetId] = {
           Modality: metadata.Modality,
-          suvbw,
           area,
           mean,
           stdDev,

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -772,11 +772,16 @@ class RectangleROITool extends AnnotationTool {
 
       const isPreScaled = isViewportPreScaled(viewport, targetId);
 
-      const { suvbw } =
-        metaData.get('scalingModule', annotation.metadata.referencedImageId) ||
-        {};
+      const scalingModule: Types.ScalingParameters | undefined =
+        annotation.metadata.referencedImageId &&
+        metaData.get('scalingModule', annotation.metadata.referencedImageId);
 
-      const textLines = this._getTextLines(data, targetId, isPreScaled, suvbw);
+      const textLines = this._getTextLines(
+        data,
+        targetId,
+        isPreScaled,
+        scalingModule?.suvbw
+      );
       if (!textLines || textLines.length === 0) {
         continue;
       }

--- a/packages/tools/src/tools/base/AnnotationTool.ts
+++ b/packages/tools/src/tools/base/AnnotationTool.ts
@@ -1,4 +1,10 @@
-import { getEnabledElement } from '@cornerstonejs/core';
+import {
+  BaseVolumeViewport,
+  StackViewport,
+  cache,
+  getEnabledElement,
+  metaData,
+} from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
 import { vec2 } from 'gl-matrix';
@@ -258,6 +264,31 @@ abstract class AnnotationTool extends AnnotationDisplayTool {
         annotation
       ),
     };
+  }
+
+  /**
+   * Returns true if the viewport is scaled to SUV units
+   * @param viewport - The viewport
+   * @param targetId - The annotation targetId
+   * @param imageId - The annotation imageId
+   * @returns
+   */
+  isSuvScaled(
+    viewport: Types.IStackViewport | Types.IVolumeViewport,
+    targetId: string,
+    imageId?: string
+  ): boolean {
+    if (viewport instanceof BaseVolumeViewport) {
+      const volumeId = targetId.split('volumeId:')[1];
+      const volume = cache.getVolume(volumeId);
+      return volume.scaling?.PET !== undefined;
+    } else if (viewport instanceof StackViewport) {
+      const scalingModule: Types.ScalingParameters | undefined =
+        imageId && metaData.get('scalingModule', imageId);
+      return typeof scalingModule?.suvbw === 'number';
+    } else {
+      throw new Error('Viewport is not a valid type');
+    }
   }
 
   /**

--- a/packages/tools/src/utilities/getModalityUnit.ts
+++ b/packages/tools/src/utilities/getModalityUnit.ts
@@ -1,8 +1,6 @@
 function getModalityUnit(modality: string, isPreScaled: boolean): string {
   if (modality === 'CT') {
     return 'HU';
-  } else if (modality === 'PT' && isPreScaled === true) {
-    return 'SUV';
   } else {
     return '';
   }

--- a/packages/tools/src/utilities/getModalityUnit.ts
+++ b/packages/tools/src/utilities/getModalityUnit.ts
@@ -1,6 +1,16 @@
-function getModalityUnit(modality: string, isPreScaled: boolean): string {
+function getModalityUnit(
+  modality: string,
+  isPreScaled: boolean,
+  suvbw?: number
+): string {
   if (modality === 'CT') {
     return 'HU';
+  } else if (
+    modality === 'PT' &&
+    isPreScaled === true &&
+    typeof suvbw === 'number'
+  ) {
+    return 'SUV';
   } else {
     return '';
   }

--- a/packages/tools/src/utilities/getModalityUnit.ts
+++ b/packages/tools/src/utilities/getModalityUnit.ts
@@ -1,14 +1,14 @@
 function getModalityUnit(
   modality: string,
   isPreScaled: boolean,
-  suvbw?: number
+  isSuvScaled: boolean
 ): string {
   if (modality === 'CT') {
     return 'HU';
   } else if (
     modality === 'PT' &&
     isPreScaled === true &&
-    typeof suvbw === 'number'
+    isSuvScaled === true
   ) {
     return 'SUV';
   } else {

--- a/utils/test/testUtilsImageLoader.js
+++ b/utils/test/testUtilsImageLoader.js
@@ -77,6 +77,11 @@ const fakeImageLoader = (imageId) => {
  * @returns metadata based on the imageId and type
  */
 function fakeMetaDataProvider(type, imageId) {
+  if (typeof imageId !== 'string') {
+    throw new Error(
+      `Expected imageId to be of type string, but received ${imageId}`
+    );
+  }
   const imageURI = imageId.split(':')[1];
   const [_, rows, columns, barStart, barWidth, x_spacing, y_spacing, rgb, PT] =
     imageURI.split('_').map((v) => parseFloat(v));


### PR DESCRIPTION
Currently PT images that are **not** in SUV are not rescaled at all. This is problematic because PT images can be in units of e.g. counts or Bq/ml, so it's important that the rescaling is applied in those cases.