### PR TITLE
fix(stackViewport): better error handling for disabled viewports

### DIFF
--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -148,9 +148,8 @@ class RenderingEngine implements IRenderingEngine {
 
     // 1.a) If there is a found viewport, we remove the viewport and create a new viewport
     if (viewport) {
+      console.log('Viewport already exists, disabling it first');
       this.disableElement(viewportId);
-      // todo: if only removing the viewport, make sure resize also happens
-      // this._removeViewport(viewportId)
     }
 
     // 2.a) See if viewport uses a custom rendering pipeline.

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1494,6 +1494,8 @@ class StackViewport extends Viewport implements IStackViewport {
     imageIds: Array<string>,
     currentImageIdIndex = 0
   ): Promise<string> {
+    this._throwIfDestroyed();
+
     this.imageIds = imageIds;
     this.currentImageIdIndex = currentImageIdIndex;
     this.targetImageIdIndex = currentImageIdIndex;
@@ -1525,6 +1527,19 @@ class StackViewport extends Viewport implements IStackViewport {
     triggerEvent(eventTarget, Events.STACK_VIEWPORT_NEW_STACK, eventDetail);
 
     return imageId;
+  }
+
+  /**
+   * Throws an error if you are using a destroyed instance of the stack viewport
+   */
+  private _throwIfDestroyed() {
+    if (this.isDisabled) {
+      throw new Error(
+        'The stack viewport has been destroyed and is no longer usable. Renderings will not be performed. If you ' +
+          'are using the same viewportId and has re-enabled the viewport, you need to grab the new viewport instance ' +
+          'using renderingEngine.getViewport(viewportId), instead of using your lexical reference to the viewport instance.'
+      );
+    }
   }
 
   /**
@@ -2278,6 +2293,8 @@ class StackViewport extends Viewport implements IStackViewport {
    * provided imageIds in setStack
    */
   public async setImageIdIndex(imageIdIndex: number): Promise<string> {
+    this._throwIfDestroyed();
+
     // If we are already on this imageId index, stop here
     if (this.currentImageIdIndex === imageIdIndex) {
       return this.getCurrentImageId();

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1536,8 +1536,8 @@ class StackViewport extends Viewport implements IStackViewport {
     if (this.isDisabled) {
       throw new Error(
         'The stack viewport has been destroyed and is no longer usable. Renderings will not be performed. If you ' +
-          'are using the same viewportId and has re-enabled the viewport, you need to grab the new viewport instance ' +
-          'using renderingEngine.getViewport(viewportId), instead of using your lexical reference to the viewport instance.'
+          'are using the same viewportId and have re-enabled the viewport, you need to grab the new viewport instance ' +
+          'using renderingEngine.getViewport(viewportId), instead of using your lexical scoped reference to the viewport instance.'
       );
     }
   }

--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -1793,9 +1793,9 @@ class CrosshairsTool extends AnnotationTool {
     for (let i = 0; i < otherViewportAnnotations.length; ++i) {
       const annotation = otherViewportAnnotations[i];
       if (
-        otherViewportsAnnotationsWithUniqueCameras.find(
+        otherViewportsAnnotationsWithUniqueCameras.some(
           (element) => element === annotation
-        ) === true
+        )
       ) {
         continue;
       }

--- a/packages/tools/src/tools/StackScrollToolMouseWheelTool.ts
+++ b/packages/tools/src/tools/StackScrollToolMouseWheelTool.ts
@@ -1,11 +1,7 @@
-import {
-  getEnabledElement,
-  VolumeViewport,
-  StackViewport,
-} from '@cornerstonejs/core';
+import { getEnabledElement } from '@cornerstonejs/core';
 import { BaseTool } from './base';
 import { MouseWheelEventType } from '../types/EventTypes';
-import { scrollVolume } from '../utilities/scroll';
+import scroll from '../utilities/scroll';
 
 /**
  * The StackScrollMouseWheelTool is a tool that allows the user to scroll through a
@@ -37,20 +33,15 @@ class StackScrollMouseWheelTool extends BaseTool {
     const { viewport } = getEnabledElement(element);
     const delta = direction * (invert ? -1 : 1);
 
-    if (viewport instanceof StackViewport) {
-      viewport.scroll(
-        delta,
-        this.configuration.debounceIfNotLoaded,
-        this.configuration.loop
-      );
-    } else if (viewport instanceof VolumeViewport) {
-      const targetId = this.getTargetId(viewport);
-      const volumeId = targetId.split('volumeId:')[1];
-      // TODO: add loop implemention for scroll volume.
-      scrollVolume(viewport, volumeId, delta);
-    } else {
-      throw new Error('StackScrollMouseWheelTool: Unsupported viewport type');
-    }
+    const targetId = this.getTargetId(viewport);
+    const volumeId = targetId.split('volumeId:')[1];
+
+    scroll(viewport, {
+      delta,
+      debounceLoading: this.configuration.debounceIfNotLoaded,
+      loop: this.configuration.loop,
+      volumeId,
+    });
   }
 }
 

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -653,7 +653,7 @@ class RectangleROITool extends AnnotationTool {
       // force to recalculate the stats from the points
       if (
         !data.cachedStats[targetId] ||
-        data.cachedStats[targetId].unit === undefined
+        data.cachedStats[targetId].areaUnit === undefined
       ) {
         data.cachedStats[targetId] = {
           Modality: null,

--- a/packages/tools/src/utilities/scroll.ts
+++ b/packages/tools/src/utilities/scroll.ts
@@ -5,6 +5,7 @@ import {
   eventTarget,
   EVENTS,
   utilities as csUtils,
+  getEnabledElement,
 } from '@cornerstonejs/core';
 import { ScrollOptions, EventTypes } from '../types';
 
@@ -21,6 +22,20 @@ export default function scroll(
   viewport: Types.IStackViewport | Types.IVolumeViewport,
   options: ScrollOptions
 ): void {
+  // check if viewport is disabled then throw error
+  const enabledElement = getEnabledElement(viewport.element);
+
+  if (!enabledElement) {
+    throw new Error('Scroll::Viewport is not enabled (it might be disabled)');
+  }
+
+  if (
+    viewport instanceof StackViewport &&
+    viewport.getImageIds().length === 0
+  ) {
+    throw new Error('Scroll::Stack Viewport has no images');
+  }
+
   const { type: viewportType } = viewport;
   const { volumeId, delta } = options;
 


### PR DESCRIPTION
- feat(stackViewport): better error handling for disabled viewports
- some fix in crosshair


## To Test
Run stackManipulationTools example locally

after setStack
re-enable the element 
and setStack again

- You have lost the scroll, but with these changes it will throw since that is what has happened
