### PR TITLE
feat(4D): fixed cine play issue and added getDynamicVolumeInfo method

### DIFF
--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -556,6 +556,11 @@ enum GeometryType {
 }
 
 // @public (undocumented)
+export const helpers: {
+    getDynamicVolumeInfo: typeof getDynamicVolumeInfo;
+};
+
+// @public (undocumented)
 interface ICache {
     getCacheSize: () => number;
     getImageLoadObject: (imageId: string) => IImageLoadObject | void;

--- a/packages/streaming-image-volume-loader/src/helpers/getDynamicVolumeInfo.ts
+++ b/packages/streaming-image-volume-loader/src/helpers/getDynamicVolumeInfo.ts
@@ -1,0 +1,16 @@
+import splitImageIdsBy4DTags from './splitImageIdsBy4DTags';
+
+/**
+ * Get some info about 4D image sets. Time points (groups of imageIds) are
+ * returned when the imageIds represents a 4D volume.
+ * @param imageIds - Array of Cornerstone Image Object's imageIds
+ * @returns 4D series infos
+ */
+function getDynamicVolumeInfo(imageIds) {
+  const timePoints = splitImageIdsBy4DTags(imageIds);
+  const isDynamicVolume = timePoints.length > 1;
+
+  return { isDynamicVolume, timePoints };
+}
+
+export default getDynamicVolumeInfo;

--- a/packages/streaming-image-volume-loader/src/helpers/index.ts
+++ b/packages/streaming-image-volume-loader/src/helpers/index.ts
@@ -1,4 +1,5 @@
 import getVolumeInfo from './getVolumeInfo';
+import getDynamicVolumeInfo from './getDynamicVolumeInfo';
 import sortImageIdsAndGetSpacing from './sortImageIdsAndGetSpacing';
 import makeVolumeMetadata from './makeVolumeMetadata';
 import autoLoad from './autoLoad';
@@ -7,6 +8,7 @@ import splitImageIdsBy4DTags from './splitImageIdsBy4DTags';
 
 export {
   getVolumeInfo,
+  getDynamicVolumeInfo,
   sortImageIdsAndGetSpacing,
   makeVolumeMetadata,
   autoLoad,

--- a/packages/streaming-image-volume-loader/src/index.ts
+++ b/packages/streaming-image-volume-loader/src/index.ts
@@ -2,10 +2,16 @@ import cornerstoneStreamingImageVolumeLoader from './cornerstoneStreamingImageVo
 import cornerstoneStreamingDynamicImageVolumeLoader from './cornerstoneStreamingDynamicImageVolumeLoader';
 import StreamingImageVolume from './StreamingImageVolume';
 import StreamingDynamicImageVolume from './StreamingDynamicImageVolume';
+import getDynamicVolumeInfo from './helpers/getDynamicVolumeInfo';
+
+const helpers = {
+  getDynamicVolumeInfo,
+};
 
 export {
   cornerstoneStreamingImageVolumeLoader,
   cornerstoneStreamingDynamicImageVolumeLoader,
   StreamingImageVolume,
   StreamingDynamicImageVolume,
+  helpers,
 };

--- a/packages/tools/examples/stackManipulationTools/index.ts
+++ b/packages/tools/examples/stackManipulationTools/index.ts
@@ -61,9 +61,7 @@ addDropdownToToolbar({
     defaultValue: defaultLeftClickTool,
   },
   onSelectedValueChange: (selectedValue) => {
-    console.log('>>>>> selectedValue :: ', selectedValue);
     const toolGroup = ToolGroupManager.getToolGroup(toolGroupId);
-    console.log('>>>>> toolGroup :: ', toolGroup);
 
     toolGroup.setToolPassive(currentLeftClickTool);
 

--- a/packages/tools/src/utilities/cine/playClip.ts
+++ b/packages/tools/src/utilities/cine/playClip.ts
@@ -298,16 +298,15 @@ function _stopClipWithData(playClipData) {
   }
 }
 
+function _getVolumesFromViewport(viewport): Types.IImageVolume[] {
+  return viewport.getActors().map((actor) => cache.getVolume(actor.uid));
+}
+
 function _getVolumeFromViewport(viewport): Types.IImageVolume {
-  const actorEntry = viewport.getDefaultActor();
+  const volumes = _getVolumesFromViewport(viewport);
+  const dynamicVolume = volumes.find((volume) => volume.isDynamicVolume());
 
-  if (!actorEntry) {
-    // This can happen during setup/teardown of viewports.
-    return;
-  }
-
-  const volumeId = actorEntry.uid;
-  return cache.getVolume(volumeId);
+  return dynamicVolume ?? volumes[0];
 }
 
 function _createStackViewportCinePlayContext(

--- a/packages/tools/src/utilities/cine/playClip.ts
+++ b/packages/tools/src/utilities/cine/playClip.ts
@@ -299,7 +299,10 @@ function _stopClipWithData(playClipData) {
 }
 
 function _getVolumesFromViewport(viewport): Types.IImageVolume[] {
-  return viewport.getActors().map((actor) => cache.getVolume(actor.uid));
+  return viewport
+    .getActors()
+    .map((actor) => cache.getVolume(actor.uid))
+    .filter((volume) => !!volume);
 }
 
 function _getVolumeFromViewport(viewport): Types.IImageVolume {


### PR DESCRIPTION
- cine is checking if there are any 4D volume loaded on a viewport instead of checking only if the default actor is a 4D series because when there are PT (4D) + CT (3D) it has to play as 4D series otherwise it can get into a state where some PT viewports plays as 4D and PT/CT viewports plays as 3D moving the 4D series in time and space at the same time.
- added getDynamicVolumeInfo that is being used by the Viewer to check if a series is a 4D series. That is the same method used when a 4D series is loaded by Cornerstone.