### PR TITLE
fix(cpu): could not render if switched to cpu in the middle

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -283,40 +283,8 @@ interface CPUFallbackEnabledElement {
         dimensions?: Point3;
         spacing?: Point3;
         origin?: Point3;
-        imagePlaneModule?: {
-            frameOfReferenceUID: string;
-            rows: number;
-            columns: number;
-            imageOrientationPatient: number[];
-            rowCosines: Point3;
-            columnCosines: Point3;
-            imagePositionPatient: number[];
-            sliceThickness?: number;
-            sliceLocation?: number;
-            pixelSpacing: Point2;
-            rowPixelSpacing: number;
-            columnPixelSpacing: number;
-        };
-        imagePixelModule?: {
-            samplesPerPixel: number;
-            photometricInterpretation: string;
-            rows: number;
-            columns: number;
-            bitsAllocated: number;
-            bitsStored: number;
-            highBit: number;
-            pixelRepresentation: number;
-            planarConfiguration?: number;
-            pixelAspectRatio?: number;
-            smallestPixelValue?: number;
-            largestPixelValue?: number;
-            redPaletteColorLookupTableDescriptor?: number[];
-            greenPaletteColorLookupTableDescriptor?: number[];
-            bluePaletteColorLookupTableDescriptor?: number[];
-            redPaletteColorLookupTableData: number[];
-            greenPaletteColorLookupTableData: number[];
-            bluePaletteColorLookupTableData: number[];
-        };
+        imagePlaneModule?: ImagePlaneModule;
+        imagePixelModule?: ImagePixelModule;
     };
     // (undocumented)
     needsRedraw?: boolean;
@@ -466,7 +434,7 @@ type CPUIImageData = {
     metadata: {
         Modality: string;
     };
-    scalarData: number[];
+    scalarData: PixelDataTypedArray;
     scaling: Scaling;
     hasPixelSpacing?: boolean;
     preScale?: {
@@ -488,7 +456,7 @@ type CPUImageData = {
     getIndexToWorld?: () => Point3;
     getSpacing?: () => Point3;
     getDirection?: () => Mat3;
-    getScalarData?: () => number[];
+    getScalarData?: () => PixelDataTypedArray;
     getDimensions?: () => Point3;
 };
 
@@ -1345,6 +1313,58 @@ type ImageLoadProgressEventDetail = {
 };
 
 // @public (undocumented)
+interface ImagePixelModule {
+    // (undocumented)
+    bitsAllocated: number;
+    // (undocumented)
+    bitsStored: number;
+    // (undocumented)
+    highBit: number;
+    // (undocumented)
+    modality: string;
+    // (undocumented)
+    photometricInterpretation: string;
+    // (undocumented)
+    pixelRepresentation: string;
+    // (undocumented)
+    samplesPerPixel: number;
+    // (undocumented)
+    voiLUTFunction: VOILUTFunctionType;
+    // (undocumented)
+    windowCenter: number | number[];
+    // (undocumented)
+    windowWidth: number | number[];
+}
+
+// @public (undocumented)
+interface ImagePlaneModule {
+    // (undocumented)
+    columnCosines?: Point3;
+    // (undocumented)
+    columnPixelSpacing?: number;
+    // (undocumented)
+    columns: number;
+    // (undocumented)
+    frameOfReferenceUID: string;
+    // (undocumented)
+    imageOrientationPatient?: Float32Array;
+    // (undocumented)
+    imagePositionPatient?: Point3;
+    // (undocumented)
+    pixelSpacing?: Point2;
+    // (undocumented)
+    rowCosines?: Point3;
+    // (undocumented)
+    rowPixelSpacing?: number;
+    // (undocumented)
+    rows: number;
+    // (undocumented)
+    sliceLocation?: number;
+    // (undocumented)
+    sliceThickness?: number;
+}
+
+// @public (undocumented)
 type ImageRenderedEvent = CustomEvent_2<ElementEnabledEventDetail>;
 
 // @public (undocumented)
@@ -1913,6 +1933,9 @@ type OrientationVectors = {
     viewUp: Point3;
 };
 
+// @public (undocumented)
+type PixelDataTypedArray = Float32Array | Int16Array | Uint16Array | Uint8Array | Int8Array | Uint8ClampedArray;
+
 declare namespace planar {
     export {
         linePlaneIntersection,
@@ -2390,7 +2413,10 @@ declare namespace Types {
         IContour,
         RGB,
         ColormapPublic,
-        ColormapRegistration
+        ColormapRegistration,
+        PixelDataTypedArray,
+        ImagePixelModule,
+        ImagePlaneModule
     }
 }
 export { Types }

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -197,40 +197,8 @@ interface CPUFallbackEnabledElement {
         dimensions?: Point3;
         spacing?: Point3;
         origin?: Point3;
-        imagePlaneModule?: {
-            frameOfReferenceUID: string;
-            rows: number;
-            columns: number;
-            imageOrientationPatient: number[];
-            rowCosines: Point3;
-            columnCosines: Point3;
-            imagePositionPatient: number[];
-            sliceThickness?: number;
-            sliceLocation?: number;
-            pixelSpacing: Point2;
-            rowPixelSpacing: number;
-            columnPixelSpacing: number;
-        };
-        imagePixelModule?: {
-            samplesPerPixel: number;
-            photometricInterpretation: string;
-            rows: number;
-            columns: number;
-            bitsAllocated: number;
-            bitsStored: number;
-            highBit: number;
-            pixelRepresentation: number;
-            planarConfiguration?: number;
-            pixelAspectRatio?: number;
-            smallestPixelValue?: number;
-            largestPixelValue?: number;
-            redPaletteColorLookupTableDescriptor?: number[];
-            greenPaletteColorLookupTableDescriptor?: number[];
-            bluePaletteColorLookupTableDescriptor?: number[];
-            redPaletteColorLookupTableData: number[];
-            greenPaletteColorLookupTableData: number[];
-            bluePaletteColorLookupTableData: number[];
-        };
+        imagePlaneModule?: ImagePlaneModule;
+        imagePixelModule?: ImagePixelModule;
     };
     // (undocumented)
     needsRedraw?: boolean;
@@ -378,7 +346,7 @@ type CPUIImageData = {
     origin: Point3;
     imageData: CPUImageData;
     metadata: { Modality: string };
-    scalarData: number[];
+    scalarData: PixelDataTypedArray;
     scaling: Scaling;
     hasPixelSpacing?: boolean;
     preScale?: {
@@ -400,7 +368,7 @@ type CPUImageData = {
     getIndexToWorld?: () => Point3;
     getSpacing?: () => Point3;
     getDirection?: () => Mat3;
-    getScalarData?: () => number[];
+    getScalarData?: () => PixelDataTypedArray;
     getDimensions?: () => Point3;
 };
 
@@ -939,6 +907,58 @@ type ImageLoadProgressEventDetail = {
     percent: number;
 };
 
+// @public (undocumented)
+interface ImagePixelModule {
+    // (undocumented)
+    bitsAllocated: number;
+    // (undocumented)
+    bitsStored: number;
+    // (undocumented)
+    highBit: number;
+    // (undocumented)
+    modality: string;
+    // (undocumented)
+    photometricInterpretation: string;
+    // (undocumented)
+    pixelRepresentation: string;
+    // (undocumented)
+    samplesPerPixel: number;
+    // (undocumented)
+    voiLUTFunction: VOILUTFunctionType;
+    // (undocumented)
+    windowCenter: number | number[];
+    // (undocumented)
+    windowWidth: number | number[];
+}
+
+// @public (undocumented)
+interface ImagePlaneModule {
+    // (undocumented)
+    columnCosines?: Point3;
+    // (undocumented)
+    columnPixelSpacing?: number;
+    // (undocumented)
+    columns: number;
+    // (undocumented)
+    frameOfReferenceUID: string;
+    // (undocumented)
+    imageOrientationPatient?: Float32Array;
+    // (undocumented)
+    imagePositionPatient?: Point3;
+    // (undocumented)
+    pixelSpacing?: Point2;
+    // (undocumented)
+    rowCosines?: Point3;
+    // (undocumented)
+    rowPixelSpacing?: number;
+    // (undocumented)
+    rows: number;
+    // (undocumented)
+    sliceLocation?: number;
+    // (undocumented)
+    sliceThickness?: number;
+}
+
 // @public
 type ImageRenderedEvent = CustomEvent_2<ElementEnabledEventDetail>;
 
@@ -1318,6 +1338,15 @@ type OrientationVectors = {
     viewPlaneNormal: Point3;
     viewUp: Point3;
 };
+
+// @public (undocumented)
+type PixelDataTypedArray =
+| Float32Array
+| Int16Array
+| Uint16Array
+| Uint8Array
+| Int8Array
+| Uint8ClampedArray;
 
 // @public
 type Plane = [number, number, number, number];

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1010,40 +1010,8 @@ interface CPUFallbackEnabledElement {
         dimensions?: Point3;
         spacing?: Point3;
         origin?: Point3;
-        imagePlaneModule?: {
-            frameOfReferenceUID: string;
-            rows: number;
-            columns: number;
-            imageOrientationPatient: number[];
-            rowCosines: Point3;
-            columnCosines: Point3;
-            imagePositionPatient: number[];
-            sliceThickness?: number;
-            sliceLocation?: number;
-            pixelSpacing: Point2;
-            rowPixelSpacing: number;
-            columnPixelSpacing: number;
-        };
-        imagePixelModule?: {
-            samplesPerPixel: number;
-            photometricInterpretation: string;
-            rows: number;
-            columns: number;
-            bitsAllocated: number;
-            bitsStored: number;
-            highBit: number;
-            pixelRepresentation: number;
-            planarConfiguration?: number;
-            pixelAspectRatio?: number;
-            smallestPixelValue?: number;
-            largestPixelValue?: number;
-            redPaletteColorLookupTableDescriptor?: number[];
-            greenPaletteColorLookupTableDescriptor?: number[];
-            bluePaletteColorLookupTableDescriptor?: number[];
-            redPaletteColorLookupTableData: number[];
-            greenPaletteColorLookupTableData: number[];
-            bluePaletteColorLookupTableData: number[];
-        };
+        imagePlaneModule?: ImagePlaneModule;
+        imagePixelModule?: ImagePixelModule;
     };
     // (undocumented)
     needsRedraw?: boolean;
@@ -1191,7 +1159,7 @@ type CPUIImageData = {
     origin: Point3;
     imageData: CPUImageData;
     metadata: { Modality: string };
-    scalarData: number[];
+    scalarData: PixelDataTypedArray;
     scaling: Scaling;
     hasPixelSpacing?: boolean;
     preScale?: {
@@ -1213,7 +1181,7 @@ type CPUImageData = {
     getIndexToWorld?: () => Point3;
     getSpacing?: () => Point3;
     getDirection?: () => Mat3;
-    getScalarData?: () => number[];
+    getScalarData?: () => PixelDataTypedArray;
     getDimensions?: () => Point3;
 };
 
@@ -2647,6 +2615,58 @@ class ImageMouseCursor extends MouseCursor {
     static getUniqueInstanceName(prefix: string): string;
 }
 
+// @public (undocumented)
+interface ImagePixelModule {
+    // (undocumented)
+    bitsAllocated: number;
+    // (undocumented)
+    bitsStored: number;
+    // (undocumented)
+    highBit: number;
+    // (undocumented)
+    modality: string;
+    // (undocumented)
+    photometricInterpretation: string;
+    // (undocumented)
+    pixelRepresentation: string;
+    // (undocumented)
+    samplesPerPixel: number;
+    // (undocumented)
+    voiLUTFunction: VOILUTFunctionType;
+    // (undocumented)
+    windowCenter: number | number[];
+    // (undocumented)
+    windowWidth: number | number[];
+}
+
+// @public (undocumented)
+interface ImagePlaneModule {
+    // (undocumented)
+    columnCosines?: Point3;
+    // (undocumented)
+    columnPixelSpacing?: number;
+    // (undocumented)
+    columns: number;
+    // (undocumented)
+    frameOfReferenceUID: string;
+    // (undocumented)
+    imageOrientationPatient?: Float32Array;
+    // (undocumented)
+    imagePositionPatient?: Point3;
+    // (undocumented)
+    pixelSpacing?: Point2;
+    // (undocumented)
+    rowCosines?: Point3;
+    // (undocumented)
+    rowPixelSpacing?: number;
+    // (undocumented)
+    rows: number;
+    // (undocumented)
+    sliceLocation?: number;
+    // (undocumented)
+    sliceThickness?: number;
+}
+
 // @public
 type ImageRenderedEvent = CustomEvent_2<ElementEnabledEventDetail>;
 
@@ -3560,6 +3580,15 @@ export class PanTool extends BaseTool {
     // (undocumented)
     touchDragCallback(evt: EventTypes_2.InteractionEventType): void;
 }
+
+// @public (undocumented)
+type PixelDataTypedArray =
+| Float32Array
+| Int16Array
+| Uint16Array
+| Uint8Array
+| Int8Array
+| Uint8ClampedArray;
 
 declare namespace planar {
     export {

--- a/packages/core/src/types/CPUFallbackEnabledElement.ts
+++ b/packages/core/src/types/CPUFallbackEnabledElement.ts
@@ -6,6 +6,8 @@ import CPUFallbackViewport from './CPUFallbackViewport';
 import CPUFallbackTransform from './CPUFallbackTransform';
 import CPUFallbackColormap from './CPUFallbackColormap';
 import CPUFallbackRenderingTools from './CPUFallbackRenderingTools';
+import { ImagePlaneModule } from './ImagePlaneModule';
+import { ImagePixelModule } from './ImagePixelModule';
 
 interface CPUFallbackEnabledElement {
   scale?: number;
@@ -31,40 +33,8 @@ interface CPUFallbackEnabledElement {
     /** Last spacing is always EPSILON for CPU */
     spacing?: Point3;
     origin?: Point3;
-    imagePlaneModule?: {
-      frameOfReferenceUID: string;
-      rows: number;
-      columns: number;
-      imageOrientationPatient: number[];
-      rowCosines: Point3;
-      columnCosines: Point3;
-      imagePositionPatient: number[];
-      sliceThickness?: number;
-      sliceLocation?: number;
-      pixelSpacing: Point2;
-      rowPixelSpacing: number;
-      columnPixelSpacing: number;
-    };
-    imagePixelModule?: {
-      samplesPerPixel: number;
-      photometricInterpretation: string;
-      rows: number;
-      columns: number;
-      bitsAllocated: number;
-      bitsStored: number;
-      highBit: number;
-      pixelRepresentation: number;
-      planarConfiguration?: number;
-      pixelAspectRatio?: number;
-      smallestPixelValue?: number;
-      largestPixelValue?: number;
-      redPaletteColorLookupTableDescriptor?: number[];
-      greenPaletteColorLookupTableDescriptor?: number[];
-      bluePaletteColorLookupTableDescriptor?: number[];
-      redPaletteColorLookupTableData: number[];
-      greenPaletteColorLookupTableData: number[];
-      bluePaletteColorLookupTableData: number[];
-    };
+    imagePlaneModule?: ImagePlaneModule;
+    imagePixelModule?: ImagePixelModule;
   };
 }
 

--- a/packages/core/src/types/CPUIImageData.ts
+++ b/packages/core/src/types/CPUIImageData.ts
@@ -1,4 +1,4 @@
-import { Point3, Scaling, Mat3 } from '../types';
+import { Point3, Scaling, Mat3, PixelDataTypedArray } from '../types';
 
 type CPUImageData = {
   worldToIndex?: (point: Point3) => Point3;
@@ -8,7 +8,7 @@ type CPUImageData = {
   /** Last spacing is always EPSILON */
   getSpacing?: () => Point3;
   getDirection?: () => Mat3;
-  getScalarData?: () => number[];
+  getScalarData?: () => PixelDataTypedArray;
   /** Last index is always 1 */
   getDimensions?: () => Point3;
 };
@@ -20,7 +20,7 @@ type CPUIImageData = {
   origin: Point3;
   imageData: CPUImageData;
   metadata: { Modality: string };
-  scalarData: number[];
+  scalarData: PixelDataTypedArray;
   scaling: Scaling;
   /** whether the image has pixel spacing and it is not undefined */
   hasPixelSpacing?: boolean;

--- a/packages/core/src/types/IImage.ts
+++ b/packages/core/src/types/IImage.ts
@@ -1,14 +1,7 @@
 import CPUFallbackLUT from './CPUFallbackLUT';
 import CPUFallbackColormap from './CPUFallbackColormap';
 import CPUFallbackEnabledElement from './CPUFallbackEnabledElement';
-
-type PixelDataTypedArray =
-  | Float32Array
-  | Int16Array
-  | Uint16Array
-  | Uint8Array
-  | Int8Array
-  | Uint8ClampedArray;
+import { PixelDataTypedArray } from './PixelDataTypedArray';
 
 /**
  * Cornerstone Image interface, it is used for both CPU and GPU rendering

--- a/packages/core/src/types/ImagePixelModule.ts
+++ b/packages/core/src/types/ImagePixelModule.ts
@@ -1,0 +1,14 @@
+import { VOILUTFunctionType } from '../enums';
+
+export interface ImagePixelModule {
+  bitsAllocated: number;
+  bitsStored: number;
+  samplesPerPixel: number;
+  highBit: number;
+  photometricInterpretation: string;
+  pixelRepresentation: string;
+  windowWidth: number | number[];
+  windowCenter: number | number[];
+  voiLUTFunction: VOILUTFunctionType;
+  modality: string;
+}

--- a/packages/core/src/types/ImagePlaneModule.ts
+++ b/packages/core/src/types/ImagePlaneModule.ts
@@ -1,0 +1,17 @@
+import Point2 from './Point2';
+import Point3 from './Point3';
+
+export interface ImagePlaneModule {
+  columnCosines?: Point3;
+  columnPixelSpacing?: number;
+  imageOrientationPatient?: Float32Array;
+  imagePositionPatient?: Point3;
+  pixelSpacing?: Point2;
+  rowCosines?: Point3;
+  rowPixelSpacing?: number;
+  sliceLocation?: number;
+  sliceThickness?: number;
+  frameOfReferenceUID: string;
+  columns: number;
+  rows: number;
+}

--- a/packages/core/src/types/PixelDataTypedArray.ts
+++ b/packages/core/src/types/PixelDataTypedArray.ts
@@ -1,0 +1,7 @@
+export type PixelDataTypedArray =
+  | Float32Array
+  | Int16Array
+  | Uint16Array
+  | Uint8Array
+  | Int8Array
+  | Uint8ClampedArray;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -77,6 +77,9 @@ import type { IContour } from './IContour';
 import type RGB from './RGB';
 import { ColormapPublic, ColormapRegistration } from './Colormap';
 import type { ViewportProperties } from './ViewportProperties';
+import type { PixelDataTypedArray } from './PixelDataTypedArray';
+import type { ImagePixelModule } from './ImagePixelModule';
+import type { ImagePlaneModule } from './ImagePlaneModule';
 
 export type {
   // config
@@ -164,4 +167,8 @@ export type {
   RGB,
   ColormapPublic,
   ColormapRegistration,
+  // PixelData
+  PixelDataTypedArray,
+  ImagePixelModule,
+  ImagePlaneModule,
 };

--- a/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertPALETTECOLOR.ts
+++ b/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertPALETTECOLOR.ts
@@ -1,5 +1,6 @@
 import { ByteArray } from 'dicom-parser';
 import { ImageFrame } from '../../types';
+import external from '../../externalModules';
 
 function convertLUTto8Bit(lut: number[], shift: number) {
   const numEntries = lut.length;
@@ -26,9 +27,40 @@ export default function (
 ): void {
   const numPixels = imageFrame.columns * imageFrame.rows;
   const pixelData = imageFrame.pixelData;
-  const rData = imageFrame.redPaletteColorLookupTableData;
-  const gData = imageFrame.greenPaletteColorLookupTableData;
-  const bData = imageFrame.bluePaletteColorLookupTableData;
+  let rData = imageFrame.redPaletteColorLookupTableData;
+
+  if (!rData) {
+    // request from metadata provider since it might grab it from bulkdataURI
+    rData = external.cornerstone.metaData.get(
+      'imagePixelModule',
+      imageFrame.imageId
+    )?.redPaletteColorLookupTableData;
+  }
+
+  let gData = imageFrame.greenPaletteColorLookupTableData;
+
+  if (!gData) {
+    gData = external.cornerstone.metaData.get(
+      'imagePixelModule',
+      imageFrame.imageId
+    )?.greenPaletteColorLookupTableData;
+  }
+
+  let bData = imageFrame.bluePaletteColorLookupTableData;
+
+  if (!bData) {
+    bData = external.cornerstone.metaData.get(
+      'imagePixelModule',
+      imageFrame.imageId
+    )?.bluePaletteColorLookupTableData;
+  }
+
+  if (!rData || !gData || !bData) {
+    throw new Error(
+      'The image does not have a complete color palette. R, G, and B palette data are required.'
+    );
+  }
+
   const len = imageFrame.redPaletteColorLookupTableData.length;
 
   let palIndex = 0;

--- a/packages/dicomImageLoader/src/imageLoader/getImageFrame.ts
+++ b/packages/dicomImageLoader/src/imageLoader/getImageFrame.ts
@@ -32,6 +32,7 @@ function getImageFrame(imageId: string): ImageFrame {
     bluePaletteColorLookupTableData:
       imagePixelModule.bluePaletteColorLookupTableData,
     pixelData: undefined, // populated later after decoding
+    imageId,
   };
 }
 

--- a/packages/dicomImageLoader/src/types/ImageFrame.ts
+++ b/packages/dicomImageLoader/src/types/ImageFrame.ts
@@ -34,6 +34,7 @@ interface ImageFrame {
   };
   minAfterScale?: number;
   maxAfterScale?: number;
+  imageId: string;
 }
 
 export default ImageFrame;

--- a/packages/tools/src/utilities/cine/playClip.ts
+++ b/packages/tools/src/utilities/cine/playClip.ts
@@ -201,7 +201,7 @@ function _stopClip(element: HTMLDivElement, stopDynamicCine: boolean): void {
     _stopClipWithData(cineToolData);
   }
 
-  if (stopDynamicCine) {
+  if (stopDynamicCine && viewport instanceof BaseVolumeViewport) {
     _stopDynamicVolumeCine(element);
   }
 }

--- a/utils/ExampleRunner/example-info.json
+++ b/utils/ExampleRunner/example-info.json
@@ -98,6 +98,10 @@
       "volumePriorityLoading": {
         "name": "Prioritizing Slices during Volume Loading",
         "description": "Demonstrates how to customize the slice loading order using the streaming-image volume loader"
+      },
+      "programaticPanZoom": {
+        "name": "Programmatic Pan/Zoom",
+        "description": "Demonstrates how to programmatically pan/zoom a stack viewport. It can be used for setting initial display area and presentation state."
       }
     },
     "tools-basic": {


### PR DESCRIPTION
### Context

CPU rendering if it is switched after the initial setup would fail to use renderToCanvas.


### Changes & Results

- Fixed the CPU rendering to use the correct rendering function
- refactor some types
- make pallet color to use metadata to fetch if needed

### Testing

1. go to https://v3-demo.ohif.org/localbasic
2. open console and say `cornerstone.setUseCPURendering(true)` 
3. drag and drop a dicom
4. thumbnail would not load



### Checklist

#### PR



- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates


- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->
