### PR TITLE
fix(utilities): added getImageLegacy for migrations of cornerstone legacy's getImage

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -766,6 +766,9 @@ export function getEnabledElementByIds(viewportId: string, renderingEngineId: st
 export function getEnabledElements(): IEnabledElement[];
 
 // @public (undocumented)
+function getImageLegacy(element: HTMLDivElement): Types.IImage | undefined;
+
+// @public (undocumented)
 function getImageSliceDataForVolumeViewport(viewport: IVolumeViewport): ImageSliceData;
 
 // @public (undocumented)
@@ -1551,6 +1554,8 @@ interface IStackViewport extends IViewport {
     // (undocumented)
     getFrameOfReferenceUID: () => string;
     // (undocumented)
+    getImage: () => IImage;
+    // (undocumented)
     getImageData(): IImageData | CPUIImageData;
     // (undocumented)
     getImageIds: () => string[];
@@ -2197,6 +2202,8 @@ export class StackViewport extends Viewport implements IStackViewport {
     // (undocumented)
     getFrameOfReferenceUID: () => string | undefined;
     // (undocumented)
+    getImage: () => IImage;
+    // (undocumented)
     getImageData: () => IImageData | CPUIImageData;
     // (undocumented)
     getImageIds: () => Array<string>;
@@ -2443,7 +2450,8 @@ declare namespace utilities {
         deepMerge,
         getScalingParameters,
         getScalarDataType,
-        colormap
+        colormap,
+        getImageLegacy
     }
 }
 export { utilities }

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1548,13 +1548,13 @@ interface IStackViewport extends IViewport {
     // (undocumented)
     getCamera(): ICamera;
     // (undocumented)
+    getCornerstoneImage: () => IImage;
+    // (undocumented)
     getCurrentImageId: () => string;
     // (undocumented)
     getCurrentImageIdIndex: () => number;
     // (undocumented)
     getFrameOfReferenceUID: () => string;
-    // (undocumented)
-    getImage: () => IImage;
     // (undocumented)
     getImageData(): IImageData | CPUIImageData;
     // (undocumented)
@@ -2194,6 +2194,8 @@ export class StackViewport extends Viewport implements IStackViewport {
     // (undocumented)
     getCamera: () => ICamera;
     // (undocumented)
+    getCornerstoneImage: () => IImage;
+    // (undocumented)
     getCurrentImageId: () => string;
     // (undocumented)
     getCurrentImageIdIndex: () => number;
@@ -2201,8 +2203,6 @@ export class StackViewport extends Viewport implements IStackViewport {
     getDefaultActor: () => ActorEntry;
     // (undocumented)
     getFrameOfReferenceUID: () => string | undefined;
-    // (undocumented)
-    getImage: () => IImage;
     // (undocumented)
     getImageData: () => IImageData | CPUIImageData;
     // (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1054,6 +1054,7 @@ interface IStackViewport extends IViewport {
     getCurrentImageId: () => string;
     getCurrentImageIdIndex: () => number;
     getFrameOfReferenceUID: () => string;
+    getImage: () => IImage;
     getImageData(): IImageData | CPUIImageData;
     getImageIds: () => string[];
     getProperties: () => StackViewportProperties;

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1051,10 +1051,10 @@ interface IStackViewport extends IViewport {
         renderingEngineId: string;
     };
     getCamera(): ICamera;
+    getCornerstoneImage: () => IImage;
     getCurrentImageId: () => string;
     getCurrentImageIdIndex: () => number;
     getFrameOfReferenceUID: () => string;
-    getImage: () => IImage;
     getImageData(): IImageData | CPUIImageData;
     getImageIds: () => string[];
     getProperties: () => StackViewportProperties;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2801,10 +2801,10 @@ interface IStackViewport extends IViewport {
         renderingEngineId: string;
     };
     getCamera(): ICamera;
+    getCornerstoneImage: () => IImage;
     getCurrentImageId: () => string;
     getCurrentImageIdIndex: () => number;
     getFrameOfReferenceUID: () => string;
-    getImage: () => IImage;
     getImageData(): IImageData | CPUIImageData;
     getImageIds: () => string[];
     getProperties: () => StackViewportProperties;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2804,6 +2804,7 @@ interface IStackViewport extends IViewport {
     getCurrentImageId: () => string;
     getCurrentImageIdIndex: () => number;
     getFrameOfReferenceUID: () => string;
+    getImage: () => IImage;
     getImageData(): IImageData | CPUIImageData;
     getImageIds: () => string[];
     getProperties: () => StackViewportProperties;

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -509,6 +509,13 @@ class StackViewport extends Viewport implements IStackViewport {
   };
 
   /**
+   * Returns the raw/loaded image being shown inside the stack viewport.
+   */
+  public getImage = (): IImage => {
+    return this.csImage;
+  };
+
+  /**
    * Creates imageMapper based on the provided vtkImageData and also creates
    * the imageSliceActor and connects it to the imageMapper.
    * For color stack images, it sets the independent components to be false which

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -511,7 +511,7 @@ class StackViewport extends Viewport implements IStackViewport {
   /**
    * Returns the raw/loaded image being shown inside the stack viewport.
    */
-  public getImage = (): IImage => {
+  public getCornerstoneImage = (): IImage => {
     return this.csImage;
   };
 

--- a/packages/core/src/types/IStackViewport.ts
+++ b/packages/core/src/types/IStackViewport.ts
@@ -8,6 +8,7 @@ import Point3 from './Point3';
 import { Scaling } from './ScalingParameters';
 import StackViewportProperties from './StackViewportProperties';
 import { ColormapRegistration } from './Colormap';
+import IImage from './IImage';
 
 /**
  * Interface for Stack Viewport
@@ -84,6 +85,10 @@ export default interface IStackViewport extends IViewport {
    * image scalar data, vtkImageData object, metadata, and scaling (e.g., PET suvbw)
    */
   getImageData(): IImageData | CPUIImageData;
+  /**
+   * Returns the raw/loaded image being shown inside the stack viewport.
+   */
+  getImage: () => IImage;
   /**
    * Reset the viewport properties to the default values
    */

--- a/packages/core/src/types/IStackViewport.ts
+++ b/packages/core/src/types/IStackViewport.ts
@@ -88,7 +88,7 @@ export default interface IStackViewport extends IViewport {
   /**
    * Returns the raw/loaded image being shown inside the stack viewport.
    */
-  getImage: () => IImage;
+  getCornerstoneImage: () => IImage;
   /**
    * Reset the viewport properties to the default values
    */

--- a/packages/core/src/utilities/getImageLegacy.ts
+++ b/packages/core/src/utilities/getImageLegacy.ts
@@ -1,0 +1,29 @@
+import { StackViewport, Types } from '..';
+import getEnabledElement from '../getEnabledElement';
+
+/**
+ * Gets the IImage rendered by the given element. This is provided as a
+ * convenience for the legacy cornerstone getImage function. However it is
+ * encouraged for IStackViewport.getImage to be used instead.
+ * @param element - the element rendering/containing the image
+ * @returns the image
+ */
+function getImageLegacy(element: HTMLDivElement): Types.IImage | undefined {
+  const enabledElement = getEnabledElement(element);
+
+  if (!enabledElement) {
+    return;
+  }
+
+  const { viewport } = enabledElement;
+
+  if (!(viewport instanceof StackViewport)) {
+    throw new Error(
+      `An image can only be fetched for a stack viewport and not for a viewport of type: ${viewport.type}`
+    );
+  }
+
+  return viewport.getImage();
+}
+
+export default getImageLegacy;

--- a/packages/core/src/utilities/getImageLegacy.ts
+++ b/packages/core/src/utilities/getImageLegacy.ts
@@ -23,7 +23,7 @@ function getImageLegacy(element: HTMLDivElement): Types.IImage | undefined {
     );
   }
 
-  return viewport.getImage();
+  return viewport.getCornerstoneImage();
 }
 
 export default getImageLegacy;

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -45,6 +45,7 @@ import deepMerge from './deepMerge';
 import getScalingParameters from './getScalingParameters';
 import getScalarDataType from './getScalarDataType';
 import isPTPrescaledWithSUV from './isPTPrescaledWithSUV';
+import getImageLegacy from './getImageLegacy';
 
 // name spaces
 import * as planar from './planar';
@@ -103,4 +104,5 @@ export {
   getScalingParameters,
   getScalarDataType,
   colormap,
+  getImageLegacy,
 };


### PR DESCRIPTION
See issue #390

Testing:

Test A: 
1. Run the basic stack viewport example.
2. Open the browser's dev tools.
3. In the browser console get the viewport element for the image displayed and assign it to a variable - say `viewportElement`.
4. In the browser console issue the command `cornerstone.utilities.getImageLegacy(viewportElement)`
5. The corresponding `IImage` object should be returned.

Test B: 
1. Run the basic volume viewport example.
2. Open the browser's dev tools.
3. In the browser console get the viewport element for the image displayed and assign it to a variable - say `viewportElement`.
4. In the browser console issue the command `cornerstone.utilities.getImageLegacy(viewportElement)`
5. An exception to the following should be output...
```
getImageLegacy.ts:21 Uncaught Error: An image can only be fetched for a stack viewport and not for a viewport of type: orthographic
    at Module.getImageLegacy (getImageLegacy.ts:21:11)
    at <anonymous>:1:23
```