### PR TITLE
fix(mouse): Avoid the delay on double click checking for right click

### DIFF
--- a/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
+++ b/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
@@ -130,9 +130,11 @@ function mouseDownListener(evt: MouseEvent) {
     return;
   }
 
+  // Only left single button click can be doubled up, so fire immediately
+  // on anything except left double click.
   doubleClickState.doubleClickTimeout = setTimeout(
     _doStateMouseDownAndUp,
-    DOUBLE_CLICK_TOLERANCE_MS
+    evt.button === 1 ? DOUBLE_CLICK_TOLERANCE_MS : 0
   );
 
   // First mouse down of a potential double click. So save it and start


### PR DESCRIPTION
The double click check was occurring for right click, delaying context menus appearing.