### PR TITLE
WIP Fixing problem related to left+right click in ZoomTool

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -5588,6 +5588,8 @@ export class ZoomTool extends BaseTool {
     // (undocumented)
     mouseDragCallback: (evt: EventTypes_2.InteractionEventType) => void;
     // (undocumented)
+    mouseUpCallback: () => void;
+    // (undocumented)
     _panCallback(evt: EventTypes_2.InteractionEventType): void;
     // (undocumented)
     _pinchCallback(evt: EventTypes_2.InteractionEventType): void;
@@ -5595,6 +5597,8 @@ export class ZoomTool extends BaseTool {
     preMouseDownCallback: (evt: EventTypes_2.InteractionEventType) => boolean;
     // (undocumented)
     preTouchStartCallback: (evt: EventTypes_2.InteractionEventType) => boolean;
+    // (undocumented)
+    setInitialMousePosition: (evt: EventTypes_2.InteractionEventType) => void;
     // (undocumented)
     static toolName: any;
     // (undocumented)

--- a/packages/tools/src/tools/ZoomTool.ts
+++ b/packages/tools/src/tools/ZoomTool.ts
@@ -79,12 +79,6 @@ class ZoomTool extends BaseTool {
 
   mouseUpCallback = (): void => {
     this.initialMousePosWorld = null;
-
-    // we should not return true here, returning true in the preMouseDownCallback
-    // means that the event is handled by the tool and no other methods
-    // can claim the event, which will result in a bug where having Zoom on primary
-    // and clicking on an annotation will not manipulate the annotation, but will
-    // instead zoom the image (which is not what we want), so we return false here
   };
 
   preTouchStartCallback = (evt: EventTypes.InteractionEventType): boolean => {

--- a/packages/tools/src/tools/ZoomTool.ts
+++ b/packages/tools/src/tools/ZoomTool.ts
@@ -42,7 +42,7 @@ class ZoomTool extends BaseTool {
     this.mouseDragCallback = this._dragCallback.bind(this);
   }
 
-  preMouseDownCallback = (evt: EventTypes.InteractionEventType): boolean => {
+  setInitialMousePosition = (evt: EventTypes.InteractionEventType): void => {
     const eventData = evt.detail;
     const { element, currentPoints } = eventData;
     const worldPos = currentPoints.world;
@@ -64,6 +64,10 @@ class ZoomTool extends BaseTool {
     dirVec = vec3.normalize(vec3.create(), dirVec);
 
     this.dirVec = dirVec as Types.Point3;
+  };
+
+  preMouseDownCallback = (evt: EventTypes.InteractionEventType): boolean => {
+    this.setInitialMousePosition(evt);
 
     // we should not return true here, returning true in the preMouseDownCallback
     // means that the event is handled by the tool and no other methods
@@ -71,6 +75,16 @@ class ZoomTool extends BaseTool {
     // and clicking on an annotation will not manipulate the annotation, but will
     // instead zoom the image (which is not what we want), so we return false here
     return false;
+  };
+
+  mouseUpCallback = (): void => {
+    this.initialMousePosWorld = null;
+
+    // we should not return true here, returning true in the preMouseDownCallback
+    // means that the event is handled by the tool and no other methods
+    // can claim the event, which will result in a bug where having Zoom on primary
+    // and clicking on an annotation will not manipulate the annotation, but will
+    // instead zoom the image (which is not what we want), so we return false here
   };
 
   preTouchStartCallback = (evt: EventTypes.InteractionEventType): boolean => {
@@ -116,6 +130,9 @@ class ZoomTool extends BaseTool {
 
   // Takes ICornerstoneEvent, Mouse or Touch
   _dragCallback(evt: EventTypes.InteractionEventType) {
+    if (!this.initialMousePosWorld) {
+      this.setInitialMousePosition(evt);
+    }
     const { element } = evt.detail;
     const enabledElement = getEnabledElement(element);
     const { viewport } = enabledElement;


### PR DESCRIPTION
This fixes the problem when ZoomTool is activated by left+right buttons, as not always the two button combination fires preMouseDownCallback, leading to an error in zoom Center implementation