### PR TITLE
fix(init): should only check gl context and not extensions

### DIFF
--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -49,18 +49,10 @@ function _getGLContext(): RenderingContext {
 function _hasActiveWebGLContext() {
   const gl = _getGLContext();
 
-  // Report the result.
-  if (gl && (gl as WebGL2RenderingContext).getExtension) {
-    const ext = (gl as WebGL2RenderingContext).getExtension(
-      'EXT_texture_norm16'
-    );
-
-    if (ext) {
-      return true;
-    }
-  }
-
-  return false;
+  // Check if the context is either WebGLRenderingContext or WebGL2RenderingContext
+  return (
+    gl instanceof WebGLRenderingContext || gl instanceof WebGL2RenderingContext
+  );
 }
 
 function hasSharedArrayBuffer() {


### PR DESCRIPTION
Simplify condition to check if the context object is an instance of a WebGLRenderingContext or WebGL2RenderingContext in "init.ts"