### PR TITLE
fix js exception when setting invertRgbTransferFunction. safe program…

### DIFF
--- a/packages/core/src/utilities/invertRgbTransferFunction.ts
+++ b/packages/core/src/utilities/invertRgbTransferFunction.ts
@@ -21,7 +21,7 @@ export default function invertRgbTransferFunction(
   rgbTransferFunction: any
 ): void {
   // cut in case there is no function at all
-  if (rgbTransferFunction) {
+  if (!rgbTransferFunction) {
     return;
   }
 

--- a/packages/core/src/utilities/invertRgbTransferFunction.ts
+++ b/packages/core/src/utilities/invertRgbTransferFunction.ts
@@ -20,6 +20,11 @@
 export default function invertRgbTransferFunction(
   rgbTransferFunction: any
 ): void {
+  // cut in case there is no function at all
+  if (rgbTransferFunction) {
+    return;
+  }
+
   const size = rgbTransferFunction.getSize();
 
   for (let index = 0; index < size; index++) {


### PR DESCRIPTION
…ming only

Safe programming only. This does add any new feature just prevent exceptions

The scenario to occur this is:
- Loaded ds with different frame series
- Change WindowLevel 
- Scroll
Expected:
- It should not throw an exception

Actual
- It throws an exception on invertRgbTransferFunction because given function is null
- Scrolling does not change the displayed frame

Tech inputs.
This occurs because loading another frame will cause a new vtk Object to be generated so transfer function is not yet set when we try to reapply it on https://github.com/cornerstonejs/cornerstone3D-beta/blob/main/packages/core/src/RenderingEngine/StackViewport.ts#L1149




