### PR TITLE
feat(docs): update cornerstonejs/tools to v0.66.0 & change dicomImageLoader webpack build process

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -31,7 +31,7 @@
     "@cornerstonejs/core": "^0.44.0",
     "@cornerstonejs/dicom-image-loader": "^0.5.0",
     "@cornerstonejs/streaming-image-volume-loader": "^0.19.0",
-    "@cornerstonejs/tools": "^0.63.0",
+    "@cornerstonejs/tools": "^0.66.0",
     "@docusaurus/core": "2.3.1",
     "@docusaurus/module-type-aliases": "2.3.1",
     "@docusaurus/preset-classic": "2.3.1",

--- a/utils/ExampleRunner/example-runner-cli.js
+++ b/utils/ExampleRunner/example-runner-cli.js
@@ -162,10 +162,13 @@ if (configuration.examples) {
 
   // say name of running example
   console.log(`\n=> Running examples ${filterExamples.join(', ')}\n`);
-  // run the build for dicom image loader
 
-  // shell.cd('../../dicomImageLoader');
-  // shell.exec(`yarn run webpack:dynamic-import`);
+  // run the build for dicom image loader
+  const currentWD = process.cwd();
+  // run the build for dicom image loader
+  shell.cd('../../dicomImageLoader');
+  shell.exec(`yarn run webpack:dynamic-import`);
+  shell.cd(currentWD);
 
   if (buildExample) {
     var exBasePath = null;

--- a/utils/ExampleRunner/template-config.js
+++ b/utils/ExampleRunner/template-config.js
@@ -90,7 +90,7 @@ module.exports = {
   devServer: {
     hot: true,
     open: false,
-    port: 3001,
+    port: 3000,
     historyApiFallback: true,
     headers: {
       "Cross-Origin-Embedder-Policy": "require-corp",


### PR DESCRIPTION
This commit updates the docs package.json to use the latest version of cornerstonejs/tools (v0.66.0) that provides an improved feature set. In addition, changes have been made to the example-runner-cli.js and template-config.js files so that the dicomImageLoader webpack build process runs without unexpected behavior while building the example runner.
