### PR TITLE
fix(crosshairs): Reference lines are wrongly clipped

### DIFF
--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -782,6 +782,9 @@ class CrosshairsTool extends AnnotationTool {
 
     const referenceLines = [];
 
+    // get canvas information for points and lines (canvas box, canvas horizontal distances)
+    const canvasBox = [0, 0, clientWidth, clientHeight];
+
     otherViewportAnnotations.forEach((annotation) => {
       const { data } = annotation;
 
@@ -830,9 +833,6 @@ class CrosshairsTool extends AnnotationTool {
 
       const pointWorld1: Types.Point3 = [0, 0, 0];
       vtkMath.subtract(otherViewportCenterWorld, direction, pointWorld1);
-
-      // get canvas information for points and lines (canvas box, canvas horizontal distances)
-      const canvasBox = [0, 0, clientWidth, clientHeight];
 
       const pointCanvas0 = viewport.worldToCanvas(pointWorld0);
 


### PR DESCRIPTION
Currently, the reference lines of the Crosshairs Tool may be wrongly clipped when the other viewports have a smaller size.
This PR aims to fix this issue by using the canvasBox of the current viewport instead of the other viewport for clipping lines.

<img width="1093" alt="wrong-clipping" src="https://user-images.githubusercontent.com/330441/231795030-cdd7ff6c-4f2d-4850-8b46-deeeb9e15dbc.png">

