### PR TITLE
feat(contour): improved performance and better configuration

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -13,6 +13,7 @@ import type { vtkImageData } from '@kitware/vtk.js/Common/DataModel/ImageData';
 import vtkImageSlice from '@kitware/vtk.js/Rendering/Core/ImageSlice';
 import type { vtkObject } from '@kitware/vtk.js/interfaces';
 import vtkPlane from '@kitware/vtk.js/Common/DataModel/Plane';
+import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import type vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 
 // @public (undocumented)
@@ -931,6 +932,8 @@ interface IContourSet {
     // (undocumented)
     readonly frameOfReferenceUID: string;
     // (undocumented)
+    getCentroid(): Point3;
+    // (undocumented)
     getColor(): any;
     // (undocumented)
     getContours(): IContour[];
@@ -945,6 +948,8 @@ interface IContourSet {
     // (undocumented)
     getPointsInContour(contourIndex: number): Point3[];
     // (undocumented)
+    getPolyData(): vtkPolyData;
+    // (undocumented)
     getSegmentIndex(): number;
     // (undocumented)
     getSizeInBytes(): number;
@@ -952,6 +957,8 @@ interface IContourSet {
     getTotalNumberOfPoints(): number;
     // (undocumented)
     readonly id: string;
+    // (undocumented)
+    setPolyData(polyData: vtkPolyData): void;
     // (undocumented)
     readonly sizeInBytes: number;
 }

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -13,7 +13,6 @@ import type { vtkImageData } from '@kitware/vtk.js/Common/DataModel/ImageData';
 import vtkImageSlice from '@kitware/vtk.js/Rendering/Core/ImageSlice';
 import type { vtkObject } from '@kitware/vtk.js/interfaces';
 import vtkPlane from '@kitware/vtk.js/Common/DataModel/Plane';
-import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import type vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 
 // @public (undocumented)
@@ -948,8 +947,6 @@ interface IContourSet {
     // (undocumented)
     getPointsInContour(contourIndex: number): Point3[];
     // (undocumented)
-    getPolyData(): vtkPolyData;
-    // (undocumented)
     getSegmentIndex(): number;
     // (undocumented)
     getSizeInBytes(): number;
@@ -957,8 +954,6 @@ interface IContourSet {
     getTotalNumberOfPoints(): number;
     // (undocumented)
     readonly id: string;
-    // (undocumented)
-    setPolyData(polyData: vtkPolyData): void;
     // (undocumented)
     readonly sizeInBytes: number;
 }

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -9,7 +9,6 @@ import type { mat4 } from 'gl-matrix';
 import type vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';
 import type { vtkImageData } from '@kitware/vtk.js/Common/DataModel/ImageData';
 import vtkImageSlice from '@kitware/vtk.js/Rendering/Core/ImageSlice';
-import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import type vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 
 // @public (undocumented)
@@ -654,7 +653,6 @@ interface IContourSet {
     getNumberOfPointsArray(): number[];
     getNumberOfPointsInAContour(contourIndex: number): number;
     getPointsInContour(contourIndex: number): Point3[];
-    getPolyData(): vtkPolyData;
     // (undocumented)
     getSegmentIndex(): number;
     // (undocumented)
@@ -662,7 +660,6 @@ interface IContourSet {
     getTotalNumberOfPoints(): number;
     // (undocumented)
     readonly id: string;
-    setPolyData(polyData: vtkPolyData): void;
     // (undocumented)
     readonly sizeInBytes: number;
 }

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -9,6 +9,7 @@ import type { mat4 } from 'gl-matrix';
 import type vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';
 import type { vtkImageData } from '@kitware/vtk.js/Common/DataModel/ImageData';
 import vtkImageSlice from '@kitware/vtk.js/Rendering/Core/ImageSlice';
+import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import type vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 
 // @public (undocumented)
@@ -644,6 +645,8 @@ interface IContourSet {
     // (undocumented)
     readonly frameOfReferenceUID: string;
     // (undocumented)
+    getCentroid(): Point3;
+    // (undocumented)
     getColor(): any;
     getContours(): IContour[];
     getFlatPointsArray(): Point3[];
@@ -651,6 +654,7 @@ interface IContourSet {
     getNumberOfPointsArray(): number[];
     getNumberOfPointsInAContour(contourIndex: number): number;
     getPointsInContour(contourIndex: number): Point3[];
+    getPolyData(): vtkPolyData;
     // (undocumented)
     getSegmentIndex(): number;
     // (undocumented)
@@ -658,6 +662,7 @@ interface IContourSet {
     getTotalNumberOfPoints(): number;
     // (undocumented)
     readonly id: string;
+    setPolyData(polyData: vtkPolyData): void;
     // (undocumented)
     readonly sizeInBytes: number;
 }

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -10,6 +10,7 @@ import type { vtkColorTransferFunction } from '@kitware/vtk.js/Rendering/Core/Co
 import type { vtkImageData } from '@kitware/vtk.js/Common/DataModel/ImageData';
 import vtkImageSlice from '@kitware/vtk.js/Rendering/Core/ImageSlice';
 import type { vtkPiecewiseFunction } from '@kitware/vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import type vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 
 declare namespace activeSegmentation {
@@ -2339,6 +2340,8 @@ interface IContourSet {
     // (undocumented)
     readonly frameOfReferenceUID: string;
     // (undocumented)
+    getCentroid(): Point3;
+    // (undocumented)
     getColor(): any;
     getContours(): IContour[];
     getFlatPointsArray(): Point3[];
@@ -2346,6 +2349,7 @@ interface IContourSet {
     getNumberOfPointsArray(): number[];
     getNumberOfPointsInAContour(contourIndex: number): number;
     getPointsInContour(contourIndex: number): Point3[];
+    getPolyData(): vtkPolyData;
     // (undocumented)
     getSegmentIndex(): number;
     // (undocumented)
@@ -2353,6 +2357,7 @@ interface IContourSet {
     getTotalNumberOfPoints(): number;
     // (undocumented)
     readonly id: string;
+    setPolyData(polyData: vtkPolyData): void;
     // (undocumented)
     readonly sizeInBytes: number;
 }

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -10,7 +10,6 @@ import type { vtkColorTransferFunction } from '@kitware/vtk.js/Rendering/Core/Co
 import type { vtkImageData } from '@kitware/vtk.js/Common/DataModel/ImageData';
 import vtkImageSlice from '@kitware/vtk.js/Rendering/Core/ImageSlice';
 import type { vtkPiecewiseFunction } from '@kitware/vtk.js/Common/DataModel/PiecewiseFunction';
-import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import type vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 
 declare namespace activeSegmentation {
@@ -2349,7 +2348,6 @@ interface IContourSet {
     getNumberOfPointsArray(): number[];
     getNumberOfPointsInAContour(contourIndex: number): number;
     getPointsInContour(contourIndex: number): Point3[];
-    getPolyData(): vtkPolyData;
     // (undocumented)
     getSegmentIndex(): number;
     // (undocumented)
@@ -2357,7 +2355,6 @@ interface IContourSet {
     getTotalNumberOfPoints(): number;
     // (undocumented)
     readonly id: string;
-    setPolyData(polyData: vtkPolyData): void;
     // (undocumented)
     readonly sizeInBytes: number;
 }

--- a/packages/core/src/cache/classes/ContourSet.ts
+++ b/packages/core/src/cache/classes/ContourSet.ts
@@ -21,6 +21,7 @@ export class ContourSet implements IContourSet {
   private color: Point3 = [200, 0, 0]; // default color
   private segmentIndex: number;
   private polyData: vtkPolyData;
+  private centroid: Point3;
   contours: IContour[];
 
   constructor(props: ContourSetProps) {
@@ -52,12 +53,43 @@ export class ContourSet implements IContourSet {
 
       this.contours.push(contour);
     });
+
+    this._updateContourSetCentroid();
+  }
+
+  // Todo: this centroid calculation has limitation in which
+  // the if there are two clusters of points, the centroid will be
+  // the center of the two clusters, not the center of the segment
+  _updateContourSetCentroid(): void {
+    const numberOfPoints = this.getTotalNumberOfPoints();
+    const flatPointsArray = this.getFlatPointsArray();
+
+    const centroid = flatPointsArray.reduce(
+      (centroid, point) => {
+        return [
+          centroid[0] + point[0],
+          centroid[1] + point[1],
+          centroid[2] + point[2],
+        ];
+      },
+      [0, 0, 0]
+    );
+
+    this.centroid = [
+      centroid[0] / numberOfPoints,
+      centroid[1] / numberOfPoints,
+      centroid[2] / numberOfPoints,
+    ];
   }
 
   _getSizeInBytes(): number {
     return this.contours.reduce((sizeInBytes, contour) => {
       return sizeInBytes + contour.sizeInBytes;
     }, 0);
+  }
+
+  public getCentroid(): Point3 {
+    return this.centroid;
   }
 
   public getSegmentIndex(): number {

--- a/packages/core/src/cache/classes/ContourSet.ts
+++ b/packages/core/src/cache/classes/ContourSet.ts
@@ -185,23 +185,6 @@ export class ContourSet implements IContourSet {
     return this.getPointsInContour(contourIndex).length;
   }
 
-  /**
-   * vtk polyData associated with the contour set
-   * @returns the vtk polydata object
-   */
-  public getPolyData(): vtkPolyData {
-    return this.polyData;
-  }
-
-  /**
-   * Sets the vtk polyData associated with the contour set
-   * for caching puproses
-   * @param polyData vtk polydata object
-   */
-  public setPolyData(polyData: any): void {
-    this.polyData = polyData;
-  }
-
   private _getDistance(pointA, pointB) {
     return Math.sqrt(
       (pointA[0] - pointB[0]) ** 2 +

--- a/packages/core/src/cache/classes/ContourSet.ts
+++ b/packages/core/src/cache/classes/ContourSet.ts
@@ -1,3 +1,4 @@
+import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import { Point3, IContourSet, IContour, ContourData } from '../../types';
 import Contour from './Contour';
 
@@ -19,6 +20,7 @@ export class ContourSet implements IContourSet {
   readonly frameOfReferenceUID: string;
   private color: Point3 = [200, 0, 0]; // default color
   private segmentIndex: number;
+  private polyData: vtkPolyData;
   contours: IContour[];
 
   constructor(props: ContourSetProps) {
@@ -136,6 +138,23 @@ export class ContourSet implements IContourSet {
    */
   public getNumberOfPointsInAContour(contourIndex: number): number {
     return this.getPointsInContour(contourIndex).length;
+  }
+
+  /**
+   * vtk polyData associated with the contour set
+   * @returns the vtk polydata object
+   */
+  public getPolyData(): vtkPolyData {
+    return this.polyData;
+  }
+
+  /**
+   * Sets the vtk polyData associated with the contour set
+   * for caching puproses
+   * @param polyData vtk polydata object
+   */
+  public setPolyData(polyData: any): void {
+    this.polyData = polyData;
   }
 
   /**

--- a/packages/core/src/cache/classes/ContourSet.ts
+++ b/packages/core/src/cache/classes/ContourSet.ts
@@ -60,9 +60,9 @@ export class ContourSet implements IContourSet {
   // it will not work for MPR, the reason is that we are finding
   // the centroid of all points but at the end we are picking the
   // closest point to the centroid, which will not work for MPR
-  // Thee reason for picking the closest is rendering issue since
+  // The reason for picking the closest is a rendering issue since
   // the centroid can be not exactly in the middle of the slice
-  // and it might cause the contour to be rendered in the wrong
+  // and it might cause the contour to be rendered in the wrong slice
   // or not rendered at all
   _updateContourSetCentroid(): void {
     const numberOfPoints = this.getTotalNumberOfPoints();

--- a/packages/core/src/types/IContourSet.ts
+++ b/packages/core/src/types/IContourSet.ts
@@ -56,15 +56,4 @@ export interface IContourSet {
    * @returns The number of points in the contour.
    */
   getNumberOfPointsInAContour(contourIndex: number): number;
-
-  /**
-   * This function returns the polydata of the contour set.
-   */
-  getPolyData(): vtkPolyData;
-
-  /**
-   * This function sets the polydata of the contour set.
-   * @param polyData - vtk polydata
-   */
-  setPolyData(polyData: vtkPolyData): void;
 }

--- a/packages/core/src/types/IContourSet.ts
+++ b/packages/core/src/types/IContourSet.ts
@@ -1,3 +1,4 @@
+import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import { ContourData, IContour, Point3 } from './';
 
 /**
@@ -54,4 +55,15 @@ export interface IContourSet {
    * @returns The number of points in the contour.
    */
   getNumberOfPointsInAContour(contourIndex: number): number;
+
+  /**
+   * This function returns the polydata of the contour set.
+   */
+  getPolyData(): vtkPolyData;
+
+  /**
+   * This function sets the polydata of the contour set.
+   * @param polyData - vtk polydata
+   */
+  setPolyData(polyData: vtkPolyData): void;
 }

--- a/packages/core/src/types/IContourSet.ts
+++ b/packages/core/src/types/IContourSet.ts
@@ -13,6 +13,7 @@ export interface IContourSet {
   _createEachContour(data: ContourData[]): void;
   getSizeInBytes(): number;
   getSegmentIndex(): number;
+  getCentroid(): Point3;
   getColor(): any;
   /**
    * This function returns the contours of the image

--- a/packages/tools/examples/contourRenderingConfiguration/index.ts
+++ b/packages/tools/examples/contourRenderingConfiguration/index.ts
@@ -122,7 +122,7 @@ addToggleButtonToToolbar({
 });
 
 addToggleButtonToToolbar({
-  title: 'Hide Green  Segment',
+  title: 'Hide Green Segment',
   onClick: (toggle) => {
     const segmentIndex = 2;
     [

--- a/packages/tools/examples/contourRenderingConfiguration/index.ts
+++ b/packages/tools/examples/contourRenderingConfiguration/index.ts
@@ -101,9 +101,30 @@ addToggleButtonToToolbar({
 });
 
 addToggleButtonToToolbar({
-  title: 'Hide Segment',
+  title: 'Hide Red Segment',
   onClick: (toggle) => {
     const segmentIndex = 1;
+    [
+      { representationUID: planarSegmentationRepresentationUID, toolGroupId },
+      {
+        representationUID: volumeSegmentationRepresentationUID,
+        toolGroupId: toolGroupId3d,
+      },
+    ].forEach(({ representationUID, toolGroupId }) => {
+      segmentation.config.visibility.setSegmentVisibility(
+        toolGroupId,
+        representationUID,
+        segmentIndex,
+        !toggle
+      );
+    });
+  },
+});
+
+addToggleButtonToToolbar({
+  title: 'Hide Green  Segment',
+  onClick: (toggle) => {
+    const segmentIndex = 2;
     [
       { representationUID: planarSegmentationRepresentationUID, toolGroupId },
       {

--- a/packages/tools/src/stateManagement/segmentation/removeSegmentationsFromToolGroup.ts
+++ b/packages/tools/src/stateManagement/segmentation/removeSegmentationsFromToolGroup.ts
@@ -1,5 +1,6 @@
 import SegmentationRepresentations from '../../enums/SegmentationRepresentations';
 import { labelmapDisplay } from '../../tools/displayTools/Labelmap';
+import { contourDisplay } from '../../tools/displayTools/Contour';
 
 import {
   getSegmentationRepresentations,
@@ -76,7 +77,11 @@ function _removeSegmentation(
       immediate
     );
   } else if (type === SegmentationRepresentations.Contour) {
-    console.debug('Contour representation is not supported yet, ignoring...');
+    contourDisplay.removeSegmentationRepresentation(
+      toolGroupId,
+      segmentationRepresentationUID,
+      immediate
+    );
   } else {
     throw new Error(`The representation ${type} is not supported yet`);
   }

--- a/packages/tools/src/tools/displayTools/Contour/addContourSetsToElement.ts
+++ b/packages/tools/src/tools/displayTools/Contour/addContourSetsToElement.ts
@@ -51,7 +51,14 @@ export function addContourSetsToElement(
     );
 
     const contourSet = geometry.data;
-    const polyData = getPolyData(contourSet);
+
+    let polyData = contourSet.getPolyData();
+
+    if (!polyData) {
+      polyData = getPolyData(contourSet);
+      contourSet.setPolyData(polyData);
+    }
+
     const color = contourSet.getColor();
 
     const size = polyData.getPoints().getNumberOfPoints();

--- a/packages/tools/src/tools/displayTools/Contour/addContourSetsToElement.ts
+++ b/packages/tools/src/tools/displayTools/Contour/addContourSetsToElement.ts
@@ -51,9 +51,7 @@ export function addContourSetsToElement(
     );
 
     const contourSet = geometry.data;
-
     const polyData = getPolyData(contourSet);
-
     const color = contourSet.getColor();
 
     const size = polyData.getPoints().getNumberOfPoints();

--- a/packages/tools/src/tools/displayTools/Contour/addContourSetsToElement.ts
+++ b/packages/tools/src/tools/displayTools/Contour/addContourSetsToElement.ts
@@ -52,12 +52,7 @@ export function addContourSetsToElement(
 
     const contourSet = geometry.data;
 
-    let polyData = contourSet.getPolyData();
-
-    if (!polyData) {
-      polyData = getPolyData(contourSet);
-      contourSet.setPolyData(polyData);
-    }
+    const polyData = getPolyData(contourSet);
 
     const color = contourSet.getColor();
 

--- a/packages/tools/src/tools/displayTools/Contour/contourConfig.ts
+++ b/packages/tools/src/tools/displayTools/Contour/contourConfig.ts
@@ -2,7 +2,7 @@ import { ContourConfig } from '../../../types/ContourTypes';
 
 const defaultContourConfig: ContourConfig = {
   renderOutline: true,
-  outlineWidthActive: 1,
+  outlineWidthActive: 2,
   outlineWidthInactive: 2,
   outlineOpacity: 1,
   outlineOpacityInactive: 0.85,

--- a/packages/tools/src/tools/displayTools/Contour/contourConfig.ts
+++ b/packages/tools/src/tools/displayTools/Contour/contourConfig.ts
@@ -2,10 +2,13 @@ import { ContourConfig } from '../../../types/ContourTypes';
 
 const defaultContourConfig: ContourConfig = {
   renderOutline: true,
-  outlineWidthActive: 2,
+  outlineWidthActive: 1,
   outlineWidthInactive: 2,
   outlineOpacity: 1,
   outlineOpacityInactive: 0.85,
+  renderFill: true,
+  fillAlpha: 1,
+  fillAlphaInactive: 0,
 };
 
 function getDefaultContourConfig(): ContourConfig {

--- a/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
+++ b/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../types/SegmentationStateTypes';
 import { addOrUpdateContourSets } from './addOrUpdateContourSets';
 import removeContourFromElement from './removeContourFromElement';
+import { deleteConfigCache } from './contourConfigCache';
 
 /**
  * It adds a new segmentation representation to the segmentation state
@@ -96,6 +97,8 @@ function removeSegmentationRepresentation(
     toolGroupId,
     segmentationRepresentationUID
   );
+
+  deleteConfigCache(segmentationRepresentationUID);
 
   if (renderImmediate) {
     const viewportsInfo = getToolGroup(toolGroupId).getViewportsInfo();

--- a/packages/tools/src/tools/displayTools/Contour/updateContourSets.ts
+++ b/packages/tools/src/tools/displayTools/Contour/updateContourSets.ts
@@ -100,19 +100,14 @@ export function updateContourSets(
 
   if (affectedSegments.length || hasCustomSegmentSpecificConfig) {
     const appendPolyData = mapper.getInputData();
-    const appendScalarData = appendPolyData
-      .getPointData()
-      .getScalars()
-      .getData();
+    const appendScalars = appendPolyData.getPointData().getScalars();
+    const appendScalarsData = appendScalars.getData();
     // below we will only manipulate the polyData of the contourSets that are affected
     // by picking the correct offset in the scalarData array
-
-    contourSets.forEach((contourSet, index) => {
+    let offset = 0;
+    contourSets.forEach((contourSet) => {
       const segmentIndex = (contourSet as Types.IContourSet).getSegmentIndex();
-      // const polyData = contourSet.getPolyData();
       const size = contourSet.getTotalNumberOfPoints();
-      // const scalars = polyData.getPointData().getScalars();
-      // const scalarData = scalars.getData();
 
       if (
         affectedSegments.includes(segmentIndex) ||
@@ -128,26 +123,21 @@ export function updateContourSets(
           visibility = segmentConfig.fillAlpha * 255;
         }
 
-        const offset = index * size * 4;
-
         for (let i = 0; i < size; ++i) {
-          appendScalarData[offset + i * 4] = color[0];
-          appendScalarData[offset + i * 4 + 1] = color[1];
-          appendScalarData[offset + i * 4 + 2] = color[2];
-          appendScalarData[offset + i * 4 + 3] = visibility;
+          appendScalarsData[offset + i * 4] = color[0];
+          appendScalarsData[offset + i * 4 + 1] = color[1];
+          appendScalarsData[offset + i * 4 + 2] = color[2];
+          appendScalarsData[offset + i * 4 + 3] = visibility;
         }
 
         polyDataModified = true;
       }
+
+      offset = offset + size * 4;
     });
 
     if (polyDataModified) {
       appendPolyData.modified();
-      mapper.setInputData(appendPolyData);
-      mapper.modified();
-      actor.modified();
-      // viewport.removeActors([contourActorUID]);
-      viewport.render();
     }
 
     setConfigCache(

--- a/packages/tools/src/tools/displayTools/Contour/updateContourSets.ts
+++ b/packages/tools/src/tools/displayTools/Contour/updateContourSets.ts
@@ -1,5 +1,4 @@
 import { cache, Types } from '@cornerstonejs/core';
-import vtkAppendPolyData from '@kitware/vtk.js/Filters/General/AppendPolyData';
 import vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';
 
 import {

--- a/packages/tools/src/tools/displayTools/Contour/updateContourSets.ts
+++ b/packages/tools/src/tools/displayTools/Contour/updateContourSets.ts
@@ -53,7 +53,7 @@ export function updateContourSets(
   const segmentsToSetToVisible = [];
 
   for (const segmentIndex of segmentsHidden) {
-    if (!cachedConfig?.segmentsHidden.has(segmentIndex)) {
+    if (!cachedConfig.segmentsHidden.has(segmentIndex)) {
       segmentsToSetToInvisible.push(segmentIndex);
     }
   }
@@ -64,7 +64,12 @@ export function updateContourSets(
       segmentsToSetToVisible.push(segmentIndex);
     }
   }
-  if (segmentsToSetToInvisible.length || segmentsToSetToVisible.length) {
+
+  const mergedInvisibleSegments = Array.from(cachedConfig.segmentsHidden)
+    .filter((segmentIndex) => !segmentsToSetToVisible.includes(segmentIndex))
+    .concat(segmentsToSetToInvisible);
+
+  if (mergedInvisibleSegments.length || segmentsToSetToVisible.length) {
     const appendPolyData = vtkAppendPolyData.newInstance();
 
     geometryIds.forEach((geometryId) => {
@@ -72,7 +77,7 @@ export function updateContourSets(
       const { data: contourSet } = geometry;
       const segmentIndex = (contourSet as Types.IContourSet).getSegmentIndex();
       const color = contourSet.getColor();
-      const visibility = segmentsToSetToInvisible.includes(segmentIndex)
+      const visibility = mergedInvisibleSegments.includes(segmentIndex)
         ? 0
         : 255;
       const polyData = getPolyData(contourSet);

--- a/packages/tools/src/tools/displayTools/Contour/utils.ts
+++ b/packages/tools/src/tools/displayTools/Contour/utils.ts
@@ -1,6 +1,5 @@
 import { Enums, Types } from '@cornerstonejs/core';
 import vtkCellArray from '@kitware/vtk.js/Common/Core/CellArray';
-import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
 import vtkPoints from '@kitware/vtk.js/Common/Core/Points';
 import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import { ToolGroupSpecificContourRepresentation } from '../../../types';

--- a/packages/tools/src/types/ContourTypes.ts
+++ b/packages/tools/src/types/ContourTypes.ts
@@ -12,6 +12,12 @@ export type ContourConfig = {
   outlineOpacityInactive?: number;
   /** outline visibility */
   renderOutline?: boolean;
+  /** render fill */
+  renderFill?: boolean;
+  /** fill alpha */
+  fillAlpha?: number;
+  /** fillAlphaInactive */
+  fillAlphaInactive?: number;
 };
 
 /**


### PR DESCRIPTION
Improved performance for updating contours and centroid calculations
To test: run https://deploy-preview-543--cornerstone-3d-docs.netlify.app/live-examples/contourrenderingconfiguration

- refactor: Update contour rendering default configuration & remove console.debug call
- perf: Optimize getting and setting vtk polydata for contour sets
- refactor(displayTools): optimize contour sets rendering with segment specific configs
- refactor: Remove redundant code for Contour display tools
- feat: add computation for centroid of the contour set
- refactor: simplify centroid calculation for better contour rendering
