### PR TITLE
Fix/expose api default mouse primary

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2893,6 +2893,10 @@ interface IToolGroup {
         (): undefined | string;
     };
     // (undocumented)
+    getDefaultMousePrimary: {
+        (): MouseBindings;
+    };
+    // (undocumented)
     getToolConfiguration: {
         (toolName: string, configurationPath: string): any;
     };

--- a/packages/tools/src/eventDispatchers/shared/getActiveToolForKeyboardEvent.ts
+++ b/packages/tools/src/eventDispatchers/shared/getActiveToolForKeyboardEvent.ts
@@ -36,6 +36,7 @@ export default function getActiveToolForKeyboardEvent(
   }
 
   const toolGroupToolNames = Object.keys(toolGroup.toolOptions);
+  const defaultMousePrimary = toolGroup.getDefaultMousePrimary();
 
   for (let j = 0; j < toolGroupToolNames.length; j++) {
     const toolName = toolGroupToolNames[j];
@@ -47,7 +48,7 @@ export default function getActiveToolForKeyboardEvent(
       toolOptions.bindings.length &&
       toolOptions.bindings.some(
         (binding) =>
-          binding.mouseButton === (mouseButton ?? MouseBindings.Primary) &&
+          binding.mouseButton === (mouseButton ?? defaultMousePrimary) &&
           binding.modifierKey === modifierKey
       );
 

--- a/packages/tools/src/eventDispatchers/shared/getActiveToolForMouseEvent.ts
+++ b/packages/tools/src/eventDispatchers/shared/getActiveToolForMouseEvent.ts
@@ -38,6 +38,7 @@ export default function getActiveToolForMouseEvent(
   }
 
   const toolGroupToolNames = Object.keys(toolGroup.toolOptions);
+  const defaultMousePrimary = toolGroup.getDefaultMousePrimary();
 
   for (let j = 0; j < toolGroupToolNames.length; j++) {
     const toolName = toolGroupToolNames[j];
@@ -50,7 +51,7 @@ export default function getActiveToolForMouseEvent(
       toolOptions.bindings.some((binding) => {
         return (
           binding.mouseButton ===
-            (mouseEvent ? mouseEvent.buttons : MouseBindings.Primary) &&
+            (mouseEvent ? mouseEvent.buttons : defaultMousePrimary) &&
           binding.modifierKey === modifierKey
         );
       });

--- a/packages/tools/src/eventDispatchers/shared/getActiveToolForTouchEvent.ts
+++ b/packages/tools/src/eventDispatchers/shared/getActiveToolForTouchEvent.ts
@@ -38,6 +38,7 @@ export default function getActiveToolForTouchEvent(
   // If any keyboard modifier key is also pressed
   const modifierKey =
     getMouseModifier(touchEvent) || keyEventListener.getModifierKey();
+  const defaultMousePrimary = toolGroup.getDefaultMousePrimary();
 
   for (let j = 0; j < toolGroupToolNames.length; j++) {
     const toolName = toolGroupToolNames[j];
@@ -55,7 +56,7 @@ export default function getActiveToolForTouchEvent(
         (binding) =>
           (binding.numTouchPoints === numTouchPoints ||
             (numTouchPoints === 1 &&
-              binding.mouseButton === MouseBindings.Primary)) &&
+              binding.mouseButton === defaultMousePrimary)) &&
           binding.modifierKey === modifierKey
       );
 

--- a/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
+++ b/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
@@ -621,6 +621,10 @@ export default class ToolGroup implements IToolGroup {
     return true;
   }
 
+  /**
+   * Returns the default mouse primary button.
+   *
+   */
   public getDefaultMousePrimary(): MouseBindings {
     return MouseBindings.Primary;
   }

--- a/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
+++ b/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
@@ -406,12 +406,13 @@ export default class ToolGroup implements IToolGroup {
       }
     );
 
+    const defaultMousePrimary = this.getDefaultMousePrimary();
+
     // Remove the primary button bindings without modifiers, if they exist
     toolOptions.bindings = toolOptions.bindings.filter(
       (binding) =>
-        binding.mouseButton !== MouseBindings.Primary || binding.modifierKey
+        binding.mouseButton !== defaultMousePrimary || binding.modifierKey
     );
-
     // If there are other bindings, set the tool to be active
     let mode = Passive;
     if (toolOptions.bindings.length !== 0) {
@@ -620,6 +621,10 @@ export default class ToolGroup implements IToolGroup {
     return true;
   }
 
+  public getDefaultMousePrimary(): MouseBindings {
+    return MouseBindings.Primary;
+  }
+
   /**
    * Get the configuration of tool. It returns only the config for the given path (in case exists).
    * ConfigurationPath is the the path of the property to get separated by '.'.
@@ -650,9 +655,11 @@ export default class ToolGroup implements IToolGroup {
    * @returns A boolean value.
    */
   private _hasMousePrimaryButtonBinding(toolOptions) {
+    const defaultMousePrimary = this.getDefaultMousePrimary();
+
     return toolOptions?.bindings?.some(
       (binding) =>
-        binding.mouseButton === MouseBindings.Primary &&
+        binding.mouseButton === defaultMousePrimary &&
         binding.modifierKey === undefined
     );
   }

--- a/packages/tools/src/types/IToolGroup.ts
+++ b/packages/tools/src/types/IToolGroup.ts
@@ -1,5 +1,9 @@
 import type { Types } from '@cornerstonejs/core';
-import { SetToolBindingsType, ToolOptionsType } from './ISetToolModeOptions';
+import {
+  SetToolBindingsType,
+  ToolOptionsType,
+  IToolBinding,
+} from './ISetToolModeOptions';
 
 /**
  * ToolGroup interface
@@ -68,5 +72,8 @@ export default interface IToolGroup {
   };
   getToolConfiguration: {
     (toolName: string, configurationPath: string): any;
+  };
+  getDefaultMousePrimary: {
+    (): MouseBindings;
   };
 }

--- a/packages/tools/src/types/IToolGroup.ts
+++ b/packages/tools/src/types/IToolGroup.ts
@@ -4,7 +4,7 @@ import {
   ToolOptionsType,
   IToolBinding,
 } from './ISetToolModeOptions';
-
+import { MouseBindings } from '../enums';
 /**
  * ToolGroup interface
  */

--- a/packages/tools/src/types/IToolGroup.ts
+++ b/packages/tools/src/types/IToolGroup.ts
@@ -1,9 +1,5 @@
 import type { Types } from '@cornerstonejs/core';
-import {
-  SetToolBindingsType,
-  ToolOptionsType,
-  IToolBinding,
-} from './ISetToolModeOptions';
+import { SetToolBindingsType, ToolOptionsType } from './ISetToolModeOptions';
 import { MouseBindings } from '../enums';
 /**
  * ToolGroup interface


### PR DESCRIPTION
This PR does not add new value to the package other than just expose an api to allow using a different default mouse primary.
Practically speaking more comparisons to "static" constants less flexible the api is.
The idea here is to expose an api that allows swapping mouse left and right with less friction to upper layers.

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
